### PR TITLE
feat: change track selection in playout schema to improve model gen

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -547,7 +547,6 @@ dependencies = [
 name = "ersatztv-playout"
 version = "0.1.0"
 dependencies = [
- "schemars",
  "serde",
  "serde_json",
  "thiserror",

--- a/crates/ersatztv-channel/src/channel_session.rs
+++ b/crates/ersatztv-channel/src/channel_session.rs
@@ -342,41 +342,13 @@ impl ChannelSession {
         realtime: bool,
         pts_duration: Option<Duration>,
     ) -> Result<(OffsetDateTime, bool), ChannelError> {
-        let current_source = current_item.source.clone();
-        let audio_source = match current_source.as_ref() {
-            Some(source) => Ok(source.to_owned()),
-            None => {
-                let audio_track_source = current_item
-                    .tracks
-                    .as_ref()
-                    .and_then(|t| t.audio.as_ref())
-                    .and_then(|a| match a {
-                        TrackSelection::Source { source, .. } => Some(source.to_owned()),
-                        _ => None,
-                    });
-                match audio_track_source {
-                    Some(source) => Ok(source),
-                    None => Err(ChannelError::PlayoutJsonAudioSourceRequired),
-                }
-            }
-        }?;
-        let video_source = match current_source.as_ref() {
-            Some(source) => Ok(source.to_owned()),
-            None => {
-                let video_track_source = current_item
-                    .tracks
-                    .as_ref()
-                    .and_then(|t| t.video.as_ref())
-                    .and_then(|v| match v {
-                        TrackSelection::Source { source, .. } => Some(source.clone()),
-                        _ => None,
-                    });
-                match video_track_source {
-                    Some(source) => Ok(source),
-                    None => Err(ChannelError::PlayoutJsonVideoSourceRequired),
-                }
-            }
-        }?;
+        // prioritize source from audio tracks, then default source
+        let audio_source = Self::resolve_source(current_item, |t| t.audio.as_ref())
+            .ok_or(ChannelError::PlayoutJsonAudioSourceRequired)?;
+
+        // prioritize source from video tracks, then default source
+        let video_source = Self::resolve_source(current_item, |t| t.video.as_ref())
+            .ok_or(ChannelError::PlayoutJsonVideoSourceRequired)?;
 
         let audio_input_source = Self::playout_source_to_input_source(audio_source.clone())?;
         let video_input_source = if video_source == audio_source {
@@ -453,19 +425,13 @@ impl ChannelSession {
             .tracks
             .as_ref()
             .and_then(|t| t.video.as_ref())
-            .and_then(|v| match v {
-                TrackSelection::StreamIndex { stream_index } => Some(*stream_index),
-                _ => None,
-            });
+            .and_then(|v| v.stream_index);
 
         let audio_index = current_item
             .tracks
             .as_ref()
             .and_then(|t| t.audio.as_ref())
-            .and_then(|a| match a {
-                TrackSelection::StreamIndex { stream_index } => Some(*stream_index),
-                _ => None,
-            });
+            .and_then(|a| a.stream_index);
 
         let input_settings = InputSettings {
             audio_input: ProbedInput {
@@ -688,13 +654,14 @@ impl ChannelSession {
             finish: next_start.unwrap_or(self.transcoded_until + Duration::from_mins(1)),
             source: None,
             tracks: Some(PlayoutItemTracks {
-                audio: Some(TrackSelection::Source {
-                    source: PlayoutItemSource::Lavfi {
+                audio: Some(TrackSelection {
+                    source: Some(PlayoutItemSource::Lavfi {
                         params: String::from("anullsrc=channel_layout=stereo:sample_rate=48000"),
-                    },
+                    }),
+                    stream_index: None,
                 }),
-                video: Some(TrackSelection::Source {
-                    source: PlayoutItemSource::Lavfi {
+                video: Some(TrackSelection {
+                    source: Some(PlayoutItemSource::Lavfi {
                         params: format!(
                             "color=c=black:s={}x{}",
                             self.channel_config
@@ -708,9 +675,21 @@ impl ChannelSession {
                                 .height
                                 .unwrap_or(1080),
                         ),
-                    },
+                    }),
+                    stream_index: None,
                 }),
             }),
         }
+    }
+
+    fn resolve_source<F>(item: &PlayoutItem, pick: F) -> Option<PlayoutItemSource>
+    where
+        F: FnOnce(&PlayoutItemTracks) -> Option<&TrackSelection>,
+    {
+        item.tracks
+            .as_ref()
+            .and_then(pick)
+            .and_then(|sel| sel.source.clone())
+            .or_else(|| item.source.clone())
     }
 }

--- a/crates/ersatztv-playout-generator/src/generate.rs
+++ b/crates/ersatztv-playout-generator/src/generate.rs
@@ -70,6 +70,11 @@ pub async fn generate_playout(
         let is_image = probe_result.streams.len() == 1
             && matches!(probe_result.streams.first(), Some(ProbeResultStream::Video(video_stream)) if IMAGE_EXTENSIONS.contains(&video_stream.codec.as_str()));
 
+        let has_audio = probe_result
+            .streams
+            .iter()
+            .any(|s| matches!(s, ProbeResultStream::Audio(_)));
+
         // use 10-sec duration for images
         let image_duration = std::time::Duration::from_secs(10);
         let duration = match probe_result.duration {
@@ -93,26 +98,46 @@ pub async fn generate_playout(
                 path,
             )
         {
-            // use separate tracks with lavfi audio for images
-            if is_image {
+            // use lavfi audio for video-only content
+            if !has_audio {
                 playout_item.tracks = Some(PlayoutItemTracks {
-                    audio: Some(TrackSelection::Source {
-                        source: PlayoutItemSource::Lavfi {
+                    audio: Some(TrackSelection {
+                        source: Some(PlayoutItemSource::Lavfi {
+                            params: String::from(
+                                "anullsrc=channel_layout=stereo:sample_rate=48000",
+                            ),
+                        }),
+                        stream_index: None,
+                    }),
+                    video: playout_item.source.as_ref().map(|s| TrackSelection {
+                        source: Some(s.clone()),
+                        stream_index: None,
+                    }),
+                });
+
+                playout_item.source = None;
+            }
+            // use separate tracks with lavfi audio for images
+            else if is_image {
+                playout_item.tracks = Some(PlayoutItemTracks {
+                    audio: Some(TrackSelection {
+                        source: Some(PlayoutItemSource::Lavfi {
                             params: format!(
-                                "sine=frequency=1000:sample_rate=48000:d={}",
+                                "anullsrc=channel_layout=stereo:sample_rate=48000:d={}",
                                 image_duration.as_secs()
                             ),
-                        },
+                        }),
+                        stream_index: None,
                         // source: PlayoutItemSource::Local {
                         //     path: String::from("~/Music/silence.mp3"),
                         //     in_point_ms: None,
                         //     out_point_ms: Some(image_duration.as_millis() as u64),
                         // },
                     }),
-                    video: playout_item
-                        .source
-                        .as_ref()
-                        .map(|s| TrackSelection::Source { source: s.clone() }),
+                    video: playout_item.source.as_ref().map(|s| TrackSelection {
+                        source: Some(s.clone()),
+                        stream_index: None,
+                    }),
                 });
 
                 playout_item.source = None;

--- a/crates/ersatztv-playout-generator/src/generate.rs
+++ b/crates/ersatztv-playout-generator/src/generate.rs
@@ -98,7 +98,7 @@ pub async fn generate_playout(
                 path,
             )
         {
-            // use lavfi audio for video-only content
+            // use separate tracks with lavfi audio for images
             if !has_audio {
                 playout_item.tracks = Some(PlayoutItemTracks {
                     audio: Some(TrackSelection {
@@ -108,31 +108,6 @@ pub async fn generate_playout(
                             ),
                         }),
                         stream_index: None,
-                    }),
-                    video: playout_item.source.as_ref().map(|s| TrackSelection {
-                        source: Some(s.clone()),
-                        stream_index: None,
-                    }),
-                });
-
-                playout_item.source = None;
-            }
-            // use separate tracks with lavfi audio for images
-            else if is_image {
-                playout_item.tracks = Some(PlayoutItemTracks {
-                    audio: Some(TrackSelection {
-                        source: Some(PlayoutItemSource::Lavfi {
-                            params: format!(
-                                "anullsrc=channel_layout=stereo:sample_rate=48000:d={}",
-                                image_duration.as_secs()
-                            ),
-                        }),
-                        stream_index: None,
-                        // source: PlayoutItemSource::Local {
-                        //     path: String::from("~/Music/silence.mp3"),
-                        //     in_point_ms: None,
-                        //     out_point_ms: Some(image_duration.as_millis() as u64),
-                        // },
                     }),
                     video: playout_item.source.as_ref().map(|s| TrackSelection {
                         source: Some(s.clone()),

--- a/crates/ersatztv-playout/Cargo.toml
+++ b/crates/ersatztv-playout/Cargo.toml
@@ -4,13 +4,8 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-schemars = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
 time = { workspace = true }
 tokio = { workspace = true }
-
-[[bin]]
-name = "gen-playout-schema"
-path = "src/bin/gen_playout_schema.rs"

--- a/crates/ersatztv-playout/src/bin/gen_playout_schema.rs
+++ b/crates/ersatztv-playout/src/bin/gen_playout_schema.rs
@@ -1,7 +1,0 @@
-use ersatztv_playout::playout::Playout;
-use schemars::schema_for;
-
-fn main() {
-    let schema = schema_for!(Playout);
-    println!("{}", serde_json::to_string_pretty(&schema).unwrap());
-}

--- a/crates/ersatztv-playout/src/playout.rs
+++ b/crates/ersatztv-playout/src/playout.rs
@@ -83,7 +83,9 @@ pub struct PlayoutItemTracks {
 
 #[derive(Debug, Deserialize, Serialize)]
 pub struct TrackSelection {
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub source: Option<PlayoutItemSource>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub stream_index: Option<u32>,
 }
 

--- a/crates/ersatztv-playout/src/playout.rs
+++ b/crates/ersatztv-playout/src/playout.rs
@@ -1,6 +1,5 @@
 use std::path::Path;
 
-use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use time::OffsetDateTime;
 use time::format_description::well_known::{Iso8601, iso8601};
@@ -16,7 +15,7 @@ pub const DATE_FORMAT: Iso8601<DATE_CONFIG> = Iso8601::<DATE_CONFIG>;
 /// Files should be named `{start}_{finish}.json` using compact ISO 8601
 /// (no separators), e.g. `20260413T000000.000000000-0500_20260414T002131.620000000-0500.json`,
 /// so that the channel can locate the correct file for the current time.
-#[derive(Debug, Deserialize, Serialize, JsonSchema)]
+#[derive(Debug, Deserialize, Serialize)]
 pub struct Playout {
     /// URI identifying the schema version, e.g. "https://ersatztv.org/playout/version/0.0.1"
     pub version: String,
@@ -32,16 +31,14 @@ impl Playout {
     }
 }
 
-#[derive(Debug, Deserialize, Serialize, JsonSchema)]
+#[derive(Debug, Deserialize, Serialize)]
 pub struct PlayoutItem {
     pub id: String,
     /// RFC3339 formatted date/time, e.g. 2026-04-13T00:24:21.527-05:00
     #[serde(with = "time::serde::rfc3339")]
-    #[schemars(with = "String")]
     pub start: OffsetDateTime,
     /// RFC3339 formatted date/time, e.g. 2026-04-13T00:24:21.527-05:00
     #[serde(with = "time::serde::rfc3339")]
-    #[schemars(with = "String")]
     pub finish: OffsetDateTime,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub source: Option<PlayoutItemSource>,
@@ -76,20 +73,21 @@ impl PlayoutItem {
     }
 }
 
-#[derive(Debug, Deserialize, Serialize, JsonSchema)]
+#[derive(Debug, Deserialize, Serialize)]
 pub struct PlayoutItemTracks {
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub audio: Option<TrackSelection>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub video: Option<TrackSelection>,
 }
 
-#[derive(Debug, Deserialize, Serialize, JsonSchema)]
-#[serde(untagged)]
-pub enum TrackSelection {
-    Source { source: PlayoutItemSource },
-    StreamIndex { stream_index: u32 },
+#[derive(Debug, Deserialize, Serialize)]
+pub struct TrackSelection {
+    pub source: Option<PlayoutItemSource>,
+    pub stream_index: Option<u32>,
 }
 
-#[derive(Debug, Deserialize, Serialize, JsonSchema, Clone, PartialEq)]
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
 #[serde(tag = "source_type", rename_all = "snake_case")]
 pub enum PlayoutItemSource {
     Local {

--- a/examples/playout/playout.json
+++ b/examples/playout/playout.json
@@ -1,6 +1,6 @@
 {
   "$schema": "../../schema/playout.json",
-  "version": "https://ersatztv.org/playout/version/1.0.0",
+  "version": "https://ersatztv.org/playout/version/0.0.1",
   "generated_at": "2026-02-23T18:02:00-05:00",
   "items": [
     {

--- a/schema/playout.json
+++ b/schema/playout.json
@@ -1,210 +1,94 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ersatztv.org/playout/version/0.0.1",
   "title": "Playout",
-  "description": "A playout schedule for a single time window.\n\nFiles should be named `{start}_{finish}.json` using compact ISO 8601\n(no separators), e.g. `20260413T000000.000000000-0500_20260414T002131.620000000-0500.json`,\nso that the channel can locate the correct file for the current time.",
+  "description": "A playout schedule for a single time window.\n\nFiles should be named `{start}_{finish}.json` using compact ISO 8601 (no separators), e.g. `20260413T000000.000000000-0500_20260414T002131.620000000-0500.json`, so that the channel can locate the correct file for the current time.",
   "type": "object",
-  "properties": {
-    "items": {
-      "type": "array",
-      "items": {
-        "$ref": "#/$defs/PlayoutItem"
-      }
-    },
-    "version": {
-      "description": "URI identifying the schema version, e.g. \"https://ersatztv.org/playout/version/0.0.1\"",
-      "type": "string"
-    }
-  },
   "required": [
     "version",
     "items"
   ],
-  "$defs": {
+  "properties": {
+    "version": {
+      "type": "string",
+      "description": "URI identifying the schema version, e.g. \"https://ersatztv.org/playout/version/0.0.1\"."
+    },
+    "items": {
+      "type": "array",
+      "description": "Ordered list of scheduled items for this window.",
+      "items": {
+        "$ref": "#/definitions/PlayoutItem"
+      }
+    }
+  },
+  "definitions": {
     "PlayoutItem": {
       "type": "object",
-      "properties": {
-        "finish": {
-          "description": "RFC3339 formatted date/time, e.g. 2026-04-13T00:24:21.527-05:00",
-          "type": "string"
-        },
-        "id": {
-          "type": "string"
-        },
-        "source": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/PlayoutItemSource"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "start": {
-          "description": "RFC3339 formatted date/time, e.g. 2026-04-13T00:24:21.527-05:00",
-          "type": "string"
-        },
-        "tracks": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/PlayoutItemTracks"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      },
+      "description": "A single scheduled item in the playout.\n\nAn item must supply media for its tracks. You can do this two ways, and they can be combined:\n\n1. Set `source` to use one shared source for every track. Track details (which stream, etc.) are chosen naively, or may be refined via `tracks`.\n2. Set `tracks` to specify each track (video, audio) individually. A track may provide its own `source`; if it doesn't, the item's top-level `source` is used.\n\nAt least one of `source` or `tracks` must be present, and every track that is selected must have an effective source (either its own or the item's).",
       "required": [
         "id",
         "start",
         "finish"
-      ]
-    },
-    "PlayoutItemSource": {
-      "oneOf": [
-        {
-          "type": "object",
-          "properties": {
-            "in_point_ms": {
-              "type": [
-                "integer",
-                "null"
-              ],
-              "format": "uint64",
-              "minimum": 0
-            },
-            "out_point_ms": {
-              "type": [
-                "integer",
-                "null"
-              ],
-              "format": "uint64",
-              "minimum": 0
-            },
-            "path": {
-              "type": "string"
-            },
-            "source_type": {
-              "type": "string",
-              "const": "local"
-            }
-          },
-          "required": [
-            "source_type",
-            "path"
-          ]
-        },
-        {
-          "type": "object",
-          "properties": {
-            "params": {
-              "type": "string"
-            },
-            "source_type": {
-              "type": "string",
-              "const": "lavfi"
-            }
-          },
-          "required": [
-            "source_type",
-            "params"
-          ]
-        },
-        {
-          "type": "object",
-          "properties": {
-            "headers": {
-              "description": "Custom HTTP headers, e.g. [\"Authorization: Bearer {{TOKEN}}\"]",
-              "type": [
-                "array",
-                "null"
-              ],
-              "items": {
-                "type": "string"
-              }
-            },
-            "in_point_ms": {
-              "type": [
-                "integer",
-                "null"
-              ],
-              "format": "uint64",
-              "minimum": 0
-            },
-            "out_point_ms": {
-              "type": [
-                "integer",
-                "null"
-              ],
-              "format": "uint64",
-              "minimum": 0
-            },
-            "reconnect": {
-              "description": "Enable reconnect on failure (default: true)",
-              "type": [
-                "boolean",
-                "null"
-              ]
-            },
-            "reconnect_delay_max": {
-              "description": "Max reconnect delay in seconds",
-              "type": [
-                "integer",
-                "null"
-              ],
-              "format": "uint32",
-              "minimum": 0
-            },
-            "source_type": {
-              "type": "string",
-              "const": "http"
-            },
-            "timeout_us": {
-              "description": "Socket timeout in microseconds",
-              "type": [
-                "integer",
-                "null"
-              ],
-              "format": "uint64",
-              "minimum": 0
-            },
-            "uri": {
-              "description": "URI template, e.g. \"https://example.com/file.mkv?token={{MY_SECRET}}\"",
-              "type": "string"
-            },
-            "user_agent": {
-              "description": "Custom user-agent string",
-              "type": [
-                "string",
-                "null"
-              ]
-            }
-          },
-          "required": [
-            "source_type",
-            "uri"
-          ]
-        }
-      ]
-    },
-    "PlayoutItemTracks": {
-      "type": "object",
+      ],
       "properties": {
-        "audio": {
-          "anyOf": [
+        "id": {
+          "type": "string",
+          "description": "Stable identifier for this item, unique within the playout."
+        },
+        "start": {
+          "type": "string",
+          "format": "date-time",
+          "description": "RFC3339 formatted start time, e.g. 2026-04-13T00:24:21.527-05:00."
+        },
+        "finish": {
+          "type": "string",
+          "format": "date-time",
+          "description": "RFC3339 formatted finish time, e.g. 2026-04-13T00:54:21.527-05:00."
+        },
+        "source": {
+          "description": "The default source shared by any track that doesn't specify its own. Required unless every selected track in `tracks` provides its own `source`.",
+          "oneOf": [
             {
-              "$ref": "#/$defs/TrackSelection"
+              "$ref": "#/definitions/PlayoutItemSource"
             },
             {
               "type": "null"
             }
           ]
         },
-        "video": {
-          "anyOf": [
+        "tracks": {
+          "description": "Per-track selection. Omit to let the server pick the first video and first audio track of the item's `source`.",
+          "oneOf": [
             {
-              "$ref": "#/$defs/TrackSelection"
+              "$ref": "#/definitions/PlayoutItemTracks"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      }
+    },
+    "PlayoutItemTracks": {
+      "type": "object",
+      "description": "Per-track overrides for a playout item. Omit a field to use the server default for that track kind (first stream of that kind in the item's `source`, if any).",
+      "properties": {
+        "video": {
+          "description": "Video track selection.",
+          "oneOf": [
+            {
+              "$ref": "#/definitions/TrackSelection"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "audio": {
+          "description": "Audio track selection.",
+          "oneOf": [
+            {
+              "$ref": "#/definitions/TrackSelection"
             },
             {
               "type": "null"
@@ -214,32 +98,172 @@
       }
     },
     "TrackSelection": {
-      "anyOf": [
-        {
-          "type": "object",
-          "properties": {
-            "source": {
-              "$ref": "#/$defs/PlayoutItemSource"
+      "type": "object",
+      "description": "Selects a single track (video or audio).\n\n- `source` absent: inherit the parent `PlayoutItem.source`.\n- `source` present: use this source for this track, overriding the parent.\n- `stream_index` absent: server picks the first stream of the track's kind in the effective source.\n- `stream_index` present: use this specific stream within the effective source.",
+      "properties": {
+        "source": {
+          "description": "Source to pull this track from. If omitted, inherits from the parent `PlayoutItem.source`.",
+          "oneOf": [
+            {
+              "$ref": "#/definitions/PlayoutItemSource"
+            },
+            {
+              "type": "null"
             }
-          },
-          "required": [
-            "source"
           ]
         },
+        "stream_index": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "minimum": 0,
+          "description": "Zero-based stream index within the effective source. If omitted, the server picks the first stream of this track's kind."
+        }
+      }
+    },
+    "PlayoutItemSource": {
+      "description": "A media source. Exactly one variant, distinguished by `source_type`.",
+      "discriminator": {
+        "propertyName": "source_type"
+      },
+      "oneOf": [
         {
-          "type": "object",
-          "properties": {
-            "stream_index": {
-              "type": "integer",
-              "format": "uint32",
-              "minimum": 0
-            }
-          },
-          "required": [
-            "stream_index"
-          ]
+          "$ref": "#/definitions/LocalSource"
+        },
+        {
+          "$ref": "#/definitions/LavfiSource"
+        },
+        {
+          "$ref": "#/definitions/HttpSource"
         }
       ]
+    },
+    "LocalSource": {
+      "type": "object",
+      "description": "A file on the local filesystem reachable by the server.",
+      "required": [
+        "source_type",
+        "path"
+      ],
+      "properties": {
+        "source_type": {
+          "type": "string",
+          "const": "local"
+        },
+        "path": {
+          "type": "string",
+          "description": "Absolute path to the media file."
+        },
+        "in_point_ms": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "minimum": 0,
+          "description": "Optional start offset into the source, in milliseconds."
+        },
+        "out_point_ms": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "minimum": 0,
+          "description": "Optional end offset into the source, in milliseconds."
+        }
+      }
+    },
+    "LavfiSource": {
+      "type": "object",
+      "description": "A synthetic source produced by an ffmpeg lavfi filter graph.",
+      "required": [
+        "source_type",
+        "params"
+      ],
+      "properties": {
+        "source_type": {
+          "type": "string",
+          "const": "lavfi"
+        },
+        "params": {
+          "type": "string",
+          "description": "The lavfi filter graph parameters, passed verbatim to ffmpeg's `-f lavfi -i`."
+        }
+      }
+    },
+    "HttpSource": {
+      "type": "object",
+      "description": "A remote source fetched over HTTP(S).",
+      "required": [
+        "source_type",
+        "uri"
+      ],
+      "properties": {
+        "source_type": {
+          "type": "string",
+          "const": "http"
+        },
+        "uri": {
+          "type": "string",
+          "description": "URI template, e.g. \"https://example.com/file.mkv?token={{MY_SECRET}}\"."
+        },
+        "in_point_ms": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "minimum": 0,
+          "description": "Optional start offset into the source, in milliseconds."
+        },
+        "out_point_ms": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "minimum": 0,
+          "description": "Optional end offset into the source, in milliseconds."
+        },
+        "headers": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          },
+          "description": "Custom HTTP headers, e.g. [\"Authorization: Bearer {{TOKEN}}\"]."
+        },
+        "user_agent": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Custom User-Agent string."
+        },
+        "timeout_us": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "minimum": 0,
+          "description": "Socket timeout in microseconds."
+        },
+        "reconnect": {
+          "type": [
+            "boolean",
+            "null"
+          ],
+          "description": "Enable reconnect on failure. Default: true."
+        },
+        "reconnect_delay_max": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "minimum": 0,
+          "description": "Maximum reconnect delay in seconds. Maps to ffmpeg's `reconnect_delay_max`."
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
Having `PlayoutItemSource` directly on `PlayoutItem` *and* within the `TrackSelection` enum coupled with two rounds of generation (generate schema from rust, generate other language models from schema) resulted in less than stellar models.

This rewrites the schema a bit, though previously generated playout JSON files should still be valid.

Playout schema generation was also removed; so this is something we'll have to manually maintain going forward.
