### PR TITLE
feat: add qsv format filter

### DIFF
--- a/crates/ffpipeline/src/accel/qsv.rs
+++ b/crates/ffpipeline/src/accel/qsv.rs
@@ -63,7 +63,7 @@ impl HwAccel for Qsv {
             }),
             VideoFormat::Hevc => Some(VideoCodec {
                 codec_name: "hevc_qsv",
-                options: &["-low_power", "0", "-look_ahead", "0"],
+                options: &["-low_power", "0", "-look_ahead", "0", "-tag:v", "hvc1"],
                 preferred_pixel_format_8bit: Some(PixelFormat::Nv12),
                 preferred_pixel_format_10bit: Some(PixelFormat::P010le),
                 is_hardware: true,

--- a/crates/ffpipeline/src/accel/qsv.rs
+++ b/crates/ffpipeline/src/accel/qsv.rs
@@ -84,6 +84,12 @@ impl HwAccel for Qsv {
         FrameSurface::Qsv
     }
 
+    fn format_filter(&self, pixel_format: &PixelFormat) -> Option<VideoFilter> {
+        Some(VideoFilter::Hardware(Box::new(FormatQsv {
+            format: pixel_format.clone(),
+        })))
+    }
+
     fn initialize(&self, _ffmpeg_info: &FfmpegInfo, _is_hdr: bool) -> Self {
         self.clone()
     }
@@ -128,5 +134,30 @@ impl HwVideoFilter for ScaleQsv {
         self.size.as_ref().map(|s|
             // TODO: anamorphic handling
             format!("vpp_qsv=w={}:h={}", s.width, s.height))
+    }
+}
+
+#[derive(Clone)]
+struct FormatQsv {
+    format: PixelFormat,
+}
+
+impl HwVideoFilter for FormatQsv {
+    fn evaluate(&self, _state: &FrameState) -> Option<VideoFilter> {
+        // called before this is used
+        None
+    }
+
+    fn apply_to(&self, state: &mut FrameState) {
+        state.pixel_format = self.format.clone();
+        state.surface = FrameSurface::Qsv;
+    }
+
+    fn required_surface(&self) -> FrameSurface {
+        FrameSurface::Qsv
+    }
+
+    fn as_arg(&self) -> Option<String> {
+        Some(format!("vpp_qsv=format={}", self.format.as_arg()))
     }
 }

--- a/crates/ffpipeline/tests/common/mod.rs
+++ b/crates/ffpipeline/tests/common/mod.rs
@@ -61,8 +61,6 @@ pub async fn run_test_case(test_env: &TestEnv, test_case: TestCase) {
 
     let mut pipeline = generate_pipeline(&test_env.ffmpeg_info, input, output).unwrap();
     pipeline.optimize();
-    let args = pipeline.args();
-    log::debug!("optimized pipeline: {}", args.join(" "));
 
     let (success, stderr) = run_ffmpeg_pipeline(&test_env.ffmpeg, &pipeline).await;
     assert!(success, "ffmpeg failed:\n{stderr}");
@@ -215,6 +213,7 @@ pub fn build_output(dir: &Path, params: TestOutputParams) -> OutputSettings {
 pub async fn run_ffmpeg_pipeline(ffmpeg: &Path, pipeline: &Pipeline) -> (bool, String) {
     let args = pipeline.args();
     let envs = pipeline.envs();
+    log::debug!("optimized pipeline: {}", args.join(" "));
 
     let output = tokio::time::timeout(
         Duration::from_secs(30),
@@ -231,6 +230,9 @@ pub async fn run_ffmpeg_pipeline(ffmpeg: &Path, pipeline: &Pipeline) -> (bool, S
     .expect("failed to spawn ffmpeg");
 
     let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
+    if !output.status.success() {
+        log::error!("ffmpeg exited with {}", output.status);
+    }
     (output.status.success(), stderr)
 }
 


### PR DESCRIPTION
This enables required bit depth conversions in the hardware pipeline (e.g. filtered output is 10-bit but h264_qsv only accepts 8-bit), and fixes a number of QSV integration tests.