### PR TITLE
feat: add qsv pixel format capability check

### DIFF
--- a/crates/ffpipeline/src/capabilities/qsv/mod.rs
+++ b/crates/ffpipeline/src/capabilities/qsv/mod.rs
@@ -1,4 +1,7 @@
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
+use std::fmt::{Debug, Formatter};
+
+use libvpl_sys::{MFX_FOURCC_NV12, MFX_FOURCC_P010};
 
 use crate::pipeline::{PixelFormat, VideoFormat};
 
@@ -16,21 +19,40 @@ pub(crate) mod stub;
 
 #[derive(Debug, Clone)]
 pub struct QsvCapabilities {
-    pub(crate) supported_decoders: HashSet<(VideoFormat, u8)>, // (format, bit_depth)
-    pub(crate) supported_encoders: HashSet<(VideoFormat, u8)>,
+    pub(crate) supported_decoders: HashMap<VideoFormat, Vec<u8>>,
+    pub(crate) supported_encoders: HashMap<VideoFormat, Vec<u8>>,
+    pub(crate) vpp_pixel_formats: HashSet<QsvPixelFormat>,
+}
+
+#[derive(Clone, PartialEq, Eq, Hash)]
+pub struct QsvPixelFormat(u32);
+
+impl Debug for QsvPixelFormat {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{:?}", String::from_utf8_lossy(&self.0.to_ne_bytes()))
+    }
 }
 
 impl QsvCapabilities {
     pub fn can_decode(&self, format: &VideoFormat, bit_depth: u8) -> bool {
-        self.supported_decoders.contains(&(*format, bit_depth))
+        self.supported_decoders
+            .get(format)
+            .is_some_and(|bit_depths| bit_depths.contains(&bit_depth))
     }
 
     pub fn can_encode(&self, format: &VideoFormat, bit_depth: u8) -> bool {
-        self.supported_encoders.contains(&(*format, bit_depth))
+        self.supported_encoders
+            .get(format)
+            .is_some_and(|bit_depths| bit_depths.contains(&bit_depth))
     }
 
     pub fn vpp_supports_format(&self, pixel_format: &PixelFormat) -> bool {
-        // TODO: actual format probe
-        matches!(pixel_format, PixelFormat::Nv12 | PixelFormat::P010le)
+        let fourcc = match pixel_format {
+            PixelFormat::Nv12 | PixelFormat::Yuv420p => Some(MFX_FOURCC_NV12),
+            PixelFormat::P010le | PixelFormat::Yuv420p10le => Some(MFX_FOURCC_P010),
+            _ => None,
+        };
+
+        fourcc.is_some_and(|c| self.vpp_pixel_formats.contains(&QsvPixelFormat(c)))
     }
 }

--- a/crates/ffpipeline/src/capabilities/qsv/stub.rs
+++ b/crates/ffpipeline/src/capabilities/qsv/stub.rs
@@ -1,4 +1,4 @@
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 
 use crate::capabilities::qsv::QsvCapabilities;
 use crate::error::FFPipelineError;
@@ -6,8 +6,9 @@ use crate::error::FFPipelineError;
 impl QsvCapabilities {
     pub fn probe() -> Result<QsvCapabilities, FFPipelineError> {
         Ok(QsvCapabilities {
-            supported_decoders: HashSet::new(),
-            supported_encoders: HashSet::new(),
+            supported_decoders: HashMap::new(),
+            supported_encoders: HashMap::new(),
+            vpp_pixel_formats: HashSet::new(),
         })
     }
 }

--- a/crates/ffpipeline/src/capabilities/qsv/vpl.rs
+++ b/crates/ffpipeline/src/capabilities/qsv/vpl.rs
@@ -1,19 +1,21 @@
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 
 use libvpl_sys::*;
 
-use crate::capabilities::qsv::QsvCapabilities;
+use crate::capabilities::qsv::{QsvCapabilities, QsvPixelFormat};
 use crate::error::FFPipelineError;
 use crate::pipeline::VideoFormat;
 
 // byte offsets of dec and enc inside mfxImplDescription.
 const IMPL_DESC_DEC_OFFSET: usize = 472;
 const IMPL_DESC_ENC_OFFSET: usize = 504;
