### PR TITLE
refactor: use Cow for ffmpeg args to save on heap allocations

### DIFF
--- a/crates/ersatztv-channel/src/channel_session.rs
+++ b/crates/ersatztv-channel/src/channel_session.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 use std::fmt::Formatter;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
@@ -504,7 +505,7 @@ impl ChannelSession {
 
         // stream current item
         let mut ffmpeg_child = tokio::process::Command::new(&self.ffmpeg_path)
-            .args(args)
+            .args(args.iter().map(Cow::as_ref))
             .envs(envs)
             .stdout(std::process::Stdio::null())
             .spawn()

--- a/crates/ffpipeline/src/accel/cuda.rs
+++ b/crates/ffpipeline/src/accel/cuda.rs
@@ -1,3 +1,4 @@
+use crate::ArgVec;
 use crate::capabilities::nvidia::NvidiaCapabilities;
 use crate::ffmpeg_info::{FfmpegInfo, KnownHardwareAccel, KnownVideoFilter};
 use crate::filter_chain::PipelineFilter;
@@ -105,22 +106,12 @@ impl HwAccel for Cuda {
         }
     }
 
-    fn decoder_arg(&self) -> Vec<String> {
+    fn decoder_arg(&self) -> ArgVec {
         log::debug!("decoder arg, is_hdr: {}", self.is_vulkan_hdr);
         if self.is_vulkan_hdr {
-            vec![
-                String::from("-hwaccel"),
-                String::from("vulkan"),
-                String::from("-hwaccel_output_format"),
-                String::from("vulkan"),
-            ]
+            args!["-hwaccel", "vulkan", "-hwaccel_output_format", "vulkan",]
         } else {
-            vec![
-                String::from("-hwaccel"),
-                String::from("cuda"),
-                String::from("-hwaccel_output_format"),
-                String::from("cuda"),
-            ]
+            args!["-hwaccel", "cuda", "-hwaccel_output_format", "cuda",]
         }
     }
 
@@ -162,17 +153,17 @@ impl HwAccel for Cuda {
         }
     }
 
