### PR TITLE
feat: generate fake playout item to fill any unscheduled gaps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -515,6 +515,7 @@ dependencies = [
  "time",
  "tokio",
  "toml",
+ "uuid",
 ]
 
 [[package]]

--- a/crates/ersatztv-channel/Cargo.toml
+++ b/crates/ersatztv-channel/Cargo.toml
@@ -17,3 +17,4 @@ thiserror = { workspace = true }
 time = { workspace = true }
 tokio = { workspace = true }
 toml = { workspace = true }
+uuid = { workspace = true }

--- a/crates/ersatztv-channel/src/channel_session.rs
+++ b/crates/ersatztv-channel/src/channel_session.rs
@@ -4,7 +4,9 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use ersatztv_core::{READY_FILE_NAME, empty_folder};
-use ersatztv_playout::playout::{PlayoutItem, PlayoutItemSource, TrackSelection};
+use ersatztv_playout::playout::{
+    PlayoutItem, PlayoutItemSource, PlayoutItemTracks, TrackSelection,
+};
 use ffpipeline::ffmpeg_info::FfmpegInfo;
 use ffpipeline::frame_rate::FrameRate;
 use ffpipeline::frame_size::FrameSize;
@@ -290,10 +292,25 @@ impl ChannelSession {
         }
 
         // TODO: transcode error message instead of bailing
-        let current_item = self
+        let current_item_result = self
             .playout_loader
             .get_current_item(&self.transcoded_until)
-            .await?;
+            .await;
+
+        let current_item = match current_item_result {
+            Ok(playout_item) => playout_item,
+            Err(ChannelError::PlayoutJsonNoItem) => {
+                let start_after_result = self
+                    .playout_loader
+                    .get_start_after(&self.transcoded_until)
+                    .await;
+                self.fake_playout_item(start_after_result)
+            }
+            Err(err) => {
+                log::error!("{}", err);
+                self.fake_playout_item(None)
+            }
+        };
 
         let current_source = current_item.source.clone();
         let audio_source = match current_source.as_ref() {
@@ -594,6 +611,27 @@ impl ChannelSession {
             out_point,
             finish,
             is_complete,
+        }
+    }
+
+    fn fake_playout_item(&self, next_start: Option<OffsetDateTime>) -> PlayoutItem {
+        PlayoutItem {
+            id: uuid::Uuid::new_v4().to_string(),
+            start: self.transcoded_until,
+            finish: next_start.unwrap_or(self.transcoded_until + Duration::from_mins(2)),
+            source: None,
+            tracks: Some(PlayoutItemTracks {
+                audio: Some(TrackSelection::Source {
+                    source: PlayoutItemSource::Lavfi {
+                        params: String::from("anullsrc=channel_layout=stereo:sample_rate=48000"),
+                    },
+                }),
+                video: Some(TrackSelection::Source {
+                    source: PlayoutItemSource::Lavfi {
+                        params: String::from("color=c=black:s=1920x1080"),
+                    },
+                }),
+            }),
         }
     }
 }

