### PR TITLE
fix: transfer surfaces consistently; init hw device consistently

### DIFF
--- a/crates/ffpipeline/src/filter_chain.rs
+++ b/crates/ffpipeline/src/filter_chain.rs
@@ -128,26 +128,13 @@ impl FilterChain {
                 *encoder_surface
             );
 
-            if *encoder_surface == FrameSurface::System {
-                let target_pixel_format = match current_state.pixel_format.bit_depth() {
-                    10 => PixelFormat::P010le,
-                    _ => PixelFormat::Nv12,
-                };
-
-                let download = VideoFilter::HwDownload {
-                    target_pixel_format,
-                };
-                download.apply_to(&mut current_state);
-                resolved.push(PipelineFilter::Video(download));
-            } else {
-                let _ = self.transfer_surface(
-                    accel,
-                    &mut resolved,
-                    &mut current_state,
-                    encoder_surface.clone(),
-                    encoder_pixel_format,
-                );
-            }
+            let _ = self.transfer_surface(
+                accel,
+                &mut resolved,
+                &mut current_state,
+                encoder_surface.clone(),
+                encoder_pixel_format,
+            );
         }
 
         if let Some(pixel_format) = encoder_pixel_format

--- a/crates/ffpipeline/src/filter_chain.rs
+++ b/crates/ffpipeline/src/filter_chain.rs
@@ -128,13 +128,15 @@ impl FilterChain {
                 *encoder_surface
             );
 
-            let _ = self.transfer_surface(
+            if !self.transfer_surface(
                 accel,
                 &mut resolved,
                 &mut current_state,
                 encoder_surface.clone(),
                 encoder_pixel_format,
-            );
+            ) {
+                log::error!("failed to transfer surface to encoder");
+            }
         }
 
         if let Some(pixel_format) = encoder_pixel_format

--- a/crates/ffpipeline/src/filter_chain.rs
+++ b/crates/ffpipeline/src/filter_chain.rs
@@ -98,61 +98,15 @@ impl FilterChain {
 
                     if let Some(required) = best.required_surface()
                         && current_state.surface != required
+                        && !self.transfer_surface(
+                            accel,
+                            &mut resolved,
+                            &mut current_state,
+                            required,
+                            encoder_pixel_format,
+                        )
                     {
-                        if required == FrameSurface::System {
-                            let target_pixel_format = match current_state.pixel_format.bit_depth() {
-                                10 => PixelFormat::P010le,
-                                _ => PixelFormat::Nv12,
-                            };
-
-                            let download = VideoFilter::HwDownload {
-                                target_pixel_format,
-                            };
-                            download.apply_to(&mut current_state);
-                            resolved.push(PipelineFilter::Video(download));
-                        } else if current_state.surface == FrameSurface::System {
-                            let is_format_supported = match accel {
-                                Some(a) => a.supports_pixel_format(&current_state.pixel_format),
-                                None => true,
-                            };
-
-                            if is_format_supported {
-                                let upload = VideoFilter::HwUpload {
-                                    target_surface: required.clone(),
-                                    source_format: current_state.pixel_format.clone(),
-                                };
-                                upload.apply_to(&mut current_state);
-                                resolved.push(PipelineFilter::Video(upload))
-                            } else {
-                                let can_convert_down = current_state.pixel_format.bit_depth() == 10
-                                    && encoder_pixel_format
-                                        .as_ref()
-                                        .is_some_and(|pf| pf.bit_depth() == 8);
-
-                                if can_convert_down {
-                                    let format = VideoFilter::Format {
-                                        format: PixelFormat::Nv12,
-                                    };
-                                    format.apply_to(&mut current_state);
-                                    resolved.push(PipelineFilter::Video(format));
-
-                                    let upload = VideoFilter::HwUpload {
-                                        target_surface: required,
-                                        source_format: current_state.pixel_format.clone(),
-                                    };
-                                    upload.apply_to(&mut current_state);
-                                    resolved.push(PipelineFilter::Video(upload));
-                                } else {
-                                    best = video_filter.clone();
-                                }
-                            }
-                        } else if let Some(map) = accel
-                            .as_ref()
-                            .and_then(|a| a.hw_map_filter(&current_state.surface, &required))
-                        {
-                            map.apply_to(&mut current_state);
-                            resolved.push(PipelineFilter::Video(map));
-                        }
+                        best = video_filter.clone();
                     }
 
                     best.apply_to(&mut current_state);
@@ -185,19 +139,14 @@ impl FilterChain {
                 };
                 download.apply_to(&mut current_state);
                 resolved.push(PipelineFilter::Video(download));
-            } else if current_state.surface == FrameSurface::System {
-                let upload = VideoFilter::HwUpload {
-                    target_surface: encoder_surface.clone(),
-                    source_format: current_state.pixel_format.clone(),
-                };
-                upload.apply_to(&mut current_state);
-                resolved.push(PipelineFilter::Video(upload))
-            } else if let Some(map) = accel
-                .as_ref()
-                .and_then(|a| a.hw_map_filter(&current_state.surface, encoder_surface))
-            {
-                map.apply_to(&mut current_state);
-                resolved.push(PipelineFilter::Video(map));
+            } else {
+                let _ = self.transfer_surface(
+                    accel,
+                    &mut resolved,
+                    &mut current_state,
+                    encoder_surface.clone(),
+                    encoder_pixel_format,
+                );
             }
         }
 
