### PR TITLE
feat: support http inputs in playouts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 .idea
+.serena

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -597,6 +597,7 @@ dependencies = [
  "log",
  "serde",
  "serde_json",
+ "simple-expand-tilde",
  "thiserror",
  "tokio",
 ]

--- a/crates/ersatztv-channel/src/channel_session.rs
+++ b/crates/ersatztv-channel/src/channel_session.rs
@@ -7,10 +7,11 @@ use ersatztv_core::{READY_FILE_NAME, empty_folder};
 use ersatztv_playout::playout::{
     PlayoutItem, PlayoutItemSource, PlayoutItemTracks, TrackSelection,
 };
+use ersatztv_playout::template::expand_template;
 use ffpipeline::ffmpeg_info::FfmpegInfo;
 use ffpipeline::frame_rate::FrameRate;
 use ffpipeline::frame_size::FrameSize;
-use ffpipeline::input::{InputSettings, InputSource, ProbedInput};
+use ffpipeline::input::{HttpInputOptions, InputSettings, InputSource, ProbedInput};
 use ffpipeline::output_settings::{AudioOutputSettings, OutputSettings};
 use ffpipeline::pipeline::{AudioFormat, Hz, Kbps, PtsOffset, SEGMENT_SECONDS, VideoFormat};
 use ffpipeline::probe::ProbeResult;