+const IMPL_DESC_VPP_OFFSET: usize = 536;
 
 impl QsvCapabilities {
     pub fn probe() -> Result<QsvCapabilities, FFPipelineError> {
-        let mut supported_decoders = HashSet::new();
-        let mut supported_encoders = HashSet::new();
+        let mut supported_decoders: HashMap<VideoFormat, Vec<u8>> = HashMap::new();
+        let mut supported_encoders: HashMap<VideoFormat, Vec<u8>> = HashMap::new();
+        let mut vpp_pixel_formats = HashSet::new();
 
         let vpl = VplLib::load()
             .map_err(|e| FFPipelineError::QsvCapabilitiesError(format!("libvpl not found: {e}")))?;
@@ -51,6 +53,7 @@ impl QsvCapabilities {
                 let base = hdl as *const u8;
                 let dec = &*(base.add(IMPL_DESC_DEC_OFFSET) as *const mfxDecoderDescription);
                 let enc = &*(base.add(IMPL_DESC_ENC_OFFSET) as *const mfxEncoderDescription);
+                let vpp = &*(base.add(IMPL_DESC_VPP_OFFSET) as *const mfxVPPDescription);
 
                 for format in [
                     VideoFormat::Av1,
@@ -72,20 +75,24 @@ impl QsvCapabilities {
                     };
 
                     if decoder_has_codec(dec, codec_id) {
-                        supported_decoders.insert((format, 8u8));
                         if decoder_has_10bit_profile(dec, codec_id) {
-                            supported_decoders.insert((format, 10u8));
+                            supported_decoders.insert(format, vec![8u8, 10u8]);
+                        } else {
+                            supported_decoders.insert(format, vec![8u8]);
                         }
                     }
 
                     let enc_profiles = encoder_profiles(enc, codec_id);
                     if !enc_profiles.is_empty() {
-                        supported_encoders.insert((format, 8u8));
                         if encoder_supports_10bit(&enc_profiles, codec_id) {
-                            supported_encoders.insert((format, 10u8));
+                            supported_encoders.insert(format, vec![8u8, 10u8]);
+                        } else {
+                            supported_encoders.insert(format, vec![8u8]);
                         }
                     }
                 }
+
+                vpp_pixel_formats = walk_filters_for_pixel_formats(vpp);
 
                 (vpl.MFXDispReleaseImplDescription)(loader, hdl);
             }
@@ -96,6 +103,7 @@ impl QsvCapabilities {
         Ok(QsvCapabilities {
             supported_decoders,
             supported_encoders,
+            vpp_pixel_formats,
         })
     }
 }
@@ -175,4 +183,39 @@ fn is_10bit_profile(codec_id: u32, profile: u32) -> bool {
         id if id == MFX_CODEC_AV1 => true,
         _ => false,
     }
+}
+
+fn walk_filters_for_pixel_formats(vpp: &mfxVPPDescription) -> HashSet<QsvPixelFormat> {
+    let mut vpp_pixel_formats = HashSet::new();
+    if vpp.NumFilters == 0 || vpp.Filters.is_null() {
+        return vpp_pixel_formats;
+    }
+
+    for i in 0..vpp.NumFilters as usize {
+        let filter = unsafe { &*vpp.Filters.add(i) };
+        if filter.NumMemTypes == 0 || filter.MemDesc.is_null() {
+            continue;
+        }
+
+        for j in 0..filter.NumMemTypes as usize {
+            let memdesc = unsafe { &*filter.MemDesc.add(j) };
+            if memdesc.NumInFormats == 0 || memdesc.Formats.is_null() {
+                continue;
+            }
+            for k in 0..memdesc.NumInFormats as usize {
+                let fmt = unsafe { &*memdesc.Formats.add(k) };
+                vpp_pixel_formats.insert(QsvPixelFormat(fmt.InFormat));
+                if fmt.NumOutFormat == 0 || fmt.OutFormats.is_null() {
+                    continue;
+                }
+
+                for l in 0..fmt.NumOutFormat as usize {
+                    let out = unsafe { &*fmt.OutFormats.add(l) };
+                    vpp_pixel_formats.insert(QsvPixelFormat(*out));
+                }
+            }
+        }
+    }
+
+    vpp_pixel_formats
 }

--- a/crates/libvpl-sys/src/lib.rs
+++ b/crates/libvpl-sys/src/lib.rs
@@ -40,6 +40,9 @@ pub const MFX_PROFILE_VP9_3: u32 = 3;
 
 // AV1: Main profile supports 8 and 10-bit, so treat any profile as potentially 10-bit capable
 
+pub const MFX_FOURCC_NV12: u32 = u32::from_ne_bytes(*b"NV12");
+pub const MFX_FOURCC_P010: u32 = u32::from_ne_bytes(*b"P010");
+
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub union mfxVariantValue {
@@ -135,6 +138,57 @@ pub struct mfxEncoderDescription_encoder_encprofile {
     pub NumMemTypes: u16,
     // 4 bytes implicit padding
     pub MemDesc: *mut c_void,
+}
+
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct mfxVPPDescription {
+    pub Version: mfxStructVersion,
+    pub reserved: [u16; 7],
+    pub NumFilters: u16,
+    // 6 bytes implicit padding
+    pub Filters: *mut mfxVPPDescription_filter,
+}
+
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct mfxVPPDescription_filter {
+    pub FilterFourCC: u32,
+    pub MaxDelayInFrames: u16,
+    pub reserved: [u16; 7],
+    pub NumMemTypes: u16,
+    // 4 bytes implicit padding
+    pub MemDesc: *mut mfxVPPDescription_filter_memdesc,
+}
+
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct mfxVPPDescription_filter_memdesc {
+    pub MemHandleType: u32,
+    pub Width: mfxRange32U,
+    pub Height: mfxRange32U,
+    pub reserved: [u16; 7],
+    pub NumInFormats: u16,
+    // 4 bytes implicit padding
+    pub Formats: *mut mfxVPPDescription_filter_memdesc_format,
+}
+
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct mfxVPPDescription_filter_memdesc_format {
+    pub InFormat: u32,
+    pub reserved: [u16; 5],
+    pub NumOutFormat: u16,
+    // 4 bytes implicit padding on 64-bit
+    pub OutFormats: *mut u32,
+}
+
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct mfxRange32U {
+    pub Min: u32,
+    pub Max: u32,
+    pub Step: u32,
 }
 
 #[cfg(all(


### PR DESCRIPTION
Walks all filters to get in and out formats, and compiles them all into "supported pixel formats" - the gist is that there may be some machines where P010 is *not* in the list, therefore it should convert to 8-bit before using any hardware filters.

New capability output looks like this on my A380

> QsvCapabilities { supported_decoders: {Av1: [8, 10], Vp8: [8], Vc1: [8], Mpeg2Video: [8], Hevc: [8, 10], H264: [8], Vp9: [8, 10]}, supported_encoders: {H264: [8], Hevc: [8, 10], Av1: [8, 10], Vp9: [8, 10]}, vpp_pixel_formats: {"P010", "BGRP", "Y416", "P016", "NV12", "Y216", "BGR4", "RG10", "AYUV", "YUY2", "RGBP", "RGB4", "Y410", "RGB2", "Y210"} }