-    fn init_hw_device(&self) -> Vec<String> {
+    fn init_hw_device(&self) -> ArgVec {
         log::debug!("init hw device, is_hdr: {}", self.is_vulkan_hdr);
         if self.is_vulkan_hdr {
-            vec![
-                String::from("-init_hw_device"),
-                String::from("cuda=nv"),
-                String::from("-init_hw_device"),
-                String::from("vulkan=vk@nv"),
+            args![
+                "-init_hw_device",
+                "cuda=nv",
+                "-init_hw_device",
+                "vulkan=vk@nv"
             ]
         } else {
-            vec![String::from("-init_hw_device"), String::from("cuda")]
+            args!["-init_hw_device", "cuda"]
         }
     }
 

--- a/crates/ffpipeline/src/accel/qsv.rs
+++ b/crates/ffpipeline/src/accel/qsv.rs
@@ -1,3 +1,4 @@
+use crate::ArgVec;
 use crate::capabilities::qsv::QsvCapabilities;
 use crate::ffmpeg_info::{FfmpegInfo, KnownHardwareAccel, KnownVideoFilter};
 use crate::frame_size::FrameSize;
@@ -71,13 +72,8 @@ impl HwAccel for Qsv {
         }
     }
 
-    fn decoder_arg(&self) -> Vec<String> {
-        vec![
-            String::from("-hwaccel"),
-            String::from("qsv"),
-            String::from("-hwaccel_output_format"),
-            String::from("qsv"),
-        ]
+    fn decoder_arg(&self) -> ArgVec {
+        args!["-hwaccel", "qsv", "-hwaccel_output_format", "qsv",]
     }
 
     fn decoder_frame_surface(&self) -> FrameSurface {
@@ -92,13 +88,8 @@ impl HwAccel for Qsv {
         self.clone()
     }
 
-    fn init_hw_device(&self) -> Vec<String> {
-        vec![
-            String::from("-init_hw_device"),
-            String::from("qsv=hw"),
-            String::from("-filter_hw_device"),
-            String::from("hw"),
-        ]
+    fn init_hw_device(&self) -> ArgVec {
+        args!["-init_hw_device", "qsv=hw", "-filter_hw_device", "hw",]
     }
 
     fn known_accel(&self) -> &KnownHardwareAccel {

--- a/crates/ffpipeline/src/accel/vaapi.rs
+++ b/crates/ffpipeline/src/accel/vaapi.rs
@@ -1,5 +1,6 @@
 use std::fmt::{Display, Formatter};
 
+use crate::ArgVec;
 use crate::capabilities::vaapi::VaapiCapabilities;
 use crate::ffmpeg_info::{FfmpegInfo, KnownHardwareAccel, KnownVideoFilter};
 use crate::frame_size::FrameSize;
@@ -111,13 +112,8 @@ impl HwAccel for Vaapi {
         }
     }
 
-    fn decoder_arg(&self) -> Vec<String> {
-        vec![
-            String::from("-hwaccel"),
-            String::from("vaapi"),
-            String::from("-hwaccel_output_format"),
-            String::from("vaapi"),
-        ]
+    fn decoder_arg(&self) -> ArgVec {
+        args!["-hwaccel", "vaapi", "-hwaccel_output_format", "vaapi"]
     }
 
     fn decoder_frame_surface(&self) -> FrameSurface {
@@ -142,8 +138,8 @@ impl HwAccel for Vaapi {
         self.clone()
     }
 
-    fn init_hw_device(&self) -> Vec<String> {
-        vec![String::from("-vaapi_device"), self.device.clone()]
+    fn init_hw_device(&self) -> ArgVec {
+        args!["-vaapi_device", self.device.clone()]
     }
 
     fn known_accel(&self) -> &KnownHardwareAccel {

--- a/crates/ffpipeline/src/accel/video_toolbox.rs
+++ b/crates/ffpipeline/src/accel/video_toolbox.rs
@@ -1,3 +1,4 @@
+use crate::ArgVec;
 use crate::ffmpeg_info::{FfmpegInfo, KnownHardwareAccel};
 use crate::hw_accel::HwAccel;
 use crate::pipeline::{FrameSurface, PixelFormat, VideoFormat};
@@ -35,12 +36,12 @@ impl HwAccel for VideoToolbox {
         }
     }
 
-    fn decoder_arg(&self) -> Vec<String> {
-        vec![
-            String::from("-hwaccel"),
-            String::from("videotoolbox"),
-            String::from("-hwaccel_output_format"),
-            String::from("videotoolbox_vld"),
+    fn decoder_arg(&self) -> ArgVec {
+        args![
+            "-hwaccel",
+            "videotoolbox",
+            "-hwaccel_output_format",
+            "videotoolbox_vld",
         ]
     }
 
@@ -56,7 +57,7 @@ impl HwAccel for VideoToolbox {
         self.clone()
     }
 
-    fn init_hw_device(&self) -> Vec<String> {
+    fn init_hw_device(&self) -> ArgVec {
         Vec::new()
     }
 

--- a/crates/ffpipeline/src/accel/vulkan.rs
+++ b/crates/ffpipeline/src/accel/vulkan.rs
@@ -1,3 +1,4 @@
+use crate::ArgVec;
 use crate::ffmpeg_info::{FfmpegInfo, KnownHardwareAccel, KnownVideoFilter};
 use crate::frame_size::FrameSize;
 use crate::hw_accel::HwAccel;
@@ -64,13 +65,8 @@ impl HwAccel for Vulkan {
         }
     }
 
-    fn decoder_arg(&self) -> Vec<String> {
-        vec![
-            String::from("-hwaccel"),
-            String::from("vulkan"),
-            String::from("-hwaccel_output_format"),
-            String::from("vulkan"),
-        ]
+    fn decoder_arg(&self) -> ArgVec {
+        args!["-hwaccel", "vulkan", "-hwaccel_output_format", "vulkan",]
     }
 
     fn decoder_frame_surface(&self) -> FrameSurface {
@@ -91,8 +87,8 @@ impl HwAccel for Vulkan {
         self.clone()
     }
 
-    fn init_hw_device(&self) -> Vec<String> {
-        vec![String::from("-init_hw_device"), String::from("vulkan")]
+    fn init_hw_device(&self) -> ArgVec {
+        args!["-init_hw_device", "vulkan"]
     }
 
     fn known_accel(&self) -> &KnownHardwareAccel {

--- a/crates/ffpipeline/src/audio_codec.rs
+++ b/crates/ffpipeline/src/audio_codec.rs
@@ -1,3 +1,5 @@
+use crate::ArgVec;
+
 #[derive(Copy, Clone, PartialEq)]
 pub enum AudioCodec {
     Copy,
@@ -6,13 +8,13 @@ pub enum AudioCodec {
 }
 
 impl AudioCodec {
-    pub(crate) fn as_arg(&self) -> Vec<String> {
+    pub(crate) fn as_arg(&self) -> ArgVec {
         let codec = match self {
-            AudioCodec::Copy => String::from("copy"),
-            AudioCodec::Aac => String::from("aac"),
-            AudioCodec::Ac3 => String::from("ac3"),
+            AudioCodec::Copy => "copy",
+            AudioCodec::Aac => "aac",
+            AudioCodec::Ac3 => "ac3",
         };
 
-        vec![String::from("-acodec"), codec]
+        args!["-acodec", codec]
     }
 }

--- a/crates/ffpipeline/src/audio_decoder.rs
+++ b/crates/ffpipeline/src/audio_decoder.rs
@@ -1,3 +1,4 @@
+use crate::ArgVec;
 use crate::output_settings::OutputSettings;
 use crate::probe::ProbeResultAudioStream;
 
@@ -19,14 +20,9 @@ impl AudioDecoder {
         }
     }
 
-    pub(crate) fn as_arg(&self) -> Vec<String> {
+    pub(crate) fn as_arg(&self) -> ArgVec {
         if self.input_codec == "ac3" && self.input_channels > 2 && self.output_channels == Some(2) {
-            return vec![
-                String::from("-acodec"),
-                String::from("ac3"),
-                String::from("-downmix"),
-                String::from("stereo"),
-            ];
+            return args!["-acodec", "ac3", "-downmix", "stereo"];
         }
 
         Vec::new()

--- a/crates/ffpipeline/src/filter_chain.rs
+++ b/crates/ffpipeline/src/filter_chain.rs
@@ -1,3 +1,4 @@
+use crate::ArgVec;
 use crate::audio_filter::AudioFilter;
 use crate::ffmpeg_info::FfmpegInfo;
 use crate::hw_accel::{HardwareAccel, HwAccel};
@@ -299,14 +300,11 @@ impl FilterChain {
         &self.video_label
     }
 
-    pub(crate) fn as_arg(&self) -> Vec<String> {
+    pub(crate) fn as_arg(&self) -> ArgVec {
         if self.complex_filter.is_empty() {
             Vec::new()
         } else {
-            vec![
-                String::from("-filter_complex"),
-                self.complex_filter.to_owned(),
-            ]
+            args!["-filter_complex", self.complex_filter.to_owned(),]
         }
     }
 }

--- a/crates/ffpipeline/src/global_option.rs
+++ b/crates/ffpipeline/src/global_option.rs
@@ -1,3 +1,5 @@
+use std::borrow::Cow;
+
 use crate::hw_accel::{HardwareAccel, HwAccel};
 
 pub enum LogLevel {
@@ -5,9 +7,9 @@ pub enum LogLevel {
 }
 
 impl LogLevel {
-    fn as_arg(&self) -> Vec<String> {
+    fn as_arg(&self) -> Vec<Cow<'static, str>> {
         match self {
-            LogLevel::Error => vec![String::from("-loglevel"), String::from("error")],
+            LogLevel::Error => args!["-loglevel", "error"],
         }
     }
 }
@@ -22,16 +24,13 @@ pub enum GlobalOption {
 }
 
 impl GlobalOption {
-    pub(crate) fn as_arg(&self) -> Vec<String> {
+    pub(crate) fn as_arg(&self) -> Vec<Cow<'static, str>> {
         match self {
-            GlobalOption::Threads(count) => vec![String::from("-threads"), count.to_string()],
-            GlobalOption::NoStdIn => vec![String::from("-nostdin")],
-            GlobalOption::HideBanner => vec![String::from("-hide_banner")],
+            GlobalOption::Threads(count) => args!["-threads", count.to_string()],
+            GlobalOption::NoStdIn => args!["-nostdin"],
+            GlobalOption::HideBanner => args!["-hide_banner"],
             GlobalOption::LogLevel(level) => level.as_arg(),
-            GlobalOption::StandardFormatFlags => vec![
-                String::from("-fflags"),
-                String::from("+genpts+discardcorrupt+igndts"),
-            ],
+            GlobalOption::StandardFormatFlags => args!["-fflags", "+genpts+discardcorrupt+igndts",],
             GlobalOption::InitHwDevice(accel) => accel.init_hw_device(),
         }
     }

--- a/crates/ffpipeline/src/hw_accel.rs
+++ b/crates/ffpipeline/src/hw_accel.rs
@@ -1,11 +1,11 @@
 use enum_dispatch::enum_dispatch;
 
-use crate::accel;
 use crate::ffmpeg_info::{FfmpegInfo, KnownHardwareAccel};
 use crate::filter_chain::PipelineFilter;
 use crate::pipeline::{FrameState, FrameSurface, PixelFormat, VideoFormat};
 use crate::video_codec::VideoCodec;
 use crate::video_filter::VideoFilter;
+use crate::{ArgVec, accel};
 
 #[enum_dispatch]
 pub trait HwAccel {
@@ -32,7 +32,7 @@ pub trait HwAccel {
         }
     }
     fn codec_for_format(&self, format: &VideoFormat) -> Option<VideoCodec>;
-    fn decoder_arg(&self) -> Vec<String>;
+    fn decoder_arg(&self) -> ArgVec;
     fn decoder_filters(&self) -> Vec<PipelineFilter> {
         Vec::new()
     }
@@ -45,7 +45,7 @@ pub trait HwAccel {
         None
     }
     fn initialize(&self, ffmpeg_info: &FfmpegInfo, is_hdr: bool) -> Self;
-    fn init_hw_device(&self) -> Vec<String>;
+    fn init_hw_device(&self) -> ArgVec;
     fn known_accel(&self) -> &KnownHardwareAccel;
     fn output_format(&self, source_pixel_format: &PixelFormat) -> PixelFormat {
         match source_pixel_format.bit_depth() {

--- a/crates/ffpipeline/src/input.rs
+++ b/crates/ffpipeline/src/input.rs
@@ -3,6 +3,7 @@ use std::time::Duration;
 use enum_dispatch::enum_dispatch;
 use simple_expand_tilde::expand_tilde;
 
+use crate::ArgVec;
 use crate::probe::ProbeResult;
 
 pub struct InputSettings {
@@ -55,46 +56,46 @@ pub enum InputSource {
 
 #[enum_dispatch]
 pub trait FfmpegInputArgs {
-    fn args_for_input(&self) -> Vec<String>;
+    fn args_for_input(&self) -> ArgVec;
 }
 
 impl FfmpegInputArgs for LocalInputSource {
-    fn args_for_input(&self) -> Vec<String> {
-        [].to_vec()
+    fn args_for_input(&self) -> ArgVec {
+        vec![]
     }
 }
 
 impl FfmpegInputArgs for LavfiInputSource {
-    fn args_for_input(&self) -> Vec<String> {
-        vec!["-f".to_string(), "lavfi".to_string()]
+    fn args_for_input(&self) -> ArgVec {
+        args!["-f", "lavfi"]
     }
 }
 impl FfmpegInputArgs for HttpInputSource {
-    fn args_for_input(&self) -> Vec<String> {
-        let mut args = Vec::new();
+    fn args_for_input(&self) -> ArgVec {
+        let mut args: ArgVec = Vec::new();
 
         if self.options.reconnect {
-            args.extend([
-                String::from("-reconnect"),
-                String::from("1"),
-                String::from("-reconnect_on_network_error"),
-                String::from("1"),
-                String::from("-reconnect_streamed"),
-                String::from("1"),
-                String::from("-multiple_requests"),
-                String::from("1"),
+            args.extend(args![
+                "-reconnect",
+                "1",
+                "-reconnect_on_network_error",
+                "1",
+                "-reconnect_streamed",
+                "1",
+                "-multiple_requests",
+                "1",
             ]);
             if let Some(max_delay) = self.options.reconnect_delay_max {
-                args.extend([String::from("-reconnect_delay_max"), max_delay.to_string()]);
+                args.extend(args!["-reconnect_delay_max", max_delay.to_string()]);
             }
         }
 
         if let Some(timeout) = self.options.timeout_us {
-            args.extend([String::from("-timeout"), timeout.to_string()]);
+            args.extend(args!["-timeout", timeout.to_string()]);
         }
 
         if let Some(ua) = &self.options.user_agent {
-            args.extend([String::from("-user_agent"), ua.clone()]);
+            args.extend(args!["-user_agent", ua.clone()]);
         }
 
         if !self.options.headers.is_empty() {
@@ -105,12 +106,12 @@ impl FfmpegInputArgs for HttpInputSource {
                 .iter()
                 .map(|h| format!("{}\r\n", h))
                 .collect();
-            args.extend([String::from("-headers"), combined]);
+            args.extend(args!["-headers", combined]);
         }
 
-        args.extend([
-            String::from("-protocol_whitelist"),
-            String::from("file,http,https,tcp,tls,crypto"),
+        args.extend(args![
+            "-protocol_whitelist",
+            "file,http,https,tcp,tls,crypto",
         ]);
 
         args

--- a/crates/ffpipeline/src/lib.rs
+++ b/crates/ffpipeline/src/lib.rs
@@ -1,3 +1,9 @@
+use std::borrow::Cow;
+
+type ArgVec = Vec<Cow<'static, str>>;
+
+#[macro_use]
+mod macros;
 pub mod accel;
 pub mod audio_codec;
 pub mod audio_decoder;

--- a/crates/ffpipeline/src/macros.rs
+++ b/crates/ffpipeline/src/macros.rs
@@ -1,0 +1,7 @@
+/// Like vec! but automatically wraps string arguments in a Cow.
+/// Handles both borrowed and owned data appropriately.
+macro_rules! args {
+  ($($arg:expr),* $(,)?) => {
+      vec![$(std::borrow::Cow::<'static, str>::from($arg)),*]
+  };
+}

--- a/crates/ffpipeline/src/output_format.rs
+++ b/crates/ffpipeline/src/output_format.rs
@@ -1,5 +1,6 @@
 use std::time::Duration;
 
+use crate::ArgVec;
 use crate::pipeline::{KEYFRAME_INTERVAL_SECONDS, OutputContext, SEGMENT_SECONDS};
 use crate::video_codec::VideoCodec;
 
@@ -12,7 +13,7 @@ pub enum OutputFormat {
 }
 
 impl OutputFormat {
-    pub(crate) fn as_arg(&self, output_context: &OutputContext) -> Vec<String> {
+    pub(crate) fn as_arg(&self, output_context: &OutputContext) -> ArgVec {
         let force_key_frames_expr = format!("expr:gte(t,n_forced*{KEYFRAME_INTERVAL_SECONDS})");
         let segment_seconds = format!("{SEGMENT_SECONDS}");
         let rounded_frame_rate = output_context
@@ -24,34 +25,34 @@ impl OutputFormat {
         let gop = format!("{}", rounded_frame_rate * KEYFRAME_INTERVAL_SECONDS);
         let keyint_min = format!("{}", rounded_frame_rate * KEYFRAME_INTERVAL_SECONDS);
 
-        let mut args: Vec<&str> = Vec::new();
+        let mut args: ArgVec = Vec::new();
 
         match self {
             OutputFormat::Hls {
                 segment_template, ..
             } => {
                 if output_context.video_codec != VideoCodec::COPY {
-                    args.extend(vec![
+                    args.extend(args![
                         "-g",
-                        &gop,
+                        gop,
                         "-keyint_min",
-                        &keyint_min,
+                        keyint_min,
                         "-force_key_frames",
-                        &force_key_frames_expr,
+                        force_key_frames_expr,
                     ]);
                 }
 
-                args.extend(vec![
+                args.extend(args![
                     "-f",
                     "hls",
                     "-hls_time",
-                    &segment_seconds,
+                    segment_seconds,
                     "-hls_list_size",
                     "0",
                     "-segment_list_flags",
                     "+live",
                     "-hls_segment_filename",
-                    segment_template,
+                    segment_template.to_owned(),
                     "-hls_segment_type",
                     "mpegts",
                     "-hls_flags",
@@ -60,7 +61,7 @@ impl OutputFormat {
 
                 match output_context.pts_offset {
                     Some(pts_offset) if pts_offset.duration > Duration::ZERO => {}
-                    _ => args.extend(vec![
+                    _ => args.extend(args![
                         "-hls_segment_options",
                         "mpegts_flags=+initial_discontinuity",
                     ]),
@@ -68,7 +69,7 @@ impl OutputFormat {
             }
         }
 
-        args.into_iter().map(String::from).collect()
+        args
     }
 
     pub(crate) fn path(&self) -> String {

--- a/crates/ffpipeline/src/output_option.rs
+++ b/crates/ffpipeline/src/output_option.rs
@@ -1,5 +1,6 @@
 use std::time::Duration;
 
+use crate::ArgVec;
 use crate::audio_codec::AudioCodec;
 use crate::frame_rate::FrameRate;
 use crate::output_format::OutputFormat;
@@ -26,73 +27,65 @@ pub enum OutputOption {
 }
 
 impl OutputOption {
-    pub(crate) fn as_arg(&self, output_context: &OutputContext) -> Vec<String> {
+    pub(crate) fn as_arg(&self, output_context: &OutputContext) -> ArgVec {
         match self {
             OutputOption::Format(format) => format.as_arg(output_context),
             OutputOption::VideoCodec(codec) => codec.as_arg(),
             OutputOption::VideoBitrate(Some(bitrate_kbps)) => {
-                vec![
-                    String::from("-b:v"),
+                args![
+                    "-b:v",
                     format!("{}k", bitrate_kbps.0),
-                    String::from("-maxrate:v"),
+                    "-maxrate:v",
                     format!("{}k", bitrate_kbps.0),
                 ]
             }
             OutputOption::VideoBitrate(None) => Vec::new(),
             OutputOption::VideoBuffer(Some(buffer_kbps)) => {
-                vec![String::from("-bufsize:v"), format!("{}k", buffer_kbps.0)]
+                args!["-bufsize:v", format!("{}k", buffer_kbps.0)]
             }
             OutputOption::VideoBuffer(None) => Vec::new(),
             OutputOption::AudioCodec(codec) => codec.as_arg(),
             OutputOption::AudioBitrate(Some(bitrate_kbps)) => {
-                vec![
-                    String::from("-b:a"),
+                args![
+                    "-b:a",
                     format!("{}k", bitrate_kbps.0),
-                    String::from("-maxrate:a"),
+                    "-maxrate:a",
                     format!("{}k", bitrate_kbps.0),
                 ]
             }
             OutputOption::AudioBitrate(None) => Vec::new(),
             OutputOption::AudioBuffer(Some(buffer_kbps)) => {
-                vec![String::from("-bufsize:a"), format!("{}k", buffer_kbps.0)]
+                args!["-bufsize:a", format!("{}k", buffer_kbps.0)]
             }
             OutputOption::AudioBuffer(None) => Vec::new(),
             OutputOption::AudioChannels(Some(channels)) => {
-                vec![String::from("-ac"), format!("{}", channels)]
+                args!["-ac", format!("{}", channels)]
             }
             OutputOption::AudioChannels(None) => Vec::new(),
             OutputOption::AudioSampleRate(Some(sample_rate)) => {
-                vec![String::from("-ar"), format!("{}", sample_rate.0)]
+                args!["-ar", format!("{}", sample_rate.0)]
             }
             OutputOption::AudioSampleRate(None) => Vec::new(),
             OutputOption::Duration(duration) => {
-                vec![String::from("-t"), format!("{}ms", duration.as_millis())]
+                args!["-t", format!("{}ms", duration.as_millis())]
             }
             OutputOption::TsOffset(Some(pts_offset)) if pts_offset.duration > Duration::ZERO => {
-                vec![
-                    String::from("-output_ts_offset"),
+                args![
+                    "-output_ts_offset",
                     format!("{}ms", pts_offset.duration.as_millis()),
                 ]
             }
             OutputOption::TsOffset(_) => Vec::new(),
-            OutputOption::CudaNoAutoScale => vec![String::from("-noautoscale")],
-            OutputOption::NoDemuxDecodeDelay => vec!["-muxdelay", "0", "-muxpreload", "0"]
-                .into_iter()
-                .map(String::from)
-                .collect(),
+            OutputOption::CudaNoAutoScale => args!["-noautoscale"],
+            OutputOption::NoDemuxDecodeDelay => args!["-muxdelay", "0", "-muxpreload", "0"],
             OutputOption::MovFlagsFastStart => {
-                vec![String::from("-movflags"), String::from("+faststart")]
+                args!["-movflags", "+faststart"]
             }
             OutputOption::DoNotMapMetadata => {
-                vec![String::from("-map_metadata"), String::from("-1")]
+                args!["-map_metadata", "-1"]
             }
             OutputOption::FrameRate(Some(frame_rate)) => {
-                vec![
-                    String::from("-r"),
-                    frame_rate.r_frame_rate.to_owned(),
-                    String::from("-vsync"),
-                    String::from("cfr"),
-                ]
+                args!["-r", frame_rate.r_frame_rate.to_owned(), "-vsync", "cfr",]
             }
             OutputOption::FrameRate(_) => Vec::new(),
         }

--- a/crates/ffpipeline/src/pipeline.rs
+++ b/crates/ffpipeline/src/pipeline.rs
@@ -1,6 +1,7 @@
 use std::fmt::Formatter;
 use std::time::Duration;
 
+use crate::ArgVec;
 use crate::audio_codec::AudioCodec;
 use crate::audio_decoder::AudioDecoder;
 use crate::audio_filter::AudioFilter;
@@ -402,8 +403,8 @@ impl Pipeline {
         }
     }
 
-    pub fn args(&self) -> Vec<String> {
-        let mut result: Vec<String> = Vec::new();
+    pub fn args(&self) -> ArgVec {
+        let mut result: ArgVec = Vec::new();
 
         let mut audio_label = String::from("0:a");
         let mut video_label = String::from("0:v");
@@ -439,7 +440,7 @@ impl Pipeline {
                     // if more than one path, audio is probably separate from video
                     if distinct_paths.len() > 1 {
                         result.extend(input_source.args_for_input());
-                        result.extend([String::from("-i"), path.to_owned()]);
+                        result.extend(args!["-i", path.to_owned()]);
                     }
                 }
                 PipelineInput::Video {
@@ -458,16 +459,16 @@ impl Pipeline {
                     video_label = format!("{}:{}", video_input_index, index);
 
                     if !seek.is_zero() {
-                        result.extend([String::from("-ss"), format!("{}ms", seek.as_millis())]);
+                        result.extend(args!["-ss", format!("{}ms", seek.as_millis())]);
                     }
 
                     if *realtime {
-                        result.extend([String::from("-readrate"), String::from("1.0")]);
+                        result.extend(args!["-readrate", "1.0"]);
                     }
 
                     result.extend(input_source.args_for_input());
 
-                    result.extend([String::from("-i"), path.to_owned()]);
+                    result.extend(args!["-i", path.to_owned()]);
                 }
             }
         }
@@ -477,8 +478,8 @@ impl Pipeline {
 
         result.extend(filter_chain.as_arg());
 
-        result.extend([String::from("-map"), filter_chain.video_label().to_owned()]);
-        result.extend([String::from("-map"), filter_chain.audio_label().to_owned()]);
+        result.extend(args!["-map", filter_chain.video_label().to_owned()]);
+        result.extend(args!["-map", filter_chain.audio_label().to_owned()]);
 
         result.extend(
             self.output_options
@@ -486,7 +487,7 @@ impl Pipeline {
                 .flat_map(|o| o.as_arg(&self.output_context)),
         );
 
-        result.extend([self.output.path.to_owned()]);
+        result.extend(args![self.output.path.to_owned()]);
 
         result
     }

--- a/crates/ffpipeline/src/probe.rs
+++ b/crates/ffpipeline/src/probe.rs
@@ -1,4 +1,4 @@
-use std::ffi::OsStr;
+use std::borrow::Cow;
 use std::fmt::Formatter;
 use std::path::Path;
 use std::time::Duration;
@@ -7,6 +7,7 @@ use enum_dispatch::enum_dispatch;
 use serde::Deserialize;
 use tokio::process::Command;
 
+use crate::ArgVec;
 use crate::error::FFPipelineError;
 use crate::error::FFPipelineError::ProbeFailed;
 use crate::frame_rate::FrameRate;
@@ -157,17 +158,17 @@ pub trait Probeable {
 
 impl Probeable for LocalInputSource {
     async fn probe(&self, probe_deps: &ProbeDeps<'_>) -> Result<ProbeResult, FFPipelineError> {
-        let mut args: Vec<String> = vec![
-            "-hide_banner".to_string(),
-            "-print_format".to_string(),
-            "json".to_string(),
-            "-show_format".to_string(),
-            "-show_streams".to_string(),
-            "-show_chapters".to_string(),
+        let mut args = args![
+            "-hide_banner",
+            "-print_format",
+            "json",
+            "-show_format",
+            "-show_streams",
+            "-show_chapters",
         ];
         args.extend(self.args_for_input());
         let expanded_path = self.expand_path().ok_or(ProbeFailed)?;
-        args.extend(["-i".to_string(), expanded_path.clone()]);
+        args.extend(args!["-i", expanded_path.clone()]);
 
         probe_with_args(probe_deps.ffprobe_path, &expanded_path, &args).await
     }
@@ -229,32 +230,28 @@ impl Probeable for LavfiInputSource {
 
 impl Probeable for HttpInputSource {
     async fn probe(&self, probe_deps: &ProbeDeps<'_>) -> Result<ProbeResult, FFPipelineError> {
-        let mut args: Vec<String> = vec![
-            "-hide_banner".to_string(),
-            "-print_format".to_string(),
-            "json".to_string(),
-            "-show_format".to_string(),
-            "-show_streams".to_string(),
-            "-show_chapters".to_string(),
+        let mut args: ArgVec = args![
+            "-hide_banner",
+            "-print_format",
+            "json",
+            "-show_format",
+            "-show_streams",
+            "-show_chapters",
         ];
         args.extend(self.args_for_input());
-        args.extend(["-i".to_string(), self.uri.clone()]);
+        args.extend(args!["-i", self.uri.clone()]);
 
         probe_with_args(probe_deps.ffprobe_path, &self.uri, &args).await
     }
 }
 
-async fn probe_with_args<I, S>(
+async fn probe_with_args(
     ffprobe_path: &Path,
     path: &str,
-    args: I,
-) -> Result<ProbeResult, FFPipelineError>
-where
-    I: IntoIterator<Item = S>,
-    S: AsRef<OsStr>,
-{
+    args: &ArgVec,
+) -> Result<ProbeResult, FFPipelineError> {
     let output = Command::new(ffprobe_path)
-        .args(args)
+        .args(args.iter().map(Cow::as_ref))
         .output()
         .await
         .map_err(|_| FFPipelineError::ProbeFailed)?;

--- a/crates/ffpipeline/src/video_codec.rs
+++ b/crates/ffpipeline/src/video_codec.rs
@@ -1,3 +1,6 @@
+use std::borrow::Cow;
+
+use crate::ArgVec;
 use crate::pipeline::PixelFormat;
 
 #[derive(Clone, PartialEq)]
@@ -34,11 +37,9 @@ impl VideoCodec {
         is_hardware: false,
     };
 
-    pub(crate) fn as_arg(&self) -> Vec<String> {
-        [&["-vcodec", self.codec_name], self.options]
-            .concat()
-            .into_iter()
-            .map(String::from)
-            .collect()
+    pub(crate) fn as_arg(&self) -> ArgVec {
+        let mut args = args!["-vcodec", self.codec_name];
+        args.extend(self.options.iter().copied().map(Cow::Borrowed));
+        args
     }
 }

--- a/crates/ffpipeline/src/video_decoder.rs
+++ b/crates/ffpipeline/src/video_decoder.rs
@@ -1,3 +1,4 @@
+use crate::ArgVec;
 use crate::filter_chain::PipelineFilter;
 use crate::hw_accel::{HardwareAccel, HwAccel};
 use crate::output_settings::OutputSettings;
@@ -63,7 +64,7 @@ impl VideoDecoder {
         }
     }
 
-    pub(crate) fn as_arg(&self) -> Vec<String> {
+    pub(crate) fn as_arg(&self) -> ArgVec {
         match self {
             VideoDecoder::None => Vec::new(),
             VideoDecoder::Software => Vec::new(),


### PR DESCRIPTION
Depends on https://github.com/ErsatzTV/next/pull/25

Most ffmpeg args are static strings built into the binary. Rather than constantly cloning these onto the heap, we can utilize Cow to represent data that is optionally owned. Most strings we deal with in these arg lists are borrowed; some are owned (dynamically allocated on the heap from user input). Cow helps us represent this.

Includes a simple macro for building lists of args and a type alias for Vec<Cow<'static, str>> called ArgVec.