### PR TITLE
feat: add software deinterlace

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -617,6 +617,7 @@ dependencies = [
  "serde",
  "serde_json",
  "simple-expand-tilde",
+ "strum",
  "thiserror",
  "tokio",
 ]
@@ -2082,6 +2083,27 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "strum"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab85eea0270ee17587ed4156089e10b9e6880ee688791d45a905f5b1ca36f664"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "subtle"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 simple-expand-tilde = "0.5.3"
 sqlx = { version = "0.8", features = ["runtime-tokio", "sqlite", "macros", "time"] }
+strum = { version = "0.28", features = ["derive"] }
 tempfile = "3"
 thiserror = "2.0"
 time = { version = "0.3", features = ["formatting", "local-offset", "macros", "parsing", "serde"] }

--- a/crates/ersatztv-channel/src/channel_session.rs
+++ b/crates/ersatztv-channel/src/channel_session.rs
@@ -161,6 +161,7 @@ impl ChannelSession {
         self.ffmpeg_info = FfmpegInfo::load(
             &self.ffmpeg_path,
             &self.channel_config.ffmpeg.disabled_filters,
+            &self.channel_config.ffmpeg.preferred_filters,
         )
         .await?;
 
@@ -427,6 +428,7 @@ impl ChannelSession {
             video_buffer: video_norm.buffer_kbps.map(Kbps),
             video_size,
             tonemap_algorithm: video_norm.tonemap_algorithm.clone(),
+            deinterlace: video_norm.deinterlace,
             accel: self.hw_accel.clone(),
             format: ffpipeline::output_format::OutputFormat::Hls {
                 playlist: self.output_file.clone(),

--- a/crates/ersatztv-channel/src/config.rs
+++ b/crates/ersatztv-channel/src/config.rs
@@ -41,6 +41,8 @@ pub struct FfmpegConfig {
     pub ffprobe_path: Option<PathBuf>,
     #[serde(default)]
     pub disabled_filters: Vec<String>,
+    #[serde(default)]
+    pub preferred_filters: Vec<String>,
 }
 
 #[derive(Deserialize, Clone, Debug, JsonSchema)]
@@ -111,6 +113,8 @@ pub struct VideoNormalizationConfig {
     pub vaapi_device: Option<PathBuf>,
     pub vaapi_driver: Option<VaapiDriver>,
     pub tonemap_algorithm: Option<String>,
+    #[serde(default)]
+    pub deinterlace: bool,
 }
 
 #[derive(Deserialize, Clone, Debug, JsonSchema)]

--- a/crates/ersatztv-channel/src/main.rs
+++ b/crates/ersatztv-channel/src/main.rs
@@ -77,8 +77,12 @@ async fn run() -> Result<(), ChannelError> {
                 .ffmpeg_path
                 .as_deref()
                 .unwrap_or(Path::new("ffmpeg"));
-            let ffmpeg_info =
-                FfmpegInfo::load(ffmpeg_path, &channel_config.ffmpeg.disabled_filters).await?;
+            let ffmpeg_info = FfmpegInfo::load(
+                ffmpeg_path,
+                &channel_config.ffmpeg.disabled_filters,
+                &channel_config.ffmpeg.preferred_filters,
+            )
+            .await?;
 
             log::debug!("{:?}", ffmpeg_info);
 

--- a/crates/ersatztv-playout-generator/src/generate.rs
+++ b/crates/ersatztv-playout-generator/src/generate.rs
@@ -70,6 +70,11 @@ pub async fn generate_playout(
         let is_image = probe_result.streams.len() == 1
             && matches!(probe_result.streams.first(), Some(ProbeResultStream::Video(video_stream)) if IMAGE_EXTENSIONS.contains(&video_stream.codec.as_str()));
 
+        let has_audio = probe_result
+            .streams
+            .iter()
+            .any(|s| matches!(s, ProbeResultStream::Audio(_)));
+
         // use 10-sec duration for images
         let image_duration = std::time::Duration::from_secs(10);
         let duration = match probe_result.duration {
@@ -93,13 +98,31 @@ pub async fn generate_playout(
                 path,
             )
         {
+            // use lavfi audio for video-only content
+            if !has_audio {
+                playout_item.tracks = Some(PlayoutItemTracks {
+                    audio: Some(TrackSelection::Source {
+                        source: PlayoutItemSource::Lavfi {
+                            params: String::from(
+                                "anullsrc=channel_layout=stereo:sample_rate=48000",
+                            ),
+                        },
+                    }),
+                    video: playout_item
+                        .source
+                        .as_ref()
+                        .map(|s| TrackSelection::Source { source: s.clone() }),
+                });
+
+                playout_item.source = None;
+            }
             // use separate tracks with lavfi audio for images
-            if is_image {
+            else if is_image {
                 playout_item.tracks = Some(PlayoutItemTracks {
                     audio: Some(TrackSelection::Source {
                         source: PlayoutItemSource::Lavfi {
                             params: format!(
-                                "sine=frequency=1000:sample_rate=48000:d={}",
+                                "anullsrc=channel_layout=stereo:sample_rate=48000:d={}",
                                 image_duration.as_secs()
                             ),
                         },

--- a/crates/ffpipeline/Cargo.toml
+++ b/crates/ffpipeline/Cargo.toml
@@ -13,6 +13,7 @@ libvt-sys = { workspace = true }
 log = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+simple-expand-tilde = { workspace = true }
+strum = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }
-simple-expand-tilde = { workspace = true }

--- a/crates/ffpipeline/src/ffmpeg_info.rs
+++ b/crates/ffpipeline/src/ffmpeg_info.rs
@@ -1,29 +1,27 @@
+use std::collections::HashSet;
 use std::path::Path;
 
+use strum::{Display, EnumIter, IntoEnumIterator};
 use tokio::process::Command;
 
 use crate::error::FFPipelineError;
 
-static KNOWN_ACCELS: &[&str] = &["cuda", "qsv", "vaapi", "videotoolbox", "vulkan"];
-static KNOWN_FILTERS: &[&str] = &[
-    "libplacebo",
-    "pad_cuda",
-    "pad_vaapi",
-    "scale_cuda",
-    "scale_vaapi",
-    "scale_vulkan",
-    "vpp_qsv",
-];
-
+#[derive(Display, EnumIter, PartialEq)]
+#[strum(serialize_all = "snake_case")]
 pub enum KnownHardwareAccel {
     Cuda,
     Qsv,
     Vaapi,
+    #[strum(serialize = "videotoolbox")]
     VideoToolbox,
     Vulkan,
 }
 
+#[derive(Display, EnumIter, PartialEq)]
+#[strum(serialize_all = "snake_case")]
 pub enum KnownVideoFilter {
+    Bwdif,
+    #[strum(serialize = "libplacebo")]
     LibPlacebo,
     PadCuda,
     PadVaapi,
@@ -31,51 +29,51 @@ pub enum KnownVideoFilter {
     ScaleVaapi,
     ScaleVulkan,
     VppQsv,
+    W3fdif,
+    Yadif,
 }
 
 #[derive(Debug, Clone, Default)]
 pub struct FfmpegInfo {
     hwaccels: Vec<String>,
-    video_filters: Vec<String>,
+    video_filters: HashSet<String>,
+    preferred_filters: Vec<String>,
 }
 
 impl FfmpegInfo {
     pub async fn load(
         path: &Path,
         disabled_filters: &[String],
+        preferred_filters: &[String],
     ) -> Result<FfmpegInfo, FFPipelineError> {
         let hwaccels = Self::load_hw_accels(path).await?;
         let video_filters = Self::load_video_filters(path, disabled_filters).await?;
+
+        // filter preferred by video_filters
+        let mut preferred: Vec<String> = Vec::new();
+        for filter in preferred_filters {
+            if video_filters.contains(filter) {
+                preferred.push(filter.clone());
+            }
+        }
+
         Ok(FfmpegInfo {
             hwaccels,
             video_filters,
+            preferred_filters: preferred,
         })
     }
 
     pub fn has_hw_accel(&self, hw_accel: &KnownHardwareAccel) -> bool {
-        let accel_string = match hw_accel {
-            KnownHardwareAccel::Cuda => "cuda",
-            KnownHardwareAccel::Qsv => "qsv",
-            KnownHardwareAccel::Vaapi => "vaapi",
-            KnownHardwareAccel::VideoToolbox => "videotoolbox",
-            KnownHardwareAccel::Vulkan => "vulkan",
-        };
-
-        self.hwaccels.iter().any(|f| f == accel_string)
+        self.hwaccels.contains(&hw_accel.to_string())
     }
 
     pub fn has_video_filter(&self, filter: &KnownVideoFilter) -> bool {
-        let filter_string = match filter {
-            KnownVideoFilter::LibPlacebo => "libplacebo",
-            KnownVideoFilter::PadCuda => "pad_cuda",
-            KnownVideoFilter::PadVaapi => "pad_vaapi",
-            KnownVideoFilter::ScaleCuda => "scale_cuda",
-            KnownVideoFilter::ScaleVaapi => "scale_vaapi",
-            KnownVideoFilter::ScaleVulkan => "scale_vulkan",
-            KnownVideoFilter::VppQsv => "vpp_qsv",
-        };
+        self.video_filters.contains(&filter.to_string())
+    }
 
-        self.video_filters.iter().any(|f| f == filter_string)
+    pub fn is_preferred_filter(&self, filter: &KnownVideoFilter) -> bool {
+        self.preferred_filters.contains(&filter.to_string())
     }
 
     async fn load_hw_accels(path: &Path) -> Result<Vec<String>, FFPipelineError> {
@@ -87,6 +85,9 @@ impl FfmpegInfo {
 
         let stdout = String::from_utf8_lossy(&output.stdout);
 
+        let known_accels: HashSet<String> =
+            KnownHardwareAccel::iter().map(|f| f.to_string()).collect();
+
         let mut accels: Vec<String> = Vec::new();
 
         for line in stdout.lines() {
@@ -96,7 +97,7 @@ impl FfmpegInfo {
                 continue;
             }
 
-            if KNOWN_ACCELS.contains(&trimmed) {
+            if known_accels.contains(trimmed) {
                 accels.push(trimmed.to_owned());
             }
         }
@@ -107,7 +108,7 @@ impl FfmpegInfo {
     async fn load_video_filters(
         path: &Path,
         disabled_filters: &[String],
-    ) -> Result<Vec<String>, FFPipelineError> {
+    ) -> Result<HashSet<String>, FFPipelineError> {
         let output = Command::new(path)
             .args(["-hide_banner", "-filters"])
             .output()
@@ -116,15 +117,18 @@ impl FfmpegInfo {
 
         let stdout = String::from_utf8_lossy(&output.stdout);
 
-        let mut filters: Vec<String> = Vec::new();
+        let known_filters: HashSet<String> =
+            KnownVideoFilter::iter().map(|f| f.to_string()).collect();
+
+        let mut filters: HashSet<String> = HashSet::new();
 
         for line in stdout.lines() {
             //  .. scale_cuda        V->V       GPU accelerated video resizer
             if let Some(filter) = line.split_whitespace().nth(1)
-                && KNOWN_FILTERS.contains(&filter)
+                && known_filters.contains(filter)
                 && !disabled_filters.iter().any(|f| f == filter)
             {
-                filters.push(filter.to_owned());
+                filters.insert(filter.to_owned());
             }
         }
 

--- a/crates/ffpipeline/src/ffmpeg_info.rs
+++ b/crates/ffpipeline/src/ffmpeg_info.rs
@@ -37,7 +37,7 @@ pub enum KnownVideoFilter {
 pub struct FfmpegInfo {
     hwaccels: Vec<String>,
     video_filters: HashSet<String>,
-    preferred_filters: Vec<String>,
+    pub(crate) preferred_filters: Vec<String>,
 }
 
 impl FfmpegInfo {
@@ -70,10 +70,6 @@ impl FfmpegInfo {
 
     pub fn has_video_filter(&self, filter: &KnownVideoFilter) -> bool {
         self.video_filters.contains(&filter.to_string())
-    }
-
-    pub fn is_preferred_filter(&self, filter: &KnownVideoFilter) -> bool {
-        self.preferred_filters.contains(&filter.to_string())
     }
 
     async fn load_hw_accels(path: &Path) -> Result<Vec<String>, FFPipelineError> {

--- a/crates/ffpipeline/src/ffmpeg_info.rs
+++ b/crates/ffpipeline/src/ffmpeg_info.rs
@@ -1,42 +1,70 @@
-use std::collections::HashSet;
+use std::borrow::Cow;
 use std::path::Path;
+use std::sync::LazyLock;
 
-use strum::{Display, EnumIter, IntoEnumIterator};
+use strum::{Display, EnumIter, IntoEnumIterator, IntoStaticStr};
 use tokio::process::Command;
 
 use crate::error::FFPipelineError;
 
-#[derive(Display, EnumIter, PartialEq)]
-#[strum(serialize_all = "snake_case")]
+static KNOWN_ACCELS: LazyLock<Vec<&'static str>> =
+    LazyLock::new(|| KnownHardwareAccel::iter().map(|x| x.into()).collect());
+
+static KNOWN_FILTERS: LazyLock<Vec<&'static str>> = LazyLock::new(|| {
+    KnownVideoFilter::iter()
+        .map(|x| x.into())
+        .collect::<Vec<&str>>()
+});
+
+#[derive(Display, EnumIter, IntoStaticStr, Debug, PartialEq)]
 pub enum KnownHardwareAccel {
+    #[strum(serialize = "cuda")]
     Cuda,
+    #[strum(serialize = "qsv")]
     Qsv,
+    #[strum(serialize = "vaapi")]
     Vaapi,
     #[strum(serialize = "videotoolbox")]
     VideoToolbox,
+    #[strum(serialize = "vulkan")]
     Vulkan,
 }
 
-#[derive(Display, EnumIter, PartialEq)]
-#[strum(serialize_all = "snake_case")]
+/// Convert a KnownHardwareAccel to a Cow-wrapped &'static str.
+impl From<KnownHardwareAccel> for Cow<'static, str> {
+    fn from(value: KnownHardwareAccel) -> Self {
+        Cow::<'static, str>::from(<KnownHardwareAccel as Into<&'static str>>::into(value))
+    }
+}
+
+#[derive(Display, EnumIter, IntoStaticStr, Debug, PartialEq)]
 pub enum KnownVideoFilter {
+    #[strum(serialize = "bwdif")]
     Bwdif,
     #[strum(serialize = "libplacebo")]
     LibPlacebo,
+    #[strum(serialize = "pad_cuda")]
     PadCuda,
+    #[strum(serialize = "pad_vaapi")]
     PadVaapi,
+    #[strum(serialize = "scale_cuda")]
     ScaleCuda,
+    #[strum(serialize = "scale_vaapi")]
     ScaleVaapi,
+    #[strum(serialize = "scale_vulkan")]
     ScaleVulkan,
+    #[strum(serialize = "vpp_qsv")]
     VppQsv,
+    #[strum(serialize = "w3fdif")]
     W3fdif,
+    #[strum(serialize = "yadif")]
     Yadif,
 }
 
 #[derive(Debug, Clone, Default)]
 pub struct FfmpegInfo {
     hwaccels: Vec<String>,
-    video_filters: HashSet<String>,
+    video_filters: Vec<String>,
     pub(crate) preferred_filters: Vec<String>,
 }
 
@@ -49,7 +77,7 @@ impl FfmpegInfo {
         let hwaccels = Self::load_hw_accels(path).await?;
         let video_filters = Self::load_video_filters(path, disabled_filters).await?;
 
-        // filter preferred by video_filters
+        // filter preferred by known video filters
         let mut preferred: Vec<String> = Vec::new();
         for filter in preferred_filters {
             if video_filters.contains(filter) {
@@ -81,9 +109,6 @@ impl FfmpegInfo {
 
         let stdout = String::from_utf8_lossy(&output.stdout);
 
-        let known_accels: HashSet<String> =
-            KnownHardwareAccel::iter().map(|f| f.to_string()).collect();
-
         let mut accels: Vec<String> = Vec::new();
 
         for line in stdout.lines() {
@@ -93,7 +118,7 @@ impl FfmpegInfo {
                 continue;
             }
 
-            if known_accels.contains(trimmed) {
+            if KNOWN_ACCELS.contains(&trimmed) {
                 accels.push(trimmed.to_owned());
             }
         }
@@ -104,7 +129,7 @@ impl FfmpegInfo {
     async fn load_video_filters(
         path: &Path,
         disabled_filters: &[String],
-    ) -> Result<HashSet<String>, FFPipelineError> {
+    ) -> Result<Vec<String>, FFPipelineError> {
         let output = Command::new(path)
             .args(["-hide_banner", "-filters"])
             .output()
@@ -113,18 +138,15 @@ impl FfmpegInfo {
 
         let stdout = String::from_utf8_lossy(&output.stdout);
 
-        let known_filters: HashSet<String> =
-            KnownVideoFilter::iter().map(|f| f.to_string()).collect();
-
-        let mut filters: HashSet<String> = HashSet::new();
+        let mut filters: Vec<String> = Vec::new();
 
         for line in stdout.lines() {
             //  .. scale_cuda        V->V       GPU accelerated video resizer
             if let Some(filter) = line.split_whitespace().nth(1)
-                && known_filters.contains(filter)
+                && KNOWN_FILTERS.contains(&filter)
                 && !disabled_filters.iter().any(|f| f == filter)
             {
-                filters.insert(filter.to_owned());
+                filters.push(filter.to_owned());
             }
         }
 

--- a/crates/ffpipeline/src/filter_chain.rs
+++ b/crates/ffpipeline/src/filter_chain.rs
@@ -43,7 +43,7 @@ impl FilterChain {
 
     /// Optimizes the filter chain by passing the frame state through each filter.
     /// Filters will be dropped when the input state already matches the desired output state.
-    pub(crate) fn evaluate(&mut self, initial_state: &FrameState) {
+    pub(crate) fn evaluate(&mut self, initial_state: &FrameState, ffmpeg_info: &FfmpegInfo) {
         let mut state = initial_state.to_owned();
         let mut active_filters = Vec::new();
 
@@ -56,7 +56,7 @@ impl FilterChain {
                     }
                 }
                 PipelineFilter::Video(vf) => {
-                    if let Some(new_filter) = vf.evaluate(&state) {
+                    if let Some(new_filter) = vf.evaluate(&state, ffmpeg_info) {
                         new_filter.apply_to(&mut state);
                         active_filters.push(PipelineFilter::Video(new_filter));
                     }
@@ -109,7 +109,7 @@ impl FilterChain {
                             if is_format_supported {
                                 let upload = VideoFilter::HwUpload {
                                     target_surface: required.clone(),
-                                    bit_depth: current_state.pixel_format.bit_depth(),
+                                    source_format: current_state.pixel_format.clone(),
                                 };
                                 upload.apply_to(&mut current_state);
                                 resolved.push(PipelineFilter::Video(upload))
@@ -128,7 +128,7 @@ impl FilterChain {
 
                                     let upload = VideoFilter::HwUpload {
                                         target_surface: required,
-                                        bit_depth: current_state.pixel_format.bit_depth(),
+                                        source_format: current_state.pixel_format.clone(),
                                     };
                                     upload.apply_to(&mut current_state);
                                     resolved.push(PipelineFilter::Video(upload));
@@ -172,7 +172,7 @@ impl FilterChain {
             } else {
                 let upload = VideoFilter::HwUpload {
                     target_surface: encoder_surface.clone(),
-                    bit_depth: current_state.pixel_format.bit_depth(),
+                    source_format: current_state.pixel_format.clone(),
                 };
                 upload.apply_to(&mut current_state);
                 resolved.push(PipelineFilter::Video(upload))

--- a/crates/ffpipeline/src/output_settings.rs
+++ b/crates/ffpipeline/src/output_settings.rs
@@ -13,6 +13,7 @@ pub struct OutputSettings {
     pub video_buffer: Option<Kbps>,
     pub video_size: Option<FrameSize>,
     pub tonemap_algorithm: Option<String>,
+    pub deinterlace: bool,
     pub accel: Option<HardwareAccel>,
     pub format: OutputFormat,
     pub pts_offset: Option<PtsOffset>,

--- a/crates/ffpipeline/src/pipeline.rs
+++ b/crates/ffpipeline/src/pipeline.rs
@@ -18,7 +18,7 @@ use crate::output_settings::OutputSettings;
 use crate::probe::{ProbeResultAudioStream, ProbeResultStream, ProbeResultVideoStream};
 use crate::video_codec::VideoCodec;
 use crate::video_decoder::VideoDecoder;
-use crate::video_filter::VideoFilter;
+use crate::video_filter::{SoftwareDeinterlaceFilter, VideoFilter};
 
 pub const KEYFRAME_INTERVAL_SECONDS: u32 = 2;
 pub const SEGMENT_SECONDS: u32 = 4;
@@ -117,6 +117,7 @@ impl PixelFormat {
 pub struct FrameState {
     pub(crate) size: FrameSize,
     pub(crate) is_anamorphic: bool,
+    pub(crate) is_interlaced: bool,
     pub(crate) sample_aspect_ratio: Option<String>,
     pub(crate) display_aspect_ratio: Option<String>,
     pub(crate) surface: FrameSurface,
@@ -224,7 +225,9 @@ impl Pipeline {
                 width: video_stream.width,
                 height: video_stream.height,
             },
-            is_anamorphic: Self::is_anamorphic(video_stream),
+            is_anamorphic: video_stream.is_anamorphic(),
+            // if user does not want to deinterlace, pretend content is not interlaced
+            is_interlaced: final_output_settings.deinterlace && video_stream.is_interlaced(),
             sample_aspect_ratio: video_stream.sample_aspect_ratio.to_owned(),
             display_aspect_ratio: video_stream.display_aspect_ratio.to_owned(),
             surface: video_decoder.output_surface(),
@@ -282,6 +285,10 @@ impl Pipeline {
                     Some(10) => PixelFormat::Yuv420p10le,
                     _ => PixelFormat::Yuv420p,
                 },
+            }),
+            PipelineFilter::Video(VideoFilter::Deinterlace {
+                filter: SoftwareDeinterlaceFilter::Yadif,
+                input_is_interlaced: initial_state.is_interlaced,
             }),
             PipelineFilter::Video(VideoFilter::Scale {
                 size: initial_scaled_size,
@@ -388,7 +395,8 @@ impl Pipeline {
             self.filter_chain.disable_video();
         }
 
-        self.filter_chain.evaluate(&self.initial_state);
+        self.filter_chain
+            .evaluate(&self.initial_state, &self.ffmpeg_info);
         self.filter_chain.resolve(
             &self.ffmpeg_info,
             &self.accel,
@@ -589,37 +597,6 @@ impl Pipeline {
                 all_audio_streams.sort_by_key(|a| std::cmp::Reverse(a.channels));
                 Ok(all_audio_streams[0])
             }
-        }
-    }
-
-    fn is_anamorphic(video_stream: &ProbeResultVideoStream) -> bool {
-        // TODO: need to calculate SAR when it's not provided; port MediaStream::SampleAspectRatio
-
-        match &video_stream.sample_aspect_ratio {
-            Some(sample_aspect_ratio) => {
-                let display_aspect_ratio = video_stream
-                    .display_aspect_ratio
-                    .as_ref()
-                    .map_or("", |dar| dar.as_ref());
-
-                // square pixels
-                if sample_aspect_ratio == "1:1" {
-                    false
-                }
-                // 0:1 is "unspecified", so anything other than that will be non-square/anamorphic
-                else if sample_aspect_ratio != "0:1" {
-                    true
-                }
-                // SAR 0:1 && DAR 0:1 (both unspecified) means square pixels
-                else if display_aspect_ratio == "0:1" {
-                    false
-                } else {
-                    // DAR == W:H is square
-                    display_aspect_ratio
-                        != format!("{}:{}", video_stream.width, video_stream.height)
-                }
-            }
-            None => false, // assumed SAR of 1:1
         }
     }
 

--- a/crates/ffpipeline/src/probe.rs
+++ b/crates/ffpipeline/src/probe.rs
@@ -44,6 +44,45 @@ pub struct ProbeResultVideoStream {
     pub display_aspect_ratio: Option<String>,
     pub pix_fmt: String,
     pub color_params: ProbeResultColorParams,
+    pub field_order: Option<String>,
+}
+
+impl ProbeResultVideoStream {
+    pub fn is_interlaced(&self) -> bool {
+        self.field_order
+            .as_ref()
+            .is_some_and(|fo| ["tt", "bb", "tb", "bt"].contains(&fo.as_str()))
+    }
+
+    pub fn is_anamorphic(&self) -> bool {
+        // TODO: need to calculate SAR when it's not provided; port MediaStream::SampleAspectRatio
+
+        match &self.sample_aspect_ratio {
+            Some(sample_aspect_ratio) => {
+                let display_aspect_ratio = self
+                    .display_aspect_ratio
+                    .as_ref()
+                    .map_or("", |dar| dar.as_ref());
+
+                // square pixels
+                if sample_aspect_ratio == "1:1" {
+                    false
+                }
+                // 0:1 is "unspecified", so anything other than that will be non-square/anamorphic
+                else if sample_aspect_ratio != "0:1" {
+                    true
+                }
+                // SAR 0:1 && DAR 0:1 (both unspecified) means square pixels
+                else if display_aspect_ratio == "0:1" {
+                    false
+                } else {
+                    // DAR == W:H is square
+                    display_aspect_ratio != format!("{}:{}", self.width, self.height)
+                }
+            }
+            None => false, // assumed SAR of 1:1
+        }
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -130,6 +169,7 @@ struct ProbeOutputStream {
     color_space: Option<String>,
     color_transfer: Option<String>,
     color_primaries: Option<String>,
+    field_order: Option<String>,
 }
 
 #[derive(Deserialize)]
@@ -328,6 +368,7 @@ fn output_to_result(output_stream: &ProbeOutputStream) -> Option<ProbeResultStre
                 color_transfer: output_stream.color_transfer.clone(),
                 color_primaries: output_stream.color_primaries.clone(),
             },
+            field_order: output_stream.field_order.clone(),
             frame_rate: FrameRate::parse(&output_stream.r_frame_rate.clone()?),
             sample_aspect_ratio: output_stream.sample_aspect_ratio.to_owned(),
             display_aspect_ratio: output_stream.display_aspect_ratio.to_owned(),

--- a/crates/ffpipeline/src/video_filter.rs
+++ b/crates/ffpipeline/src/video_filter.rs
@@ -137,7 +137,13 @@ impl VideoFilter {
                         (KnownVideoFilter::W3fdif, SoftwareDeinterlaceFilter::W3fdif),
                     ];
 
-                    filter_options.sort_by_key(|(k, _)| !ffmpeg_info.is_preferred_filter(k));
+                    filter_options.sort_by_key(|(k, _)| {
+                        ffmpeg_info
+                            .preferred_filters
+                            .iter()
+                            .position(|p| p == &k.to_string())
+                            .unwrap_or(usize::MAX)
+                    });
 
                     for (known_filter, software_filter) in filter_options {
                         if ffmpeg_info.has_video_filter(&known_filter) {
@@ -197,7 +203,10 @@ impl VideoFilter {
             }
             VideoFilter::Deinterlace { .. } => {
                 state.is_interlaced = false;
-                state.pixel_format = PixelFormat::Yuv420p;
+                state.pixel_format = match state.pixel_format.bit_depth() {
+                    10 => PixelFormat::Yuv420p10le,
+                    _ => PixelFormat::Yuv420p,
+                }
             }
         }
     }
@@ -293,11 +302,11 @@ impl VideoFilter {
             VideoFilter::Deinterlace {
                 filter: SoftwareDeinterlaceFilter::Bwdif,
                 ..
-            } => Some(String::from("bwdif")),
+            } => Some(String::from("bwdif=1")),
             VideoFilter::Deinterlace {
                 filter: SoftwareDeinterlaceFilter::W3fdif,
                 ..
-            } => Some(String::from("w3fdif")),
+            } => Some(String::from("w3fdif=1")),
         }
     }
 }

--- a/crates/ffpipeline/src/video_filter.rs
+++ b/crates/ffpipeline/src/video_filter.rs
@@ -1,5 +1,6 @@
 use dyn_clone::DynClone;
 
+use crate::ffmpeg_info::{FfmpegInfo, KnownVideoFilter};
 use crate::frame_size::FrameSize;
 use crate::pipeline::{FrameState, FrameSurface, PixelFormat};
 
@@ -22,6 +23,13 @@ impl ForceOriginalAspectRatio {
     }
 }
 
+#[derive(Clone)]
+pub enum SoftwareDeinterlaceFilter {
+    Bwdif,
+    Yadif,
+    W3fdif,
+}
+
 pub trait HwVideoFilter: DynClone {
     fn evaluate(&self, state: &FrameState) -> Option<VideoFilter>;
     fn apply_to(&self, state: &mut FrameState);
@@ -35,7 +43,7 @@ dyn_clone::clone_trait_object!(HwVideoFilter);
 pub enum VideoFilter {
     HwUpload {
         target_surface: FrameSurface,
-        bit_depth: u8,
+        source_format: PixelFormat,
     },
     HwDownload {
         target_pixel_format: PixelFormat,
@@ -58,12 +66,20 @@ pub enum VideoFilter {
         algorithm: Option<String>,
         format: PixelFormat,
     },
+    Deinterlace {
+        filter: SoftwareDeinterlaceFilter,
+        input_is_interlaced: bool,
+    },
     Hardware(Box<dyn HwVideoFilter>),
 }
 
 impl VideoFilter {
     /// Determines whether the filter is needed given the input frame state.
-    pub(crate) fn evaluate(&self, state: &FrameState) -> Option<VideoFilter> {
+    pub(crate) fn evaluate(
+        &self,
+        state: &FrameState,
+        ffmpeg_info: &FfmpegInfo,
+    ) -> Option<VideoFilter> {
         match self {
             // hardware filters aren't present at the point where this is called
             VideoFilter::HwUpload { .. } => None,
@@ -110,6 +126,31 @@ impl VideoFilter {
                     Some(self.clone())
                 }
             }
+            VideoFilter::Deinterlace {
+                input_is_interlaced,
+                ..
+            } => {
+                if *input_is_interlaced {
+                    let mut filter_options = [
+                        (KnownVideoFilter::Yadif, SoftwareDeinterlaceFilter::Yadif),
+                        (KnownVideoFilter::Bwdif, SoftwareDeinterlaceFilter::Bwdif),
+                        (KnownVideoFilter::W3fdif, SoftwareDeinterlaceFilter::W3fdif),
+                    ];
+
+                    filter_options.sort_by_key(|(k, _)| !ffmpeg_info.is_preferred_filter(k));
+
+                    for (known_filter, software_filter) in filter_options {
+                        if ffmpeg_info.has_video_filter(&known_filter) {
+                            return Some(VideoFilter::Deinterlace {
+                                filter: software_filter,
+                                input_is_interlaced: *input_is_interlaced,
+                            });
+                        }
+                    }
+                }
+
+                None
+            }
         }
     }
 
@@ -154,6 +195,10 @@ impl VideoFilter {
                 state.pixel_format = format.clone();
                 state.is_hdr = false;
             }
+            VideoFilter::Deinterlace { .. } => {
+                state.is_interlaced = false;
+                state.pixel_format = PixelFormat::Yuv420p;
+            }
         }
     }
 
@@ -168,6 +213,7 @@ impl VideoFilter {
             VideoFilter::Loop { .. } => Some(FrameSurface::System),
             VideoFilter::Format { .. } => Some(FrameSurface::System),
             VideoFilter::ToneMap { .. } => Some(FrameSurface::System),
+            VideoFilter::Deinterlace { .. } => Some(FrameSurface::System),
         }
     }
 
@@ -175,21 +221,30 @@ impl VideoFilter {
         match self {
             VideoFilter::HwUpload {
                 target_surface,
-                bit_depth,
-            } => match target_surface {
-                // TODO: refactor this into each hwaccel, maybe a hw_upload_filter() fn?
-                FrameSurface::Cuda => Some(String::from("hwupload_cuda")),
-                FrameSurface::Qsv => Some(String::from("hwupload=extra_hw_frames=64")),
-                FrameSurface::Vaapi => Some(String::from("hwupload")),
-                FrameSurface::Vulkan => {
-                    let format = match bit_depth {
-                        10 => "p010le",
-                        _ => "nv12",
-                    };
-                    Some(format!("format={},hwupload", format))
+                source_format,
+            } => {
+                let target_format = match source_format.bit_depth() {
+                    10 => PixelFormat::P010le,
+                    _ => PixelFormat::Nv12,
+                };
+
+                let format_filter = if source_format == &target_format {
+                    String::new()
+                } else {
+                    format!("format={},", target_format.as_arg())
+                };
+
+                match target_surface {
+                    // TODO: refactor this into each hwaccel, maybe a hw_upload_filter() fn?
+                    FrameSurface::Cuda => Some(format!("{format_filter}hwupload_cuda")),
+                    FrameSurface::Qsv => {
+                        Some(format!("{format_filter}hwupload=extra_hw_frames=64"))
+                    }
+                    FrameSurface::Vaapi => Some(format!("{format_filter}hwupload")),
+                    FrameSurface::Vulkan => Some(format!("{format_filter}hwupload")),
+                    _ => None,
                 }
-                _ => None,
-            },
+            }
             VideoFilter::HwDownload {
                 target_pixel_format,
             } => Some(format!(
@@ -231,6 +286,18 @@ impl VideoFilter {
                 algorithm.as_deref().unwrap_or("linear"),
                 format.as_arg()
             )),
+            VideoFilter::Deinterlace {
+                filter: SoftwareDeinterlaceFilter::Yadif,
+                ..
+            } => Some(String::from("yadif=1")),
+            VideoFilter::Deinterlace {
+                filter: SoftwareDeinterlaceFilter::Bwdif,
+                ..
+            } => Some(String::from("bwdif")),
+            VideoFilter::Deinterlace {
+                filter: SoftwareDeinterlaceFilter::W3fdif,
+                ..
+            } => Some(String::from("w3fdif")),
         }
     }
 }

--- a/schema/channel_config.json
+++ b/schema/channel_config.json
@@ -127,13 +127,22 @@
           "type": [
             "string",
             "null"
-          ]
+          ],
+          "default": null
         },
         "ffprobe_path": {
           "type": [
             "string",
             "null"
-          ]
+          ],
+          "default": null
+        },
+        "preferred_filters": {
+          "type": "array",
+          "default": [],
+          "items": {
+            "type": "string"
+          }
         }
       }
     },
@@ -234,6 +243,10 @@
           ],
           "format": "uint32",
           "minimum": 0
+        },
+        "deinterlace": {
+          "type": "boolean",
+          "default": false
         },
         "format": {
           "anyOf": [


### PR DESCRIPTION
Resolves #44

This makes a handful of changes:

1. Playout generator now adds lavfi silence when scheduling content without audio streams, e.g. test interlaced content:

https://samples.ffmpeg.org/MPEG2/interlaced/burosch1.mpg
https://samples.ffmpeg.org/MPEG2/interlaced/burosch2.mpg

2. Adds `preferred_filters` array to channel config; for logical filters that have multiple implementations, filter selection will first check against this list.

3. Probe has been updated to store field order, which is used to make a basic determination of interlaced/not interlaced content. Future work may add more involved probing, or we could add probe hints to the playout JSON schema to always consider certain content as interlaced.

4. Adds `deinterlace` (true, false) to channel config under video normalization. When deinterlace is true, content that is detected as interlaced will be deinterlaced using software filters.

5. Adds an additional pixel format check in `HwUpload` filter since software deinterlace can take in `nv12` but output a different format like `yuv420p`. If pixel format doesn't match, a format filter will be inserted to correct (e.g. `yuv420p` after deinterlace will be converted back to `nv12` before upload).