### PR TITLE
feat: add vulkan hw accel

### DIFF
--- a/crates/ersatztv-channel/src/config.rs
+++ b/crates/ersatztv-channel/src/config.rs
@@ -114,6 +114,7 @@ pub enum HardwareAccel {
     Qsv,
     Vaapi,
     VideoToolbox,
+    Vulkan,
 }
 
 impl HardwareAccel {
@@ -202,6 +203,9 @@ impl HardwareAccel {
             }
             HardwareAccel::VideoToolbox => Some(ffpipeline::hw_accel::HardwareAccel::VideoToolbox(
                 ffpipeline::accel::video_toolbox::VideoToolbox,
+            )),
+            HardwareAccel::Vulkan => Some(ffpipeline::hw_accel::HardwareAccel::Vulkan(
+                ffpipeline::accel::vulkan::Vulkan,
             )),
         }
     }

--- a/crates/ffpipeline/src/accel/cuda.rs
+++ b/crates/ffpipeline/src/accel/cuda.rs
@@ -142,10 +142,6 @@ impl HwAccel for Cuda {
         FrameSurface::Cuda
     }
 
-    fn envs(&self) -> Vec<(String, String)> {
-        Vec::new()
-    }
-
     fn format_filter(&self, pixel_format: &PixelFormat) -> Option<VideoFilter> {
         Some(VideoFilter::Hardware(Box::new(FormatCuda {
             format: pixel_format.clone(),
@@ -177,13 +173,6 @@ impl HwAccel for Cuda {
 
     fn known_accel(&self) -> &KnownHardwareAccel {
         &KnownHardwareAccel::Cuda
-    }
-
-    fn output_format(&self, source_pixel_format: &PixelFormat) -> PixelFormat {
-        match source_pixel_format.bit_depth() {
-            10 => PixelFormat::P010le,
-            _ => PixelFormat::Nv12,
-        }
     }
 }
 

--- a/crates/ffpipeline/src/accel/cuda.rs
+++ b/crates/ffpipeline/src/accel/cuda.rs
@@ -23,7 +23,12 @@ impl Cuda {
 }
 
 impl HwAccel for Cuda {
-    fn best_filter(&self, video_filter: &VideoFilter, ffmpeg_info: &FfmpegInfo) -> VideoFilter {
+    fn best_filter(
+        &self,
+        video_filter: &VideoFilter,
+        ffmpeg_info: &FfmpegInfo,
+        _current_state: &FrameState,
+    ) -> VideoFilter {
         match video_filter {
             VideoFilter::Scale {
                 size,

--- a/crates/ffpipeline/src/accel/mod.rs
+++ b/crates/ffpipeline/src/accel/mod.rs
@@ -2,3 +2,4 @@ pub mod cuda;
 pub mod qsv;
 pub mod vaapi;
 pub mod video_toolbox;
+pub mod vulkan;

--- a/crates/ffpipeline/src/accel/qsv.rs
+++ b/crates/ffpipeline/src/accel/qsv.rs
@@ -1,6 +1,5 @@
 use crate::capabilities::qsv::QsvCapabilities;
 use crate::ffmpeg_info::{FfmpegInfo, KnownHardwareAccel, KnownVideoFilter};
-use crate::filter_chain::PipelineFilter;
 use crate::frame_size::FrameSize;
 use crate::hw_accel::HwAccel;
 use crate::pipeline::{FrameState, FrameSurface, PixelFormat, VideoFormat};
@@ -76,24 +75,12 @@ impl HwAccel for Qsv {
         ]
     }
 
-    fn decoder_filters(&self) -> Vec<PipelineFilter> {
-        Vec::new()
-    }
-
     fn decoder_frame_surface(&self) -> FrameSurface {
         FrameSurface::Qsv
     }
 
     fn encoder_frame_surface(&self) -> FrameSurface {
         FrameSurface::Qsv
-    }
-
-    fn envs(&self) -> Vec<(String, String)> {
-        Vec::new()
-    }
-
-    fn format_filter(&self, _pixel_format: &PixelFormat) -> Option<VideoFilter> {
-        None
     }
 
     fn initialize(&self, _ffmpeg_info: &FfmpegInfo, _is_hdr: bool) -> Self {
@@ -111,13 +98,6 @@ impl HwAccel for Qsv {
 
     fn known_accel(&self) -> &KnownHardwareAccel {
         &KnownHardwareAccel::Qsv
-    }
-
-    fn output_format(&self, source_pixel_format: &PixelFormat) -> PixelFormat {
-        match source_pixel_format.bit_depth() {
-            10 => PixelFormat::P010le,
-            _ => PixelFormat::Nv12,
-        }
     }
 
     fn supports_pixel_format(&self, pixel_format: &PixelFormat) -> bool {

--- a/crates/ffpipeline/src/accel/qsv.rs
+++ b/crates/ffpipeline/src/accel/qsv.rs
@@ -12,7 +12,12 @@ pub struct Qsv {
 }
 
 impl HwAccel for Qsv {
-    fn best_filter(&self, video_filter: &VideoFilter, ffmpeg_info: &FfmpegInfo) -> VideoFilter {
+    fn best_filter(
+        &self,
+        video_filter: &VideoFilter,
+        ffmpeg_info: &FfmpegInfo,
+        _current_state: &FrameState,
+    ) -> VideoFilter {
         match video_filter {
             VideoFilter::Scale { size, .. }
                 if ffmpeg_info.has_video_filter(&KnownVideoFilter::VppQsv) =>

--- a/crates/ffpipeline/src/accel/vaapi.rs
+++ b/crates/ffpipeline/src/accel/vaapi.rs
@@ -2,7 +2,6 @@ use std::fmt::{Display, Formatter};
 
 use crate::capabilities::vaapi::VaapiCapabilities;
 use crate::ffmpeg_info::{FfmpegInfo, KnownHardwareAccel, KnownVideoFilter};
-use crate::filter_chain::PipelineFilter;
 use crate::frame_size::FrameSize;
 use crate::hw_accel::HwAccel;
 use crate::pipeline::{FrameState, FrameSurface, PixelFormat, VideoFormat};
@@ -116,10 +115,6 @@ impl HwAccel for Vaapi {
         ]
     }
 
-    fn decoder_filters(&self) -> Vec<PipelineFilter> {
-        Vec::new()
-    }
-
     fn decoder_frame_surface(&self) -> FrameSurface {
         FrameSurface::Vaapi
     }
@@ -148,13 +143,6 @@ impl HwAccel for Vaapi {
 
     fn known_accel(&self) -> &KnownHardwareAccel {
         &KnownHardwareAccel::Vaapi
-    }
-
-    fn output_format(&self, source_pixel_format: &PixelFormat) -> PixelFormat {
-        match source_pixel_format.bit_depth() {
-            10 => PixelFormat::P010le,
-            _ => PixelFormat::Nv12,
-        }
     }
 
     fn supports_pixel_format(&self, pixel_format: &PixelFormat) -> bool {

--- a/crates/ffpipeline/src/accel/vaapi.rs
+++ b/crates/ffpipeline/src/accel/vaapi.rs
@@ -33,7 +33,12 @@ pub struct Vaapi {
 }
 
 impl HwAccel for Vaapi {
-    fn best_filter(&self, video_filter: &VideoFilter, ffmpeg_info: &FfmpegInfo) -> VideoFilter {
+    fn best_filter(
+        &self,
+        video_filter: &VideoFilter,
+        ffmpeg_info: &FfmpegInfo,
+        _current_state: &FrameState,
+    ) -> VideoFilter {
         match video_filter {
             VideoFilter::Scale {
                 size,

--- a/crates/ffpipeline/src/accel/video_toolbox.rs
+++ b/crates/ffpipeline/src/accel/video_toolbox.rs
@@ -1,18 +1,12 @@
 use crate::ffmpeg_info::{FfmpegInfo, KnownHardwareAccel};
-use crate::filter_chain::PipelineFilter;
 use crate::hw_accel::HwAccel;
 use crate::pipeline::{FrameSurface, PixelFormat, VideoFormat};
 use crate::video_codec::VideoCodec;
-use crate::video_filter::VideoFilter;
 
 #[derive(Debug, Clone)]
 pub struct VideoToolbox;
 
 impl HwAccel for VideoToolbox {
-    fn best_filter(&self, video_filter: &VideoFilter, _ffmpeg_info: &FfmpegInfo) -> VideoFilter {
-        video_filter.clone()
-    }
-
     fn can_decode(&self, codec: &str, _profile: &str, pixel_format: &PixelFormat) -> bool {
         match pixel_format.bit_depth() {
             10 => matches!(codec, "hevc"),
@@ -50,24 +44,12 @@ impl HwAccel for VideoToolbox {
         ]
     }
 
-    fn decoder_filters(&self) -> Vec<PipelineFilter> {
-        Vec::new()
-    }
-
     fn decoder_frame_surface(&self) -> FrameSurface {
         FrameSurface::VideoToolbox
     }
 
     fn encoder_frame_surface(&self) -> FrameSurface {
         FrameSurface::VideoToolbox
-    }
-
-    fn envs(&self) -> Vec<(String, String)> {
-        Vec::new()
-    }
-
-    fn format_filter(&self, _pixel_format: &PixelFormat) -> Option<VideoFilter> {
-        None
     }
 
     fn initialize(&self, _ffmpeg_info: &FfmpegInfo, _is_hdr: bool) -> Self {
@@ -80,12 +62,5 @@ impl HwAccel for VideoToolbox {
 
     fn known_accel(&self) -> &KnownHardwareAccel {
         &KnownHardwareAccel::VideoToolbox
-    }
-
-    fn output_format(&self, source_pixel_format: &PixelFormat) -> PixelFormat {
-        match source_pixel_format.bit_depth() {
-            10 => PixelFormat::P010le,
-            _ => PixelFormat::Nv12,
-        }
     }
 }

--- a/crates/ffpipeline/src/accel/vulkan.rs
+++ b/crates/ffpipeline/src/accel/vulkan.rs
@@ -1,0 +1,193 @@
+use crate::ffmpeg_info::{FfmpegInfo, KnownHardwareAccel, KnownVideoFilter};
+use crate::frame_size::FrameSize;
+use crate::hw_accel::HwAccel;
+use crate::pipeline::{FrameState, FrameSurface, PixelFormat, VideoFormat};
+use crate::video_codec::VideoCodec;
+use crate::video_filter::{HwVideoFilter, VideoFilter};
+
+#[derive(Debug, Clone)]
+pub struct Vulkan;
+
+impl HwAccel for Vulkan {
+    fn best_filter(&self, video_filter: &VideoFilter, ffmpeg_info: &FfmpegInfo) -> VideoFilter {
+        match video_filter {
+            VideoFilter::Scale {
+                size,
+                input_is_anamorphic,
+                ..
+            } if ffmpeg_info.has_video_filter(&KnownVideoFilter::ScaleVulkan) => {
+                // TODO: this only works with 8-bit content
+                VideoFilter::Hardware(Box::new(ScaleVulkan {
+                    size: size.clone(),
+                    input_is_anamorphic: *input_is_anamorphic,
+                    //force_original_aspect_ratio: force_original_aspect_ratio.clone(),
+                }))
+            }
+            VideoFilter::ToneMap { algorithm, .. }
+                if ffmpeg_info.has_video_filter(&KnownVideoFilter::LibPlacebo) =>
+            {
+                VideoFilter::Hardware(Box::new(Libplacebo {
+                    algorithm: algorithm.clone(),
+                }))
+            }
+            _ => video_filter.clone(),
+        }
+    }
+
+    fn codec_for_format(&self, format: &VideoFormat) -> Option<VideoCodec> {
+        match format {
+            VideoFormat::H264 => Some(VideoCodec {
+                codec_name: "h264_vulkan",
+                options: &[],
+                preferred_pixel_format_8bit: Some(PixelFormat::Nv12),
+                preferred_pixel_format_10bit: Some(PixelFormat::P010le),
+                is_hardware: true,
+            }),
+            VideoFormat::Hevc => Some(VideoCodec {
+                codec_name: "hevc_vulkan",
+                options: &["-tag:v", "hvc1"],
+                preferred_pixel_format_8bit: Some(PixelFormat::Nv12),
+                preferred_pixel_format_10bit: Some(PixelFormat::P010le),
+                is_hardware: true,
+            }),
+            _ => None,
+        }
+    }
+
+    fn decoder_arg(&self) -> Vec<String> {
+        vec![
+            String::from("-hwaccel"),
+            String::from("vulkan"),
+            String::from("-hwaccel_output_format"),
+            String::from("vulkan"),
+        ]
+    }
+
+    fn decoder_frame_surface(&self) -> FrameSurface {
+        FrameSurface::Vulkan
+    }
+
+    fn encoder_frame_surface(&self) -> FrameSurface {
+        FrameSurface::Vulkan
+    }
+
+    fn format_filter(&self, pixel_format: &PixelFormat) -> Option<VideoFilter> {
+        Some(VideoFilter::Hardware(Box::new(FormatVulkan {
+            format: pixel_format.clone(),
+        })))
+    }
+
+    fn initialize(&self, _ffmpeg_info: &FfmpegInfo, _is_hdr: bool) -> Self {
+        self.clone()
+    }
+
+    fn init_hw_device(&self) -> Vec<String> {
+        vec![String::from("-init_hw_device"), String::from("vulkan")]
+    }
+
+    fn known_accel(&self) -> &KnownHardwareAccel {
+        &KnownHardwareAccel::Vulkan
+    }
+}
+
+#[derive(Clone)]
+struct FormatVulkan {
+    format: PixelFormat,
+}
+
+impl HwVideoFilter for FormatVulkan {
+    fn evaluate(&self, _state: &FrameState) -> Option<VideoFilter> {
+        // called before this is used
+        None
+    }
+
+    fn apply_to(&self, state: &mut FrameState) {
+        state.pixel_format = self.format.clone();
+    }
+
+    fn required_surface(&self) -> FrameSurface {
+        FrameSurface::Vulkan
+    }
+
+    fn as_arg(&self) -> Option<String> {
+        Some(format!("scale_vulkan=format={}", self.format.as_arg()))
+    }
+}
+
+#[derive(Clone)]
+struct Libplacebo {
+    algorithm: Option<String>,
+}
+
+impl HwVideoFilter for Libplacebo {
+    fn evaluate(&self, _state: &FrameState) -> Option<VideoFilter> {
+        // called before this is used
+        None
+    }
+
+    fn apply_to(&self, state: &mut FrameState) {
+        state.is_hdr = false;
+    }
+
+    fn required_surface(&self) -> FrameSurface {
+        FrameSurface::Vulkan
+    }
+
+    fn as_arg(&self) -> Option<String> {
+        Some(format!(
+            "libplacebo=tonemapping={}:colorspace=bt709:color_primaries=bt709:color_trc=bt709",
+            self.algorithm.as_deref().unwrap_or("linear")
+        ))
+    }
+}
+
+#[derive(Clone)]
+struct ScaleVulkan {
+    size: Option<FrameSize>,
+    input_is_anamorphic: bool,
+    //force_original_aspect_ratio: Option<ForceOriginalAspectRatio>,
+}
+
+impl HwVideoFilter for ScaleVulkan {
+    fn evaluate(&self, _state: &FrameState) -> Option<VideoFilter> {
+        // called before this is used
+        None
+    }
+
+    fn apply_to(&self, state: &mut FrameState) {
+        if let Some(size) = &self.size {
+            state.size = size.clone();
+            state.surface = FrameSurface::Vulkan;
+            state.is_anamorphic = false;
+            state.sample_aspect_ratio = Some(String::from("1:1"));
+            state.display_aspect_ratio = None;
+        }
+    }
+
+    fn required_surface(&self) -> FrameSurface {
+        FrameSurface::Vulkan
+    }
+
+    fn as_arg(&self) -> Option<String> {
+        if let Some(size) = &self.size {
+            // let aspect_ratio = self
+            //     .force_original_aspect_ratio
+            //     .as_ref()
+            //     .map_or(String::new(), |f| f.as_arg());
+            //
+            if self.input_is_anamorphic {
+                Some(format!(
+                    "scale_vulkan=iw*sar:ih,setsar=1,scale_vulkan={}:{}",
+                    size.width, size.height
+                ))
+            } else {
+                Some(format!(
+                    "scale_vulkan={}:{},setsar=1",
+                    size.width, size.height
+                ))
+            }
+        } else {
+            None
+        }
+    }
+}

--- a/crates/ffpipeline/src/accel/vulkan.rs
+++ b/crates/ffpipeline/src/accel/vulkan.rs
@@ -9,25 +9,35 @@ use crate::video_filter::{HwVideoFilter, VideoFilter};
 pub struct Vulkan;
 
 impl HwAccel for Vulkan {
-    fn best_filter(&self, video_filter: &VideoFilter, ffmpeg_info: &FfmpegInfo) -> VideoFilter {
+    fn best_filter(
+        &self,
+        video_filter: &VideoFilter,
+        ffmpeg_info: &FfmpegInfo,
+        current_state: &FrameState,
+    ) -> VideoFilter {
         match video_filter {
             VideoFilter::Scale {
                 size,
                 input_is_anamorphic,
                 ..
-            } if ffmpeg_info.has_video_filter(&KnownVideoFilter::ScaleVulkan) => {
-                // TODO: this only works with 8-bit content
+            } if ffmpeg_info.has_video_filter(&KnownVideoFilter::ScaleVulkan)
+                && current_state.pixel_format.bit_depth() == 8 =>
+            {
                 VideoFilter::Hardware(Box::new(ScaleVulkan {
                     size: size.clone(),
                     input_is_anamorphic: *input_is_anamorphic,
                     //force_original_aspect_ratio: force_original_aspect_ratio.clone(),
                 }))
             }
-            VideoFilter::ToneMap { algorithm, .. }
+            VideoFilter::ToneMap { algorithm, format }
                 if ffmpeg_info.has_video_filter(&KnownVideoFilter::LibPlacebo) =>
             {
                 VideoFilter::Hardware(Box::new(Libplacebo {
                     algorithm: algorithm.clone(),
+                    format: match format {
+                        PixelFormat::Yuv420p10le => PixelFormat::P010le,
+                        _ => PixelFormat::Nv12,
+                    },
                 }))
             }
             _ => video_filter.clone(),
@@ -117,6 +127,7 @@ impl HwVideoFilter for FormatVulkan {
 #[derive(Clone)]
 struct Libplacebo {
     algorithm: Option<String>,
+    format: PixelFormat,
 }
 
 impl HwVideoFilter for Libplacebo {
@@ -126,6 +137,7 @@ impl HwVideoFilter for Libplacebo {
     }
 
     fn apply_to(&self, state: &mut FrameState) {
+        state.pixel_format = self.format.clone();
         state.is_hdr = false;
     }
 
@@ -135,8 +147,9 @@ impl HwVideoFilter for Libplacebo {
 
     fn as_arg(&self) -> Option<String> {
         Some(format!(
-            "libplacebo=tonemapping={}:colorspace=bt709:color_primaries=bt709:color_trc=bt709",
-            self.algorithm.as_deref().unwrap_or("linear")
+            "libplacebo=tonemapping={}:colorspace=bt709:color_primaries=bt709:color_trc=bt709:format={}",
+            self.algorithm.as_deref().unwrap_or("linear"),
+            self.format.as_arg(),
         ))
     }
 }

--- a/crates/ffpipeline/src/ffmpeg_info.rs
+++ b/crates/ffpipeline/src/ffmpeg_info.rs
@@ -11,6 +11,7 @@ static KNOWN_FILTERS: &[&str] = &[
     "pad_vaapi",
     "scale_cuda",
     "scale_vaapi",
+    "scale_vulkan",
     "vpp_qsv",
 ];
 
@@ -28,6 +29,7 @@ pub enum KnownVideoFilter {
     PadVaapi,
     ScaleCuda,
     ScaleVaapi,
+    ScaleVulkan,
     VppQsv,
 }
 
@@ -69,6 +71,7 @@ impl FfmpegInfo {
             KnownVideoFilter::PadVaapi => "pad_vaapi",
             KnownVideoFilter::ScaleCuda => "scale_cuda",
             KnownVideoFilter::ScaleVaapi => "scale_vaapi",
+            KnownVideoFilter::ScaleVulkan => "scale_vulkan",
             KnownVideoFilter::VppQsv => "vpp_qsv",
         };
 

--- a/crates/ffpipeline/src/filter_chain.rs
+++ b/crates/ffpipeline/src/filter_chain.rs
@@ -81,7 +81,7 @@ impl FilterChain {
             match filter {
                 PipelineFilter::Video(video_filter) => {
                     let mut best = match accel {
-                        Some(a) => a.best_filter(video_filter, ffmpeg_info),
+                        Some(a) => a.best_filter(video_filter, ffmpeg_info, &current_state),
                         _ => video_filter.clone(),
                     };
 

--- a/crates/ffpipeline/src/filter_chain.rs
+++ b/crates/ffpipeline/src/filter_chain.rs
@@ -108,6 +108,7 @@ impl FilterChain {
                             if is_format_supported {
                                 let upload = VideoFilter::HwUpload {
                                     target_surface: required.clone(),
+                                    bit_depth: current_state.pixel_format.bit_depth(),
                                 };
                                 upload.apply_to(&mut current_state);
                                 resolved.push(PipelineFilter::Video(upload))
@@ -126,6 +127,7 @@ impl FilterChain {
 
                                     let upload = VideoFilter::HwUpload {
                                         target_surface: required,
+                                        bit_depth: current_state.pixel_format.bit_depth(),
                                     };
                                     upload.apply_to(&mut current_state);
                                     resolved.push(PipelineFilter::Video(upload));
@@ -169,6 +171,7 @@ impl FilterChain {
             } else {
                 let upload = VideoFilter::HwUpload {
                     target_surface: encoder_surface.clone(),
+                    bit_depth: current_state.pixel_format.bit_depth(),
                 };
                 upload.apply_to(&mut current_state);
                 resolved.push(PipelineFilter::Video(upload))

--- a/crates/ffpipeline/src/hw_accel.rs
+++ b/crates/ffpipeline/src/hw_accel.rs
@@ -9,7 +9,9 @@ use crate::video_filter::VideoFilter;
 
 #[enum_dispatch]
 pub trait HwAccel {
-    fn best_filter(&self, video_filter: &VideoFilter, ffmpeg_info: &FfmpegInfo) -> VideoFilter;
+    fn best_filter(&self, video_filter: &VideoFilter, _ffmpeg_info: &FfmpegInfo) -> VideoFilter {
+        video_filter.clone()
+    }
     fn can_decode(&self, codec: &str, _profile: &str, pixel_format: &PixelFormat) -> bool {
         match pixel_format.bit_depth() {
             10 => matches!(codec, "av1" | "hevc"),
@@ -26,15 +28,26 @@ pub trait HwAccel {
     }
     fn codec_for_format(&self, format: &VideoFormat) -> Option<VideoCodec>;
     fn decoder_arg(&self) -> Vec<String>;
-    fn decoder_filters(&self) -> Vec<PipelineFilter>;
+    fn decoder_filters(&self) -> Vec<PipelineFilter> {
+        Vec::new()
+    }
     fn decoder_frame_surface(&self) -> FrameSurface;
     fn encoder_frame_surface(&self) -> FrameSurface;
-    fn envs(&self) -> Vec<(String, String)>;
-    fn format_filter(&self, pixel_format: &PixelFormat) -> Option<VideoFilter>;
+    fn envs(&self) -> Vec<(String, String)> {
+        Vec::new()
+    }
+    fn format_filter(&self, _pixel_format: &PixelFormat) -> Option<VideoFilter> {
+        None
+    }
     fn initialize(&self, ffmpeg_info: &FfmpegInfo, is_hdr: bool) -> Self;
     fn init_hw_device(&self) -> Vec<String>;
     fn known_accel(&self) -> &KnownHardwareAccel;
-    fn output_format(&self, source_pixel_format: &PixelFormat) -> PixelFormat;
+    fn output_format(&self, source_pixel_format: &PixelFormat) -> PixelFormat {
+        match source_pixel_format.bit_depth() {
+            10 => PixelFormat::P010le,
+            _ => PixelFormat::Nv12,
+        }
+    }
     fn supports_pixel_format(&self, _pixel_format: &PixelFormat) -> bool {
         true
     }
@@ -47,4 +60,5 @@ pub enum HardwareAccel {
     Qsv(accel::qsv::Qsv),
     Vaapi(accel::vaapi::Vaapi),
     VideoToolbox(accel::video_toolbox::VideoToolbox),
+    Vulkan(accel::vulkan::Vulkan),
 }

--- a/crates/ffpipeline/src/hw_accel.rs
+++ b/crates/ffpipeline/src/hw_accel.rs
@@ -3,13 +3,18 @@ use enum_dispatch::enum_dispatch;
 use crate::accel;
 use crate::ffmpeg_info::{FfmpegInfo, KnownHardwareAccel};
 use crate::filter_chain::PipelineFilter;
-use crate::pipeline::{FrameSurface, PixelFormat, VideoFormat};
+use crate::pipeline::{FrameState, FrameSurface, PixelFormat, VideoFormat};
 use crate::video_codec::VideoCodec;
 use crate::video_filter::VideoFilter;
 
 #[enum_dispatch]
 pub trait HwAccel {
-    fn best_filter(&self, video_filter: &VideoFilter, _ffmpeg_info: &FfmpegInfo) -> VideoFilter {
+    fn best_filter(
+        &self,
+        video_filter: &VideoFilter,
+        _ffmpeg_info: &FfmpegInfo,
+        _current_state: &FrameState,
+    ) -> VideoFilter {
         video_filter.clone()
     }
     fn can_decode(&self, codec: &str, _profile: &str, pixel_format: &PixelFormat) -> bool {

--- a/crates/ffpipeline/src/video_filter.rs
+++ b/crates/ffpipeline/src/video_filter.rs
@@ -35,6 +35,7 @@ dyn_clone::clone_trait_object!(HwVideoFilter);
 pub enum VideoFilter {
     HwUpload {
         target_surface: FrameSurface,
+        bit_depth: u8,
     },
     HwDownload {
         target_pixel_format: PixelFormat,
@@ -114,7 +115,7 @@ impl VideoFilter {
 
     pub(crate) fn apply_to(&self, state: &mut FrameState) {
         match self {
-            VideoFilter::HwUpload { target_surface } => {
+            VideoFilter::HwUpload { target_surface, .. } => {
                 state.surface = target_surface.clone();
                 state.pixel_format = match &state.pixel_format {
                     PixelFormat::Yuv420p => PixelFormat::Nv12,
@@ -172,10 +173,21 @@ impl VideoFilter {
 
     pub(crate) fn as_arg(&self) -> Option<String> {
         match self {
-            VideoFilter::HwUpload { target_surface } => match target_surface {
+            VideoFilter::HwUpload {
+                target_surface,
+                bit_depth,
+            } => match target_surface {
+                // TODO: refactor this into each hwaccel, maybe a hw_upload_filter() fn?
                 FrameSurface::Cuda => Some(String::from("hwupload_cuda")),
                 FrameSurface::Qsv => Some(String::from("hwupload=extra_hw_frames=64")),
                 FrameSurface::Vaapi => Some(String::from("hwupload")),
+                FrameSurface::Vulkan => {
+                    let format = match bit_depth {
+                        10 => "p010le",
+                        _ => "nv12",
+                    };
+                    Some(format!("format={},hwupload", format))
+                }
                 _ => None,
             },
             VideoFilter::HwDownload {

--- a/examples/channel.toml
+++ b/examples/channel.toml
@@ -47,7 +47,7 @@ bitrate_kbps = 2_000
 
 buffer_kbps = 4_000
 
-# `cuda`, `qsv`, `vaapi` and `videotoolbox` accels are minimally supported at this point
+# `cuda`, `qsv`, `vaapi`, `videotoolbox` and `vulkan` accels are minimally supported at this point
 #accel = "cuda"
 
 # algorithm used for tone mapping when transcoding HDR content


### PR DESCRIPTION
there's currently a pretty big limitation where `scale_vulkan` only accepts 8-bit frames as input, but the pipeline accounts for this. decoding, encoding, scaling and even tonemapping seem to work okay.