@@ -458,10 +459,7 @@ impl ChannelSession {
 
         let input_settings = InputSettings {
             audio_input: ProbedInput {
-                input_source: match audio_source {
-                    PlayoutItemSource::Local { path, .. } => InputSource::Local { path },
-                    PlayoutItemSource::Lavfi { params } => InputSource::Lavfi { params },
-                },
+                input_source: Self::playout_source_to_input_source(audio_source)?,
                 in_point: audio_timing.in_point,
                 out_point: audio_timing.out_point,
                 probe_result: audio_probe_result,
@@ -469,10 +467,7 @@ impl ChannelSession {
                 video_index: None,
             },
             video_input: ProbedInput {
-                input_source: match video_source {
-                    PlayoutItemSource::Local { path, .. } => InputSource::Local { path },
-                    PlayoutItemSource::Lavfi { params } => InputSource::Lavfi { params },
-                },
+                input_source: Self::playout_source_to_input_source(video_source)?,
                 in_point: if video_probe_result.is_still_image() {
                     Duration::ZERO
                 } else {
@@ -583,6 +578,49 @@ impl ChannelSession {
 
                 Ok(probe_result)
             }
+            PlayoutItemSource::Http { uri, .. } => {
+                let expanded_uri = expand_template(uri)?;
+                let probe_result = probe::probe(ffprobe_path, &expanded_uri).await?;
+
+                Ok(probe_result)
+            }
+        }
+    }
+
+    fn playout_source_to_input_source(
+        source: PlayoutItemSource,
+    ) -> Result<InputSource, ChannelError> {
+        match source {
+            PlayoutItemSource::Local { path, .. } => Ok(InputSource::Local { path }),
+            PlayoutItemSource::Lavfi { params } => Ok(InputSource::Lavfi { params }),
+            PlayoutItemSource::Http {
+                uri,
+                headers,
+                user_agent,
+                timeout_us,
+                reconnect,
+                reconnect_delay_max,
+                ..
+            } => {
+                let expanded_uri = expand_template(&uri)?;
+                let expanded_headers: Vec<String> = headers
+                    .unwrap_or_default()
+                    .iter()
+                    .map(|h| expand_template(h))
+                    .collect::<Result<Vec<_>, _>>()?;
+                let expanded_ua = user_agent.as_deref().map(expand_template).transpose()?;
+
+                Ok(InputSource::Http {
+                    uri: expanded_uri,
+                    options: HttpInputOptions {
+                        headers: expanded_headers,
+                        user_agent: expanded_ua,
+                        timeout_us,
+                        reconnect: reconnect.unwrap_or(true),
+                        reconnect_delay_max,
+                    },
+                })
+            }
         }
     }
 
@@ -599,11 +637,13 @@ impl ChannelSession {
         let item_finish = current_item.finish;
         let item_duration = current_item.finish - current_item.start;
         let item_in_point_base_ms = match source {
-            PlayoutItemSource::Local { in_point_ms, .. } => in_point_ms.unwrap_or(0),
+            PlayoutItemSource::Local { in_point_ms, .. }
+            | PlayoutItemSource::Http { in_point_ms, .. } => in_point_ms.unwrap_or(0),
             _ => 0,
         };
         let item_out_point_ms = match source {
-            PlayoutItemSource::Local { out_point_ms, .. } => out_point_ms
+            PlayoutItemSource::Local { out_point_ms, .. }
+            | PlayoutItemSource::Http { out_point_ms, .. } => out_point_ms
                 .unwrap_or(item_in_point_base_ms + item_duration.whole_milliseconds() as u64),
             _ => item_in_point_base_ms + item_duration.whole_milliseconds() as u64,
         };

--- a/crates/ersatztv-channel/src/channel_session.rs
+++ b/crates/ersatztv-channel/src/channel_session.rs
@@ -11,12 +11,14 @@ use ersatztv_playout::template::expand_template;
 use ffpipeline::ffmpeg_info::FfmpegInfo;
 use ffpipeline::frame_rate::FrameRate;
 use ffpipeline::frame_size::FrameSize;
-use ffpipeline::input::{HttpInputOptions, InputSettings, InputSource, ProbedInput};
+use ffpipeline::input::{
+    HttpInputOptions, HttpInputSource, InputSettings, InputSource, LavfiInputSource,
+    LocalInputSource, ProbedInput,
+};
 use ffpipeline::output_settings::{AudioOutputSettings, OutputSettings};
 use ffpipeline::pipeline::{AudioFormat, Hz, Kbps, PtsOffset, SEGMENT_SECONDS, VideoFormat};
-use ffpipeline::probe::ProbeResult;
+use ffpipeline::probe::{ProbeResult, Probeable};
 use ffpipeline::{pipeline, probe};
-use simple_expand_tilde::expand_tilde;
 use time::OffsetDateTime;
 use tokio::sync::Mutex;
 
@@ -375,12 +377,19 @@ impl ChannelSession {
             }
         }?;
 
+        let audio_input_source = Self::playout_source_to_input_source(audio_source.clone())?;
+        let video_input_source = if video_source == audio_source {
+            audio_input_source.clone()
+        } else {
+            Self::playout_source_to_input_source(video_source.clone())?
+        };
+
         let audio_probe_result =
-            Self::probe_source(&self.ffprobe_path, &self.ffmpeg_path, &audio_source).await?;
+            Self::probe_source(&self.ffprobe_path, &self.ffmpeg_path, &audio_input_source).await?;
         let video_probe_result = if video_source == audio_source {
             audio_probe_result.clone()
         } else {
-            Self::probe_source(&self.ffprobe_path, &self.ffmpeg_path, &video_source).await?
+            Self::probe_source(&self.ffprobe_path, &self.ffmpeg_path, &video_input_source).await?
         };
 
         let audio_norm = &self.channel_config.normalization.audio;
@@ -459,7 +468,7 @@ impl ChannelSession {
 
         let input_settings = InputSettings {
             audio_input: ProbedInput {
-                input_source: Self::playout_source_to_input_source(audio_source)?,
+                input_source: audio_input_source,
                 in_point: audio_timing.in_point,
                 out_point: audio_timing.out_point,
                 probe_result: audio_probe_result,
@@ -467,7 +476,7 @@ impl ChannelSession {
                 video_index: None,
             },
             video_input: ProbedInput {
-                input_source: Self::playout_source_to_input_source(video_source)?,
+                input_source: video_input_source,
                 in_point: if video_probe_result.is_still_image() {
                     Duration::ZERO
                 } else {
@@ -557,42 +566,26 @@ impl ChannelSession {
     async fn probe_source(
         ffprobe_path: &Path,
         ffmpeg_path: &Path,
-        source: &PlayoutItemSource,
+        source: &InputSource,
     ) -> Result<ProbeResult, ChannelError> {
-        match source {
-            PlayoutItemSource::Local { path, .. } => {
-                let expanded_path_buf =
-                    expand_tilde(path).ok_or(ChannelError::PlayoutJsonInvalidLocalSource)?;
-                let expanded_path = expanded_path_buf
-                    .as_os_str()
-                    .to_str()
-                    .ok_or(ChannelError::PlayoutJsonInvalidLocalSource)?;
+        let probe_deps = probe::ProbeDeps {
+            ffprobe_path,
+            ffmpeg_path,
+        };
 
-                // probe current item
-                let probe_result = probe::probe(ffprobe_path, expanded_path).await?;
-
-                Ok(probe_result)
-            }
-            PlayoutItemSource::Lavfi { params } => {
-                let probe_result = probe::probe_lavfi(ffprobe_path, ffmpeg_path, params).await?;
-
-                Ok(probe_result)
-            }
-            PlayoutItemSource::Http { uri, .. } => {
-                let expanded_uri = expand_template(uri)?;
-                let probe_result = probe::probe(ffprobe_path, &expanded_uri).await?;
-
-                Ok(probe_result)
-            }
-        }
+        Ok(source.probe(&probe_deps).await?)
     }
 
     fn playout_source_to_input_source(
         source: PlayoutItemSource,
     ) -> Result<InputSource, ChannelError> {
         match source {
-            PlayoutItemSource::Local { path, .. } => Ok(InputSource::Local { path }),
-            PlayoutItemSource::Lavfi { params } => Ok(InputSource::Lavfi { params }),
+            PlayoutItemSource::Local { path, .. } => {
+                Ok(InputSource::Local(LocalInputSource { path }))
+            }
+            PlayoutItemSource::Lavfi { params } => {
+                Ok(InputSource::Lavfi(LavfiInputSource { params }))
+            }
             PlayoutItemSource::Http {
                 uri,
                 headers,
@@ -610,7 +603,7 @@ impl ChannelSession {
                     .collect::<Result<Vec<_>, _>>()?;
                 let expanded_ua = user_agent.as_deref().map(expand_template).transpose()?;
 
-                Ok(InputSource::Http {
+                Ok(InputSource::Http(HttpInputSource {
                     uri: expanded_uri,
                     options: HttpInputOptions {
                         headers: expanded_headers,
@@ -619,7 +612,7 @@ impl ChannelSession {
                         reconnect: reconnect.unwrap_or(true),
                         reconnect_delay_max,
                     },
-                })
+                }))
             }
         }
     }

--- a/crates/ersatztv-channel/src/error.rs
+++ b/crates/ersatztv-channel/src/error.rs
@@ -35,9 +35,10 @@ pub enum ChannelError {
     #[error("unable to find current item in playout JSON")]
     PlayoutJsonNoItem { next_start: Option<OffsetDateTime> },
 
-    #[error("local source is invalid for playout item")]
-    PlayoutJsonInvalidLocalSource,
-
+    // This value got pushed down into another module (pipeline)
+    // See if there is a way to port this over
+    // #[error("local source is invalid for playout item")]
+    // PlayoutJsonInvalidLocalSource,
     #[error("audio source is required for playout item")]
     PlayoutJsonAudioSourceRequired,
 

--- a/crates/ersatztv-channel/src/playout_loader.rs
+++ b/crates/ersatztv-channel/src/playout_loader.rs
@@ -70,13 +70,30 @@ impl PlayoutLoader {
                 if path.ends_with(".json") {
                     let split: Vec<&str> = file_name.split("_").collect();
                     if split.len() == 2 {
-                        let maybe_start = OffsetDateTime::parse(split[0], &DATE_FORMAT).ok();
-                        let maybe_finish = OffsetDateTime::parse(split[1], &DATE_FORMAT).ok();
-                        if let (Some(start), Some(finish)) = (maybe_start, maybe_finish)
-                            && now >= &start
-                            && now < &finish
-                        {
-                            return Ok(path);
+                        let maybe_start = OffsetDateTime::parse(split[0], &DATE_FORMAT)
+                            .ok()
+                            .or_else(|| parse_unix_timestamp(split[0]));
+
+                        let maybe_finish = OffsetDateTime::parse(split[1], &DATE_FORMAT)
+                            .ok()
+                            .or_else(|| parse_unix_timestamp(split[1]));
+
+                        match (maybe_start, maybe_finish) {
+                            (Some(start), Some(finish)) => {
+                                log::trace!(
+                                    "Successfully parsed playout date range ({}, {}).",
+                                    start,
+                                    finish
+                                );
+                                if now >= &start && now < &finish {
+                                    return Ok(path);
+                                }
+                            }
+                            _ => {
+                                log::debug!(
+                                    "Could not parse start and end time for filename {file_name}"
+                                )
+                            }
                         }
                     }
                 }
@@ -97,5 +114,19 @@ impl PlayoutLoader {
             .iter()
             .find(|i| &i.start > now)
             .map(|i| i.start)
+    }
+}
+
+fn parse_unix_timestamp(timestamp: &str) -> Option<OffsetDateTime> {
+    let maybe_epoch = timestamp
+        .parse::<i64>()
+        .map(|i| if timestamp.len() > 10 { i / 1000 } else { i });
+
+    if let Ok(epoch) = maybe_epoch {
+        // TODO: Could use more logging maybe
+        OffsetDateTime::from_unix_timestamp(epoch).ok()
+    } else {
+        log::trace!("Couldn't parse Unix timestamp ({})", timestamp);
+        None
     }
 }

--- a/crates/ersatztv-playout-generator/src/main.rs
+++ b/crates/ersatztv-playout-generator/src/main.rs
@@ -5,7 +5,9 @@ mod sync;
 use std::path::{Path, PathBuf};
 
 use clap::{Parser, Subcommand};
-use ffpipeline::probe::ProbeResult;
+use ffpipeline::input::{InputSource, LocalInputSource};
+use ffpipeline::probe;
+use ffpipeline::probe::{ProbeResult, Probeable};
 use walkdir::DirEntry;
 
 use crate::error::PlayoutGeneratorError;
@@ -92,11 +94,15 @@ fn is_image_extension(dir_entry: &DirEntry) -> bool {
 
 async fn to_probe_result(dir_entry: &DirEntry) -> Option<PathAndProbe> {
     if let Some(video_path) = dir_entry.path().to_str()
-        && let Ok(probe_result) = ffpipeline::probe::probe(Path::new("ffprobe"), video_path).await
-    // && probe_result
-    //     .duration
-    //     .filter(|d| d.as_secs() < 120)
-    //     .is_some()
+        && let input_source = InputSource::Local(LocalInputSource {
+            path: video_path.to_string(),
+        })
+        && let Ok(probe_result) = input_source
+            .probe(&probe::ProbeDeps {
+                ffprobe_path: Path::new("ffprobe"),
+                ffmpeg_path: Path::new("ffmpeg"),
+            })
+            .await
     {
         return Some(PathAndProbe {
             path: dir_entry.path().to_path_buf(),

--- a/crates/ersatztv-playout/src/error.rs
+++ b/crates/ersatztv-playout/src/error.rs
@@ -10,4 +10,10 @@ pub enum PlayoutError {
 
     #[error("date formatting error: {0}")]
     PlayoutDateFormatError(#[from] time::error::Format),
+
+    #[error("template references missing environment variable: {0}")]
+    TemplateMissingEnvVar(String),
+
+    #[error("environment variable '{0}' contains invalid characters (control chars not allowed)")]
+    TemplateInvalidEnvVarValue(String),
 }

--- a/crates/ersatztv-playout/src/lib.rs
+++ b/crates/ersatztv-playout/src/lib.rs
@@ -1,2 +1,3 @@
 pub mod error;
 pub mod playout;
+pub mod template;

--- a/crates/ersatztv-playout/src/playout.rs
+++ b/crates/ersatztv-playout/src/playout.rs
@@ -102,6 +102,30 @@ pub enum PlayoutItemSource {
     Lavfi {
         params: String,
     },
+    Http {
+        /// URI template, e.g. "https://example.com/file.mkv?token={{MY_SECRET}}"
+        uri: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        in_point_ms: Option<u64>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        out_point_ms: Option<u64>,
+        /// Custom HTTP headers, e.g. ["Authorization: Bearer {{TOKEN}}"]
+        #[serde(skip_serializing_if = "Option::is_none")]
+        headers: Option<Vec<String>>,
+        /// Custom user-agent string
+        #[serde(skip_serializing_if = "Option::is_none")]
+        user_agent: Option<String>,
+        /// Socket timeout in microseconds
+        #[serde(skip_serializing_if = "Option::is_none")]
+        timeout_us: Option<u64>,
+        /// Enable reconnect on failure (default: true)
+        #[serde(skip_serializing_if = "Option::is_none")]
+        reconnect: Option<bool>,
+        /// Max reconnect delay in seconds
+        /// Maps directly to the reconnect_delay_max ffmpeg option
+        #[serde(skip_serializing_if = "Option::is_none")]
+        reconnect_delay_max: Option<u32>,
+    },
 }
 
 pub struct PlayoutLoadResult {

--- a/crates/ersatztv-playout/src/template.rs
+++ b/crates/ersatztv-playout/src/template.rs
@@ -1,0 +1,164 @@
+use crate::error::PlayoutError;
+
+/// Expand all `{{VAR_NAME}}` occurrences in `input` using `std::env::var`.
+///
+/// Variable names must match `[A-Za-z_][A-Za-z0-9_]*`. Returns the expanded
+/// string, or an error if any referenced variable is missing or its value
+/// contains control characters (bytes < 0x20 except tab).
+pub fn expand_template(input: &str) -> Result<String, PlayoutError> {
+    let mut result = String::with_capacity(input.len());
+    let mut chars = input.char_indices().peekable();
+
+    while let Some((i, ch)) = chars.next() {
+        if ch == '{' {
+            // Check for second '{'
+            if let Some(&(_, '{')) = chars.peek() {
+                chars.next(); // consume second '{'
+
+                let name_start = i + 2; // past "{{"
+                let mut name_end = name_start;
+                let mut found_close = false;
+                let mut partial_match = false;
+
+                while let Some(&(j, c)) = chars.peek() {
+                    if c == '}' {
+                        name_end = j;
+                        chars.next(); // consume first '}'
+                        // Expect second '}'
+                        if let Some(&(_, '}')) = chars.peek() {
+                            chars.next(); // consume second '}'
+                            found_close = true;
+                        } else {
+                            // Single '}' — not a template, emit literally
+                            result.push_str(&input[i..=j]);
+                            partial_match = true;
+                            break;
+                        }
+                        break;
+                    }
+                    chars.next();
+                }
+
+                if partial_match {
+                    continue;
+                } else if found_close {
+                    let var_name = &input[name_start..name_end];
+                    if var_name.is_empty() || !is_valid_var_name(var_name) {
+                        // Not a valid variable reference, emit literally
+                        result.push_str("{{");
+                        result.push_str(var_name);
+                        result.push_str("}}");
+                    } else {
+                        let value = std::env::var(var_name).map_err(|_| {
+                            PlayoutError::TemplateMissingEnvVar(var_name.to_string())
+                        })?;
+
+                        // Validate: no control characters except tab
+                        if value.bytes().any(|b| b < 0x20 && b != b'\t') {
+                            return Err(PlayoutError::TemplateInvalidEnvVarValue(
+                                var_name.to_string(),
+                            ));
+                        }
+
+                        result.push_str(&value);
+                    }
+                } else if !found_close {
+                    // Reached end of input without closing "}}", emit what we consumed
+                    result.push_str(&input[i..]);
+                    return Ok(result);
+                }
+            } else {
+                result.push(ch);
+            }
+        } else {
+            result.push(ch);
+        }
+    }
+
+    Ok(result)
+}
+
+fn is_valid_var_name(name: &str) -> bool {
+    let mut chars = name.chars();
+    match chars.next() {
+        Some(c) if c.is_ascii_alphabetic() || c == '_' => {}
+        _ => return false,
+    }
+    chars.all(|c| c.is_ascii_alphanumeric() || c == '_')
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn no_templates() {
+        let result = expand_template("https://example.com/file.mkv").unwrap();
+        assert_eq!(result, "https://example.com/file.mkv");
+    }
+
+    #[test]
+    fn single_template() {
+        // SAFETY: test-only, single-threaded
+        unsafe { std::env::set_var("TEST_TOKEN_1", "secret123") };
+        let result =
+            expand_template("https://example.com/file.mkv?token={{TEST_TOKEN_1}}").unwrap();
+        assert_eq!(result, "https://example.com/file.mkv?token=secret123");
+    }
+
+    #[test]
+    fn multiple_templates() {
+        // SAFETY: test-only, single-threaded
+        unsafe {
+            std::env::set_var("TEST_HOST_1", "my.server.com");
+            std::env::set_var("TEST_KEY_1", "abc");
+        }
+        let result = expand_template("https://{{TEST_HOST_1}}/path?key={{TEST_KEY_1}}").unwrap();
+        assert_eq!(result, "https://my.server.com/path?key=abc");
+    }
+
+    #[test]
+    fn missing_env_var() {
+        // SAFETY: test-only, single-threaded
+        unsafe { std::env::remove_var("TEST_NONEXISTENT_VAR") };
+        let result = expand_template("{{TEST_NONEXISTENT_VAR}}");
+        assert!(matches!(
+            result,
+            Err(PlayoutError::TemplateMissingEnvVar(_))
+        ));
+    }
+
+    #[test]
+    fn control_chars_rejected() {
+        // SAFETY: test-only, single-threaded
+        unsafe { std::env::set_var("TEST_BAD_VAR_1", "value\nwith\nnewlines") };
+        let result = expand_template("{{TEST_BAD_VAR_1}}");
+        assert!(matches!(
+            result,
+            Err(PlayoutError::TemplateInvalidEnvVarValue(_))
+        ));
+    }
+
+    #[test]
+    fn literal_braces_preserved() {
+        let result = expand_template("single { brace } here").unwrap();
+        assert_eq!(result, "single { brace } here");
+    }
+
+    #[test]
+    fn malformed_single_close_brace_no_duplication() {
+        // {{VAR}X should emit literally without duplication and not
+        // prevent subsequent templates from being processed.
+        unsafe { std::env::set_var("TEST_AFTER_MALFORMED", "ok") };
+        let result = expand_template("{{VAR}X then {{TEST_AFTER_MALFORMED}}").unwrap();
+        assert_eq!(result, "{{VAR}X then ok");
+    }
+
+    #[test]
+    fn tab_allowed_in_value() {
+        // SAFETY: test-only, single-threaded
+        unsafe { std::env::set_var("TEST_TAB_VAR", "value\twith\ttabs") };
+        let result = expand_template("{{TEST_TAB_VAR}}").unwrap();
+        assert_eq!(result, "value\twith\ttabs");
+    }
+}

--- a/crates/ersatztv-playout/src/template.rs
+++ b/crates/ersatztv-playout/src/template.rs
@@ -42,7 +42,7 @@ pub fn expand_template(input: &str) -> Result<String, PlayoutError> {
                 if partial_match {
                     continue;
                 } else if found_close {
-                    let var_name = &input[name_start..name_end];
+                    let var_name = input[name_start..name_end].trim();
                     if var_name.is_empty() || !is_valid_var_name(var_name) {
                         // Not a valid variable reference, emit literally
                         result.push_str("{{");
@@ -103,6 +103,15 @@ mod tests {
         unsafe { std::env::set_var("TEST_TOKEN_1", "secret123") };
         let result =
             expand_template("https://example.com/file.mkv?token={{TEST_TOKEN_1}}").unwrap();
+        assert_eq!(result, "https://example.com/file.mkv?token=secret123");
+    }
+
+    #[test]
+    fn consumes_extra_whitespace() {
+        // SAFETY: test-only, single-threaded
+        unsafe { std::env::set_var("TEST_TOKEN_1", "secret123") };
+        let result =
+            expand_template("https://example.com/file.mkv?token={{ TEST_TOKEN_1  }}").unwrap();
         assert_eq!(result, "https://example.com/file.mkv?token=secret123");
     }
 

--- a/crates/ffpipeline/Cargo.toml
+++ b/crates/ffpipeline/Cargo.toml
@@ -14,3 +14,4 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }
+simple-expand-tilde = "0.5.3"

--- a/crates/ffpipeline/src/input.rs
+++ b/crates/ffpipeline/src/input.rs
@@ -7,10 +7,27 @@ pub struct InputSettings {
     pub video_input: ProbedInput,
 }
 
+#[derive(Clone, Debug)]
+pub struct HttpInputOptions {
+    pub headers: Vec<String>,
+    pub user_agent: Option<String>,
+    pub timeout_us: Option<u64>,
+    pub reconnect: bool,
+    pub reconnect_delay_max: Option<u32>,
+}
+
 #[derive(Clone)]
 pub enum InputSource {
-    Local { path: String },
-    Lavfi { params: String },
+    Local {
+        path: String,
+    },
+    Lavfi {
+        params: String,
+    },
+    Http {
+        uri: String,
+        options: HttpInputOptions,
+    },
 }
 
 pub struct ProbedInput {

--- a/crates/ffpipeline/src/input.rs
+++ b/crates/ffpipeline/src/input.rs
@@ -1,5 +1,8 @@
 use std::time::Duration;
 
+use enum_dispatch::enum_dispatch;
+use simple_expand_tilde::expand_tilde;
+
 use crate::probe::ProbeResult;
 
 pub struct InputSettings {
@@ -17,17 +20,101 @@ pub struct HttpInputOptions {
 }
 
 #[derive(Clone)]
+pub struct LocalInputSource {
+    pub path: String,
+}
+
+impl LocalInputSource {
+    pub fn expand_path(&self) -> Option<String> {
+        let expanded_path_buf = expand_tilde(self.path.as_str()); //.ok_or(ChannelError::PlayoutJsonInvalidLocalSource)?;
+        expanded_path_buf
+            .map(|p| p.into_os_string())
+            .and_then(|p| p.into_string().ok())
+    }
+}
+
+#[derive(Clone)]
+pub struct LavfiInputSource {
+    pub params: String,
+}
+
+#[derive(Clone)]
+pub struct HttpInputSource {
+    pub uri: String,
+    pub options: HttpInputOptions,
+}
+
+#[derive(Clone)]
+#[enum_dispatch(Probeable)]
+#[enum_dispatch(FfmpegInputArgs)]
 pub enum InputSource {
-    Local {
-        path: String,
-    },
-    Lavfi {
-        params: String,
-    },
-    Http {
-        uri: String,
-        options: HttpInputOptions,
-    },
+    Local(LocalInputSource),
+    Lavfi(LavfiInputSource),
+    Http(HttpInputSource),
+}
+
+#[enum_dispatch]
+pub trait FfmpegInputArgs {
+    fn args_for_input(&self) -> Vec<String>;
+}
+
+impl FfmpegInputArgs for LocalInputSource {
+    fn args_for_input(&self) -> Vec<String> {
+        [].to_vec()
+    }
+}
+
+impl FfmpegInputArgs for LavfiInputSource {
+    fn args_for_input(&self) -> Vec<String> {
+        vec!["-f".to_string(), "lavfi".to_string()]
+    }
+}
+impl FfmpegInputArgs for HttpInputSource {
+    fn args_for_input(&self) -> Vec<String> {
+        let mut args = Vec::new();
+
+        if self.options.reconnect {
+            args.extend([
+                String::from("-reconnect"),
+                String::from("1"),
+                String::from("-reconnect_on_network_error"),
+                String::from("1"),
+                String::from("-reconnect_streamed"),
+                String::from("1"),
+                String::from("-multiple_requests"),
+                String::from("1"),
+            ]);
+            if let Some(max_delay) = self.options.reconnect_delay_max {
+                args.extend([String::from("-reconnect_delay_max"), max_delay.to_string()]);
+            }
+        }
+
+        if let Some(timeout) = self.options.timeout_us {
+            args.extend([String::from("-timeout"), timeout.to_string()]);
+        }
+
+        if let Some(ua) = &self.options.user_agent {
+            args.extend([String::from("-user_agent"), ua.clone()]);
+        }
+
+        if !self.options.headers.is_empty() {
+            // FFmpeg expects headers separated by \r\n, with trailing \r\n
+            let combined: String = self
+                .options
+                .headers
+                .iter()
+                .map(|h| format!("{}\r\n", h))
+                .collect();
+            args.extend([String::from("-headers"), combined]);
+        }
+
+        args.extend([
+            String::from("-protocol_whitelist"),
+            String::from("file,http,https,tcp,tls,crypto"),
+        ]);
+
+        args
+    }
 }
 
 pub struct ProbedInput {

--- a/crates/ffpipeline/src/pipeline.rs
+++ b/crates/ffpipeline/src/pipeline.rs
@@ -11,7 +11,7 @@ use crate::frame_rate::FrameRate;
 use crate::frame_size::FrameSize;
 use crate::global_option::{GlobalOption, LogLevel};
 use crate::hw_accel::{HardwareAccel, HwAccel};
-use crate::input::{HttpInputOptions, InputSettings, InputSource};
+use crate::input::{FfmpegInputArgs, InputSettings, InputSource};
 use crate::output_option::OutputOption;
 use crate::output_settings::OutputSettings;
 use crate::probe::{ProbeResultAudioStream, ProbeResultStream, ProbeResultVideoStream};
@@ -438,16 +438,7 @@ impl Pipeline {
 
                     // if more than one path, audio is probably separate from video
                     if distinct_paths.len() > 1 {
-                        match input_source {
-                            InputSource::Lavfi { .. } => {
-                                result.extend([String::from("-f"), String::from("lavfi")]);
-                            }
-                            InputSource::Http { options, .. } => {
-                                result.extend(Self::http_input_args(options));
-                            }
-                            _ => {}
-                        }
-
+                        result.extend(input_source.args_for_input());
                         result.extend([String::from("-i"), path.to_owned()]);
                     }
                 }
@@ -474,15 +465,7 @@ impl Pipeline {
                         result.extend([String::from("-readrate"), String::from("1.0")]);
                     }
 
-                    match input_source {
-                        InputSource::Lavfi { .. } => {
-                            result.extend([String::from("-f"), String::from("lavfi")]);
-                        }
-                        InputSource::Http { options, .. } => {
-                            result.extend(Self::http_input_args(options));
-                        }
-                        _ => {}
-                    }
+                    result.extend(input_source.args_for_input());
 
                     result.extend([String::from("-i"), path.to_owned()]);
                 }
@@ -506,51 +489,6 @@ impl Pipeline {
         result.extend([self.output.path.to_owned()]);
 
         result
-    }
-
-    fn http_input_args(options: &HttpInputOptions) -> Vec<String> {
-        let mut args = Vec::new();
-
-        if options.reconnect {
-            args.extend([
-                String::from("-reconnect"),
-                String::from("1"),
-                String::from("-reconnect_on_network_error"),
-                String::from("1"),
-                String::from("-reconnect_streamed"),
-                String::from("1"),
-                String::from("-multiple_requests"),
-                String::from("1"),
-            ]);
-            if let Some(max_delay) = options.reconnect_delay_max {
-                args.extend([String::from("-reconnect_delay_max"), max_delay.to_string()]);
-            }
-        }
-
-        if let Some(timeout) = options.timeout_us {
-            args.extend([String::from("-timeout"), timeout.to_string()]);
-        }
-
-        if let Some(ua) = &options.user_agent {
-            args.extend([String::from("-user_agent"), ua.clone()]);
-        }
-
-        if !options.headers.is_empty() {
-            // FFmpeg expects headers separated by \r\n, with trailing \r\n
-            let combined: String = options
-                .headers
-                .iter()
-                .map(|h| format!("{}\r\n", h))
-                .collect();
-            args.extend([String::from("-headers"), combined]);
-        }
-
-        args.extend([
-            String::from("-protocol_whitelist"),
-            String::from("file,http,https,tcp,tls,crypto"),
-        ]);
-
-        args
     }
 
     pub fn envs(&self) -> Vec<(String, String)> {

--- a/crates/ffpipeline/src/pipeline.rs
+++ b/crates/ffpipeline/src/pipeline.rs
@@ -11,7 +11,7 @@ use crate::frame_rate::FrameRate;
 use crate::frame_size::FrameSize;
 use crate::global_option::{GlobalOption, LogLevel};
 use crate::hw_accel::{HardwareAccel, HwAccel};
-use crate::input::{InputSettings, InputSource};
+use crate::input::{HttpInputOptions, InputSettings, InputSource};
 use crate::output_option::OutputOption;
 use crate::output_settings::OutputSettings;
 use crate::probe::{ProbeResultAudioStream, ProbeResultStream, ProbeResultVideoStream};
@@ -438,8 +438,14 @@ impl Pipeline {
 
                     // if more than one path, audio is probably separate from video
                     if distinct_paths.len() > 1 {
-                        if matches!(input_source, InputSource::Lavfi { .. }) {
-                            result.extend([String::from("-f"), String::from("lavfi")]);
+                        match input_source {
+                            InputSource::Lavfi { .. } => {
+                                result.extend([String::from("-f"), String::from("lavfi")]);
+                            }
+                            InputSource::Http { options, .. } => {
+                                result.extend(Self::http_input_args(options));
+                            }
+                            _ => {}
                         }
 
                         result.extend([String::from("-i"), path.to_owned()]);
@@ -468,8 +474,14 @@ impl Pipeline {
                         result.extend([String::from("-readrate"), String::from("1.0")]);
                     }
 
-                    if matches!(input_source, InputSource::Lavfi { .. }) {
-                        result.extend([String::from("-f"), String::from("lavfi")]);
+                    match input_source {
+                        InputSource::Lavfi { .. } => {
+                            result.extend([String::from("-f"), String::from("lavfi")]);
+                        }
+                        InputSource::Http { options, .. } => {
+                            result.extend(Self::http_input_args(options));
+                        }
+                        _ => {}
                     }
 
                     result.extend([String::from("-i"), path.to_owned()]);
@@ -494,6 +506,51 @@ impl Pipeline {
         result.extend([self.output.path.to_owned()]);
 
         result
+    }
+
+    fn http_input_args(options: &HttpInputOptions) -> Vec<String> {
+        let mut args = Vec::new();
+
+        if options.reconnect {
+            args.extend([
+                String::from("-reconnect"),
+                String::from("1"),
+                String::from("-reconnect_on_network_error"),
+                String::from("1"),
+                String::from("-reconnect_streamed"),
+                String::from("1"),
+                String::from("-multiple_requests"),
+                String::from("1"),
+            ]);
+            if let Some(max_delay) = options.reconnect_delay_max {
+                args.extend([String::from("-reconnect_delay_max"), max_delay.to_string()]);
+            }
+        }
+
+        if let Some(timeout) = options.timeout_us {
+            args.extend([String::from("-timeout"), timeout.to_string()]);
+        }
+
+        if let Some(ua) = &options.user_agent {
+            args.extend([String::from("-user_agent"), ua.clone()]);
+        }
+
+        if !options.headers.is_empty() {
+            // FFmpeg expects headers separated by \r\n, with trailing \r\n
+            let combined: String = options
+                .headers
+                .iter()
+                .map(|h| format!("{}\r\n", h))
+                .collect();
+            args.extend([String::from("-headers"), combined]);
+        }
+
+        args.extend([
+            String::from("-protocol_whitelist"),
+            String::from("file,http,https,tcp,tls,crypto"),
+        ]);
+
+        args
     }
 
     pub fn envs(&self) -> Vec<(String, String)> {

--- a/crates/ffpipeline/src/probe.rs
+++ b/crates/ffpipeline/src/probe.rs
@@ -154,6 +154,11 @@ pub async fn probe(
         .map_err(|_| FFPipelineError::ProbeFailed)?;
 
     if !output.status.success() {
+        log::warn!(
+            "error executing ffprobe: {}\n{}",
+            output.status,
+            String::from_utf8_lossy(&output.stderr)
+        );
         return Err(FFPipelineError::ProbeFailed);
     }
 

--- a/crates/ffpipeline/src/probe.rs
+++ b/crates/ffpipeline/src/probe.rs
@@ -1,11 +1,19 @@
+use std::ffi::OsStr;
 use std::fmt::Formatter;
+use std::path::Path;
 use std::time::Duration;
 
+use enum_dispatch::enum_dispatch;
 use serde::Deserialize;
 use tokio::process::Command;
 
 use crate::error::FFPipelineError;
+use crate::error::FFPipelineError::ProbeFailed;
 use crate::frame_rate::FrameRate;
+use crate::input::InputSource;
+use crate::input::LavfiInputSource;
+use crate::input::LocalInputSource;
+use crate::input::{FfmpegInputArgs, HttpInputSource};
 
 #[derive(Debug, Clone)]
 pub struct ProbeResultColorParams {
@@ -134,21 +142,119 @@ struct ProbeOutput {
     format: ProbeOutputFormat,
 }
 
-pub async fn probe(
-    ffprobe_path: &std::path::Path,
+pub struct ProbeDeps<'a> {
+    pub ffmpeg_path: &'a Path,
+    pub ffprobe_path: &'a Path,
+}
+
+#[enum_dispatch]
+pub trait Probeable {
+    // Temporarily allow this - expanding out to the impl Future syntax
+    // seems to break enum_dispatch.
+    #[allow(async_fn_in_trait)]
+    async fn probe(&self, probe_deps: &ProbeDeps<'_>) -> Result<ProbeResult, FFPipelineError>;
+}
+
+impl Probeable for LocalInputSource {
+    async fn probe(&self, probe_deps: &ProbeDeps<'_>) -> Result<ProbeResult, FFPipelineError> {
+        let mut args: Vec<String> = vec![
+            "-hide_banner".to_string(),
+            "-print_format".to_string(),
+            "json".to_string(),
+            "-show_format".to_string(),
+            "-show_streams".to_string(),
+            "-show_chapters".to_string(),
+        ];
+        args.extend(self.args_for_input());
+        let expanded_path = self.expand_path().ok_or(ProbeFailed)?;
+        args.extend(["-i".to_string(), expanded_path.clone()]);
+
+        probe_with_args(probe_deps.ffprobe_path, &expanded_path, &args).await
+    }
+}
+
+impl Probeable for LavfiInputSource {
+    async fn probe(&self, probe_deps: &ProbeDeps<'_>) -> Result<ProbeResult, FFPipelineError> {
+        let mut ffmpeg = Command::new(probe_deps.ffmpeg_path)
+            .args([
+                "-f",
+                "lavfi",
+                "-i",
+                self.params.as_str(),
+                "-t",
+                "1",
+                "-f",
+                "nut",
+                "pipe:1",
+            ])
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::null())
+            .spawn()
+            .map_err(|_| FFPipelineError::ProbeFailed)?;
+
+        let ffmpeg_stdout: std::process::Stdio = ffmpeg
+            .stdout
+            .take()
+            .ok_or(FFPipelineError::ProbeFailed)?
+            .try_into()
+            .map_err(|_| FFPipelineError::ProbeFailed)?;
+
+        let output = Command::new(probe_deps.ffprobe_path)
+            .args([
+                "-hide_banner",
+                "-print_format",
+                "json",
+                "-show_format",
+                "-show_streams",
+                "-show_chapters",
+                "-i",
+                "pipe:0",
+            ])
+            .stdin(ffmpeg_stdout)
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::null())
+            .output()
+            .await
+            .map_err(|_| FFPipelineError::ProbeFailed)?;
+
+        let _ = ffmpeg.wait().await;
+
+        if !output.status.success() {
+            return Err(FFPipelineError::ProbeFailed);
+        }
+
+        parse_ffprobe_stdout(self.params.clone(), output.stdout)
+    }
+}
+
+impl Probeable for HttpInputSource {
+    async fn probe(&self, probe_deps: &ProbeDeps<'_>) -> Result<ProbeResult, FFPipelineError> {
+        let mut args: Vec<String> = vec![
+            "-hide_banner".to_string(),
+            "-print_format".to_string(),
+            "json".to_string(),
+            "-show_format".to_string(),
+            "-show_streams".to_string(),
+            "-show_chapters".to_string(),
+        ];
+        args.extend(self.args_for_input());
+        args.extend(["-i".to_string(), self.uri.clone()]);
+
+        probe_with_args(probe_deps.ffprobe_path, &self.uri, &args).await
+    }
+}
+
+async fn probe_with_args<I, S>(
+    ffprobe_path: &Path,
     path: &str,
-) -> Result<ProbeResult, FFPipelineError> {
+    args: I,
+) -> Result<ProbeResult, FFPipelineError>
+where
+    I: IntoIterator<Item = S>,
+    S: AsRef<OsStr>,
+{
     let output = Command::new(ffprobe_path)
-        .args([
-            "-hide_banner",
-            "-print_format",
-            "json",
-            "-show_format",
-            "-show_streams",
-            "-show_chapters",
-            "-i",
-            path,
-        ])
+        .args(args)
         .output()
         .await
         .map_err(|_| FFPipelineError::ProbeFailed)?;
@@ -162,56 +268,10 @@ pub async fn probe(
         return Err(FFPipelineError::ProbeFailed);
     }
 
-    parse_ffprobe_stdout(path, output.stdout)
+    parse_ffprobe_stdout(path.to_owned(), output.stdout)
 }
 
-pub async fn probe_lavfi(
-    ffprobe_path: &std::path::Path,
-    ffmpeg_path: &std::path::Path,
-    lavfi: &str,
-) -> Result<ProbeResult, FFPipelineError> {
-    let mut ffmpeg = Command::new(ffmpeg_path)
-        .args(["-f", "lavfi", "-i", lavfi, "-t", "1", "-f", "nut", "pipe:1"])
-        .stdout(std::process::Stdio::piped())
-        .stderr(std::process::Stdio::null())
-        .spawn()
-        .map_err(|_| FFPipelineError::ProbeFailed)?;
-
-    let ffmpeg_stdout: std::process::Stdio = ffmpeg
-        .stdout
-        .take()
-        .ok_or(FFPipelineError::ProbeFailed)?
-        .try_into()
-        .map_err(|_| FFPipelineError::ProbeFailed)?;
-
-    let output = Command::new(ffprobe_path)
-        .args([
-            "-hide_banner",
-            "-print_format",
-            "json",
-            "-show_format",
-            "-show_streams",
-            "-show_chapters",
-            "-i",
-            "pipe:0",
-        ])
-        .stdin(ffmpeg_stdout)
-        .stdout(std::process::Stdio::piped())
-        .stderr(std::process::Stdio::null())
-        .output()
-        .await
-        .map_err(|_| FFPipelineError::ProbeFailed)?;
-
-    let _ = ffmpeg.wait().await;
-
-    if !output.status.success() {
-        return Err(FFPipelineError::ProbeFailed);
-    }
-
-    parse_ffprobe_stdout(lavfi, output.stdout)
-}
-
-fn parse_ffprobe_stdout(path: &str, stdout: Vec<u8>) -> Result<ProbeResult, FFPipelineError> {
+fn parse_ffprobe_stdout(path: String, stdout: Vec<u8>) -> Result<ProbeResult, FFPipelineError> {
     let raw_output = String::from_utf8(stdout).map_err(|_| FFPipelineError::ProbeFailedToParse)?;
 
     //println!("{raw_output}");

--- a/examples/playout/playout.json
+++ b/examples/playout/playout.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "../../schema/playout.json",
   "version": "https://ersatztv.org/playout/version/1.0.0",
   "generated_at": "2026-02-23T18:02:00-05:00",
   "items": [

--- a/schema/playout.json
+++ b/schema/playout.json
@@ -110,6 +110,81 @@
             "source_type",
             "params"
           ]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "headers": {
+              "description": "Custom HTTP headers, e.g. [\"Authorization: Bearer {{TOKEN}}\"]",
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": "string"
+              }
+            },
+            "in_point_ms": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "format": "uint64",
+              "minimum": 0
+            },
+            "out_point_ms": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "format": "uint64",
+              "minimum": 0
+            },
+            "reconnect": {
+              "description": "Enable reconnect on failure (default: true)",
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "reconnect_delay_max": {
+              "description": "Max reconnect delay in seconds",
+              "type": [
+                "integer",
+                "null"
+              ],
+              "format": "uint32",
+              "minimum": 0
+            },
+            "source_type": {
+              "type": "string",
+              "const": "http"
+            },
+            "timeout_us": {
+              "description": "Socket timeout in microseconds",
+              "type": [
+                "integer",
+                "null"
+              ],
+              "format": "uint64",
+              "minimum": 0
+            },
+            "uri": {
+              "description": "URI template, e.g. \"https://example.com/file.mkv?token={{MY_SECRET}}\"",
+              "type": "string"
+            },
+            "user_agent": {
+              "description": "Custom user-agent string",
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          },
+          "required": [
+            "source_type",
+            "uri"
+          ]
         }
       ]
     },


### PR DESCRIPTION
Supports artibitrary subtitution of environment variables in configuration fields to allow for passing secrets or other values into channel configuration, e.g. Plex tokens.

Also adds support for specifying playout JSON files using unix timestamps in seconds or millis since epoch.