### PR TITLE
fix: use correct resolution for fake playout item

### DIFF
--- a/crates/ersatztv-channel/src/channel_session.rs
+++ b/crates/ersatztv-channel/src/channel_session.rs
@@ -699,7 +699,7 @@ impl ChannelSession {
                             self.channel_config
                                 .normalization
                                 .video
-                                .height
+                                .width
                                 .unwrap_or(1920),
                             self.channel_config
                                 .normalization


### PR DESCRIPTION
Fixes copy paste error in fake playout item resolution.

The easiest way to test is by using a virtual start date where no playout JSON exists.