### PR TITLE
refactor: use enum_dispatch to simplify HwAccel dynamic dispatch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -430,6 +430,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "enum_dispatch"
+version = "0.3.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa18ce2bc66555b3218614519ac839ddb759a7d6720732f979ef8d13be147ecd"
+dependencies = [
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "env_filter"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -577,6 +589,7 @@ name = "ffpipeline"
 version = "0.1.0"
 dependencies = [
  "dyn-clone",
+ "enum_dispatch",
  "libnvidia-sys",
  "libva-sys",
  "libvpl-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ resolver = "3"
 axum = "0.8"
 clap = { version = "4.6", features = ["derive"] }
 dyn-clone = "1.0"
+enum_dispatch = "0.3.13"
 env_logger = "0.11"
 ersatztv-core = { path = "crates/ersatztv-core" }
 ersatztv-playout = { path = "crates/ersatztv-playout" }

--- a/crates/ffpipeline/Cargo.toml
+++ b/crates/ffpipeline/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2024"
 
 [dependencies]
 dyn-clone = { workspace = true }
+enum_dispatch = { workspace = true }
 libnvidia-sys = { workspace = true }
 libva-sys = { workspace = true }
 libvpl-sys = { workspace = true }

--- a/crates/ffpipeline/src/hw_accel.rs
+++ b/crates/ffpipeline/src/hw_accel.rs
@@ -1,3 +1,5 @@
+use enum_dispatch::enum_dispatch;
+
 use crate::accel;
 use crate::ffmpeg_info::FfmpegInfo;
 use crate::filter_chain::PipelineFilter;
@@ -5,6 +7,7 @@ use crate::pipeline::{FrameSurface, PixelFormat, VideoFormat};
 use crate::video_codec::VideoCodec;
 use crate::video_filter::VideoFilter;
 
+#[enum_dispatch]
 pub trait HwAccel {
     fn best_filter(&self, video_filter: &VideoFilter, ffmpeg_info: &FfmpegInfo) -> VideoFilter;
     fn can_decode(&self, codec: &str, _profile: &str, pixel_format: &PixelFormat) -> bool {
@@ -36,127 +39,10 @@ pub trait HwAccel {
 }
 
 #[derive(Debug, Clone)]
+#[enum_dispatch(HwAccel)]
 pub enum HardwareAccel {
     Cuda(accel::cuda::Cuda),
     Qsv(accel::qsv::Qsv),
     Vaapi(accel::vaapi::Vaapi),
     VideoToolbox(accel::video_toolbox::VideoToolbox),
-}
-
-impl HwAccel for HardwareAccel {
-    fn best_filter(&self, video_filter: &VideoFilter, ffmpeg_info: &FfmpegInfo) -> VideoFilter {
-        match self {
-            Self::Cuda(a) => a.best_filter(video_filter, ffmpeg_info),
-            Self::Qsv(a) => a.best_filter(video_filter, ffmpeg_info),
-            Self::Vaapi(a) => a.best_filter(video_filter, ffmpeg_info),
-            Self::VideoToolbox(a) => a.best_filter(video_filter, ffmpeg_info),
-        }
-    }
-
-    fn can_decode(&self, codec: &str, profile: &str, pixel_format: &PixelFormat) -> bool {
-        match self {
-            Self::Cuda(a) => a.can_decode(codec, profile, pixel_format),
-            Self::Qsv(a) => a.can_decode(codec, profile, pixel_format),
-            Self::Vaapi(a) => a.can_decode(codec, profile, pixel_format),
-            Self::VideoToolbox(a) => a.can_decode(codec, profile, pixel_format),
-        }
-    }
-
-    fn can_encode(&self, format: &VideoFormat, bit_depth: u8) -> bool {
-        match self {
-            Self::Cuda(a) => a.can_encode(format, bit_depth),
-            Self::Qsv(a) => a.can_encode(format, bit_depth),
-            Self::Vaapi(a) => a.can_encode(format, bit_depth),
-            Self::VideoToolbox(a) => a.can_encode(format, bit_depth),
-        }
-    }
-
-    fn codec_for_format(&self, format: &VideoFormat) -> Option<VideoCodec> {
-        match self {
-            Self::Cuda(a) => a.codec_for_format(format),
-            Self::Qsv(a) => a.codec_for_format(format),
-            Self::Vaapi(a) => a.codec_for_format(format),
-            Self::VideoToolbox(a) => a.codec_for_format(format),
-        }
-    }
-
-    fn decoder_arg(&self) -> Vec<String> {
-        match self {
-            Self::Cuda(a) => a.decoder_arg(),
-            Self::Qsv(a) => a.decoder_arg(),
-            Self::Vaapi(a) => a.decoder_arg(),
-            Self::VideoToolbox(a) => a.decoder_arg(),
-        }
-    }
-
-    fn decoder_filters(&self) -> Vec<PipelineFilter> {
-        match self {
-            Self::Cuda(a) => a.decoder_filters(),
-            Self::Qsv(a) => a.decoder_filters(),
-            Self::Vaapi(a) => a.decoder_filters(),
-            Self::VideoToolbox(a) => a.decoder_filters(),
-        }
-    }
-
-    fn envs(&self) -> Vec<(String, String)> {
-        match self {
-            Self::Cuda(a) => a.envs(),
-            Self::Qsv(a) => a.envs(),
-            Self::Vaapi(a) => a.envs(),
-            Self::VideoToolbox(a) => a.envs(),
-        }
-    }
-
-    fn ffmpeg_name(&self) -> &str {
-        match self {
-            Self::Cuda(a) => a.ffmpeg_name(),
-            Self::Qsv(a) => a.ffmpeg_name(),
-            Self::Vaapi(a) => a.ffmpeg_name(),
-            Self::VideoToolbox(a) => a.ffmpeg_name(),
-        }
-    }
-
-    fn format_filter(&self, pixel_format: &PixelFormat) -> Option<VideoFilter> {
-        match self {
-            Self::Cuda(a) => a.format_filter(pixel_format),
-            Self::Qsv(a) => a.format_filter(pixel_format),
-            Self::Vaapi(a) => a.format_filter(pixel_format),
-            Self::VideoToolbox(a) => a.format_filter(pixel_format),
-        }
-    }
-
-    fn frame_surface(&self) -> FrameSurface {
-        match self {
-            Self::Cuda(a) => a.frame_surface(),
-            Self::Qsv(a) => a.frame_surface(),
-            Self::Vaapi(a) => a.frame_surface(),
-            Self::VideoToolbox(a) => a.frame_surface(),
-        }
-    }
-
-    fn init_hw_device(&self) -> Vec<String> {
-        match self {
-            Self::Cuda(a) => a.init_hw_device(),
-            Self::Qsv(a) => a.init_hw_device(),
-            Self::Vaapi(a) => a.init_hw_device(),
-            Self::VideoToolbox(a) => a.init_hw_device(),
-        }
-    }
-
-    fn output_format(&self, source_pixel_format: &PixelFormat) -> PixelFormat {
-        match self {
-            Self::Cuda(a) => a.output_format(source_pixel_format),
-            Self::Qsv(a) => a.output_format(source_pixel_format),
-            Self::Vaapi(a) => a.output_format(source_pixel_format),
-            Self::VideoToolbox(a) => a.output_format(source_pixel_format),
-        }
-    }
-
-    fn supports_pixel_format(&self, pixel_format: &PixelFormat) -> bool {
-        match self {
-            Self::Qsv(a) => a.supports_pixel_format(pixel_format),
-            Self::Vaapi(a) => a.supports_pixel_format(pixel_format),
-            _ => true,
-        }
-    }
 }


### PR DESCRIPTION
The [enum_dispatch](https://docs.rs/enum_dispatch/latest/enum_dispatch/) crate is designed to make it easy to create dynamically dispatched code based on an enum which points to various trait implementations. It also simplifies the process of adding new enum values. They claim the macro gen can also account for a 10x speedup in dispatch.