@@ -229,6 +178,72 @@ impl FilterChain {
         }
 
         self.filters = resolved;
+    }
+
+    fn transfer_surface(
+        &self,
+        accel: &Option<HardwareAccel>,
+        resolved: &mut Vec<PipelineFilter>,
+        current_state: &mut FrameState,
+        required: FrameSurface,
+        encoder_pixel_format: &Option<PixelFormat>,
+    ) -> bool {
+        if required == FrameSurface::System {
+            let target_pixel_format = match current_state.pixel_format.bit_depth() {
+                10 => PixelFormat::P010le,
+                _ => PixelFormat::Nv12,
+            };
+
+            let download = VideoFilter::HwDownload {
+                target_pixel_format,
+            };
+            download.apply_to(current_state);
+            resolved.push(PipelineFilter::Video(download))
+        } else {
+            let is_format_supported = match accel {
+                Some(a) => a.supports_pixel_format(&current_state.pixel_format),
+                None => true,
+            };
+
+            if is_format_supported {
+                let upload = VideoFilter::HwUpload {
+                    target_surface: required.clone(),
+                    source_format: current_state.pixel_format.clone(),
+                };
+                upload.apply_to(current_state);
+                resolved.push(PipelineFilter::Video(upload));
+            } else if current_state.surface == FrameSurface::System {
+                let can_convert_down = current_state.pixel_format.bit_depth() == 10
+                    && encoder_pixel_format
+                        .as_ref()
+                        .is_some_and(|pf| pf.bit_depth() == 8);
+
+                if can_convert_down {
+                    let format = VideoFilter::Format {
+                        format: PixelFormat::Nv12,
+                    };
+                    format.apply_to(current_state);
+                    resolved.push(PipelineFilter::Video(format));
+
+                    let upload = VideoFilter::HwUpload {
+                        target_surface: required,
+                        source_format: current_state.pixel_format.clone(),
+                    };
+                    upload.apply_to(current_state);
+                    resolved.push(PipelineFilter::Video(upload));
+                } else {
+                    return false;
+                }
+            } else if let Some(map) = accel
+                .as_ref()
+                .and_then(|a| a.hw_map_filter(&current_state.surface, &required))
+            {
+                map.apply_to(current_state);
+                resolved.push(PipelineFilter::Video(map));
+            }
+        }
+
+        true
     }
 
     pub(crate) fn optimize(&mut self) {

--- a/crates/ffpipeline/src/pipeline.rs
+++ b/crates/ffpipeline/src/pipeline.rs
@@ -618,10 +618,17 @@ impl Pipeline {
     }
 
     fn needs_hw_device(&self) -> Option<HardwareAccel> {
+        // if we decoded to hw, we need to init hw device
+        if self.initial_state.surface != FrameSurface::System {
+            return self.accel.clone();
+        }
+
+        // if we encode in hw, we need to init hw device
         if self.output_context.video_codec.is_hardware {
             return self.accel.clone();
         }
 
+        // if any filters are hw filters, we need to init hw device
         for filter in &self.filter_chain.filters {
             if let PipelineFilter::Video(video_filter) = filter {
                 match video_filter.required_surface() {


### PR DESCRIPTION
This fixes two bugs that were causing a bunch of test failures for me, mostly on older devices without 10-bit capabilities.

1. Surface transfer would only properly "downgrade" the software frames from 10-bit to 8-bit in preparation for an upload before a filter. Any upload required for an encoder did not perform this downgrade, so 10-bit frames would be uploaded on a system that does not support 10-bit frames. This has been refactored so both upload scenarios are consistent.
2. `-init_hw_device` options were not properly included when only decoding in hw (sw filters, sw encode). This adds an initial surface check to determine whether we need to `-init_hw_device`.