--- a/crates/ersatztv-channel/src/channel_session.rs
+++ b/crates/ersatztv-channel/src/channel_session.rs
@@ -618,7 +618,7 @@ impl ChannelSession {
         PlayoutItem {
             id: uuid::Uuid::new_v4().to_string(),
             start: self.transcoded_until,
-            finish: next_start.unwrap_or(self.transcoded_until + Duration::from_mins(2)),
+            finish: next_start.unwrap_or(self.transcoded_until + Duration::from_mins(1)),
             source: None,
             tracks: Some(PlayoutItemTracks {
                 audio: Some(TrackSelection::Source {

--- a/crates/ersatztv-channel/src/channel_session.rs
+++ b/crates/ersatztv-channel/src/channel_session.rs
@@ -628,7 +628,19 @@ impl ChannelSession {
                 }),
                 video: Some(TrackSelection::Source {
                     source: PlayoutItemSource::Lavfi {
-                        params: String::from("color=c=black:s=1920x1080"),
+                        params: format!(
+                            "color=c=black:s={}x{}",
+                            self.channel_config
+                                .normalization
+                                .video
+                                .height
+                                .unwrap_or(1920),
+                            self.channel_config
+                                .normalization
+                                .video
+                                .height
+                                .unwrap_or(1080),
+                        ),
                     },
                 }),
             }),

--- a/crates/ersatztv-channel/src/channel_session.rs
+++ b/crates/ersatztv-channel/src/channel_session.rs
@@ -299,12 +299,8 @@ impl ChannelSession {
 
         let current_item = match current_item_result {
             Ok(playout_item) => playout_item,
-            Err(ChannelError::PlayoutJsonNoItem) => {
-                let start_after_result = self
-                    .playout_loader
-                    .get_start_after(&self.transcoded_until)
-                    .await;
-                self.fake_playout_item(start_after_result)
+            Err(ChannelError::PlayoutJsonNoItem { next_start }) => {
+                self.fake_playout_item(next_start)
             }
             Err(err) => {
                 log::error!("{}", err);

--- a/crates/ersatztv-channel/src/error.rs
+++ b/crates/ersatztv-channel/src/error.rs
@@ -1,6 +1,7 @@
 use ersatztv_playout::error::PlayoutError;
 use ffpipeline::error::FFPipelineError;
 use thiserror::Error;
+use time::OffsetDateTime;
 
 #[derive(Error, Debug)]
 pub enum ChannelError {
@@ -27,6 +28,9 @@ pub enum ChannelError {
 
     #[error("{0}")]
     PlayoutJsonLoadFailure(#[from] PlayoutError),
+
+    #[error("unable to find playout JSON file for time {0}")]
+    PlayoutJsonNoFileForTime(OffsetDateTime),
 
     #[error("unable to find current item in playout JSON")]
     PlayoutJsonNoItem,

--- a/crates/ersatztv-channel/src/error.rs
+++ b/crates/ersatztv-channel/src/error.rs
@@ -33,7 +33,7 @@ pub enum ChannelError {
     PlayoutJsonNoFileForTime(OffsetDateTime),
 
     #[error("unable to find current item in playout JSON")]
-    PlayoutJsonNoItem,
+    PlayoutJsonNoItem { next_start: Option<OffsetDateTime> },
 
     #[error("local source is invalid for playout item")]
     PlayoutJsonInvalidLocalSource,

--- a/crates/ersatztv-channel/src/playout_loader.rs
+++ b/crates/ersatztv-channel/src/playout_loader.rs
@@ -28,7 +28,37 @@ impl PlayoutLoader {
                 .to_string_lossy()
         );
 
-        // find first playout JSON in folder
+        let path = self.playout_file_for_time(now).await?;
+        log::debug!("playout JSON is {path}");
+
+        // load playout JSON
+        let playout_result = ersatztv_playout::playout::from_file(&path).await?;
+
+        // find current item
+        playout_result
+            .playout
+            .items
+            .into_iter()
+            .rfind(|i| now >= &i.start && now < &i.finish())
+            .ok_or(ChannelError::PlayoutJsonNoItem)
+    }
+
+    pub async fn get_start_after(&self, now: &OffsetDateTime) -> Option<OffsetDateTime> {
+        match self.playout_file_for_time(now).await {
+            Ok(path) => match ersatztv_playout::playout::from_file(&path).await {
+                Ok(playout_result) => playout_result
+                    .playout
+                    .items
+                    .into_iter()
+                    .find(|i| &i.start > now)
+                    .map(|i| i.start),
+                Err(_) => None,
+            },
+            Err(_) => None,
+        }
+    }
+
+    async fn playout_file_for_time(&self, now: &OffsetDateTime) -> Result<String, ChannelError> {
         let mut entries = tokio::fs::read_dir(self.channel_config.expanded_playout_folder())
             .await
             .map_err(|e| {
@@ -58,27 +88,13 @@ impl PlayoutLoader {
                             && now >= &start
                             && now < &finish
                         {
-                            log::debug!("playout JSON is {path}");
-
-                            // load playout JSON
-                            let playout_result =
-                                ersatztv_playout::playout::from_file(&path).await?;
-
-                            // find current item
-                            return playout_result
-                                .playout
-                                .items
-                                .into_iter()
-                                .rfind(|i| now >= &i.start && now < &i.finish())
-                                .ok_or(ChannelError::PlayoutJsonNoItem);
+                            return Ok(path);
                         }
                     }
                 }
             }
         }
 
-        Err(ChannelError::ChannelConfigFailure(String::from(
-            "found no files for the current time",
-        )))
+        Err(ChannelError::PlayoutJsonNoFileForTime(*now))
     }
 }

--- a/crates/ersatztv-channel/src/playout_loader.rs
+++ b/crates/ersatztv-channel/src/playout_loader.rs
@@ -1,4 +1,4 @@
-use ersatztv_playout::playout::{DATE_FORMAT, PlayoutItem};
+use ersatztv_playout::playout::{DATE_FORMAT, PlayoutItem, PlayoutLoadResult};
 use time::OffsetDateTime;
 
 use crate::config::ChannelConfig;
@@ -34,28 +34,16 @@ impl PlayoutLoader {
         // load playout JSON
         let playout_result = ersatztv_playout::playout::from_file(&path).await?;
 
+        // in case current item isn't found
+        let next_start = self.next_start(&playout_result, now);
+
         // find current item
         playout_result
             .playout
             .items
             .into_iter()
             .rfind(|i| now >= &i.start && now < &i.finish())
-            .ok_or(ChannelError::PlayoutJsonNoItem)
-    }
-
-    pub async fn get_start_after(&self, now: &OffsetDateTime) -> Option<OffsetDateTime> {
-        match self.playout_file_for_time(now).await {
-            Ok(path) => match ersatztv_playout::playout::from_file(&path).await {
-                Ok(playout_result) => playout_result
-                    .playout
-                    .items
-                    .into_iter()
-                    .find(|i| &i.start > now)
-                    .map(|i| i.start),
-                Err(_) => None,
-            },
-            Err(_) => None,
-        }
+            .ok_or(ChannelError::PlayoutJsonNoItem { next_start })
     }
 
     async fn playout_file_for_time(&self, now: &OffsetDateTime) -> Result<String, ChannelError> {
@@ -96,5 +84,18 @@ impl PlayoutLoader {
         }
 
         Err(ChannelError::PlayoutJsonNoFileForTime(*now))
+    }
+
+    fn next_start(
+        &self,
+        playout_result: &PlayoutLoadResult,
+        now: &OffsetDateTime,
+    ) -> Option<OffsetDateTime> {
+        playout_result
+            .playout
+            .items
+            .iter()
+            .find(|i| &i.start > now)
+            .map(|i| i.start)
     }
 }


### PR DESCRIPTION
The fake playout item will play until the next scheduled item start, or for 1 minute if no next item start can be found.