### PR TITLE
refactor: break video filter impl out into traits

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -582,7 +582,6 @@ checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 name = "ffpipeline"
 version = "0.1.0"
 dependencies = [
- "dyn-clone",
  "enum_dispatch",
  "env_logger",
  "libnvidia-sys",

--- a/crates/ffpipeline/Cargo.toml
+++ b/crates/ffpipeline/Cargo.toml
@@ -4,7 +4,6 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-dyn-clone = { workspace = true }
 enum_dispatch = { workspace = true }
 libnvidia-sys = { workspace = true }
 libva-sys = { workspace = true }

--- a/crates/ffpipeline/src/accel/cuda.rs
+++ b/crates/ffpipeline/src/accel/cuda.rs
@@ -6,7 +6,10 @@ use crate::frame_size::FrameSize;
 use crate::hw_accel::HwAccel;
 use crate::pipeline::{FrameState, FrameSurface, PixelFormat, VideoFormat};
 use crate::video_codec::VideoCodec;
-use crate::video_filter::{ForceOriginalAspectRatio, HwVideoFilter, VideoFilter};
+use crate::video_filter::{
+    DeinterlaceFilter, ForceOriginalAspectRatio, PadFilter, ScaleFilter, ToneMapFilter,
+    VideoFilter, VideoFilterOp,
+};
 
 #[derive(Debug, Clone)]
 pub struct Cuda {
@@ -31,40 +34,41 @@ impl HwAccel for Cuda {
         _current_state: &FrameState,
     ) -> VideoFilter {
         match video_filter {
-            VideoFilter::Scale {
+            VideoFilter::Scale(ScaleFilter {
                 size,
                 input_is_anamorphic,
                 force_original_aspect_ratio,
-            } if ffmpeg_info.has_video_filter(&KnownVideoFilter::ScaleCuda) => {
-                VideoFilter::Hardware(Box::new(ScaleCuda {
-                    size: size.clone(),
-                    input_is_anamorphic: *input_is_anamorphic,
-                    force_original_aspect_ratio: force_original_aspect_ratio.clone(),
-                }))
+            }) if ffmpeg_info.has_video_filter(&KnownVideoFilter::ScaleCuda) => ScaleCuda {
+                size: size.clone(),
+                input_is_anamorphic: *input_is_anamorphic,
+                force_original_aspect_ratio: force_original_aspect_ratio.clone(),
             }
-            VideoFilter::Pad { size }
+            .into(),
+            VideoFilter::Pad(PadFilter { size })
                 if ffmpeg_info.has_video_filter(&KnownVideoFilter::PadCuda) =>
             {
-                VideoFilter::Hardware(Box::new(PadCuda { size: size.clone() }))
+                PadCuda { size: size.clone() }.into()
             }
-            VideoFilter::ToneMap { algorithm, format } if self.is_vulkan_hdr => {
-                VideoFilter::Hardware(Box::new(Libplacebo {
+            VideoFilter::ToneMap(ToneMapFilter { algorithm, format }) if self.is_vulkan_hdr => {
+                LibplaceboCuda {
                     algorithm: algorithm.clone(),
                     format: match format {
                         PixelFormat::Yuv420p10le => PixelFormat::P010le,
                         _ => PixelFormat::Nv12,
                     },
-                }))
+                }
+                .into()
             }
-            VideoFilter::Deinterlace { .. } => {
+            VideoFilter::Deinterlace(DeinterlaceFilter { .. }) => {
                 let best_cuda_filter = ffmpeg_info
                     .find_best_fit(&[KnownVideoFilter::YadifCuda, KnownVideoFilter::BwdifCuda])
                     .and_then(|known_filter| CudaDeinterlaceFilter::try_from(known_filter).ok());
 
                 if let Some(best_cuda_filter) = best_cuda_filter {
-                    return VideoFilter::Hardware(Box::new(DeinterlaceCuda {
+                    return DeinterlaceCuda {
                         filter: best_cuda_filter,
-                    }));
+                    }
+                    .into();
                 }
 
                 video_filter.clone()
@@ -144,9 +148,7 @@ impl HwAccel for Cuda {
         if self.is_vulkan_hdr {
             Vec::new()
         } else {
-            vec![PipelineFilter::Video(VideoFilter::Hardware(Box::new(
-                HwUploadCudaWorkaround,
-            )))]
+            vec![PipelineFilter::Video(HwUploadCudaWorkaround.into())]
         }
     }
 
@@ -163,9 +165,12 @@ impl HwAccel for Cuda {
     }
 
     fn format_filter(&self, pixel_format: &PixelFormat) -> Option<VideoFilter> {
-        Some(VideoFilter::Hardware(Box::new(FormatCuda {
-            format: pixel_format.clone(),
-        })))
+        Some(
+            FormatCuda {
+                format: pixel_format.clone(),
+            }
+            .into(),
+        )
     }
 
     fn initialize(&self, ffmpeg_info: &FfmpegInfo, is_hdr: bool) -> Self {
@@ -197,15 +202,14 @@ impl HwAccel for Cuda {
 }
 
 #[derive(Clone)]
-struct ScaleCuda {
-    size: Option<FrameSize>,
-    input_is_anamorphic: bool,
-    force_original_aspect_ratio: Option<ForceOriginalAspectRatio>,
+pub struct ScaleCuda {
+    pub(crate) size: Option<FrameSize>,
+    pub(crate) input_is_anamorphic: bool,
+    pub(crate) force_original_aspect_ratio: Option<ForceOriginalAspectRatio>,
 }
 
-impl HwVideoFilter for ScaleCuda {
-    fn evaluate(&self, _state: &FrameState) -> Option<VideoFilter> {
-        // called before this is used
+impl VideoFilterOp for ScaleCuda {
+    fn evaluate(&self, _state: &FrameState, _ffmpeg_info: &FfmpegInfo) -> Option<VideoFilter> {
         None
     }
 
@@ -219,8 +223,8 @@ impl HwVideoFilter for ScaleCuda {
         }
     }
 
-    fn required_surface(&self) -> FrameSurface {
-        FrameSurface::Cuda
+    fn required_surface(&self) -> Option<FrameSurface> {
+        Some(FrameSurface::Cuda)
     }
 
     fn as_arg(&self) -> Option<String> {
@@ -248,13 +252,12 @@ impl HwVideoFilter for ScaleCuda {
 }
 
 #[derive(Clone)]
-struct PadCuda {
-    size: Option<FrameSize>,
+pub struct PadCuda {
+    pub(crate) size: Option<FrameSize>,
 }
 
-impl HwVideoFilter for PadCuda {
-    fn evaluate(&self, _state: &FrameState) -> Option<VideoFilter> {
-        // called before this is used
+impl VideoFilterOp for PadCuda {
+    fn evaluate(&self, _state: &FrameState, _ffmpeg_info: &FfmpegInfo) -> Option<VideoFilter> {
         None
     }
 
@@ -265,8 +268,8 @@ impl HwVideoFilter for PadCuda {
         }
     }
 
-    fn required_surface(&self) -> FrameSurface {
-        FrameSurface::Cuda
+    fn required_surface(&self) -> Option<FrameSurface> {
+        Some(FrameSurface::Cuda)
     }
 
     fn as_arg(&self) -> Option<String> {
@@ -280,13 +283,12 @@ impl HwVideoFilter for PadCuda {
 }
 
 #[derive(Clone)]
-struct FormatCuda {
-    format: PixelFormat,
+pub struct FormatCuda {
+    pub(crate) format: PixelFormat,
 }
 
-impl HwVideoFilter for FormatCuda {
-    fn evaluate(&self, _state: &FrameState) -> Option<VideoFilter> {
-        // called before this is used
+impl VideoFilterOp for FormatCuda {
+    fn evaluate(&self, _state: &FrameState, _ffmpeg_info: &FfmpegInfo) -> Option<VideoFilter> {
         None
     }
 
@@ -295,8 +297,8 @@ impl HwVideoFilter for FormatCuda {
         state.surface = FrameSurface::Cuda;
     }
 
-    fn required_surface(&self) -> FrameSurface {
-        FrameSurface::Cuda
+    fn required_surface(&self) -> Option<FrameSurface> {
+        Some(FrameSurface::Cuda)
     }
 
     fn as_arg(&self) -> Option<String> {
@@ -305,21 +307,21 @@ impl HwVideoFilter for FormatCuda {
 }
 
 #[derive(Clone)]
-struct HwUploadCudaWorkaround;
+pub struct HwUploadCudaWorkaround;
 
-impl HwVideoFilter for HwUploadCudaWorkaround {
-    fn evaluate(&self, _state: &FrameState) -> Option<VideoFilter> {
+impl VideoFilterOp for HwUploadCudaWorkaround {
+    fn evaluate(&self, _state: &FrameState, _ffmpeg_info: &FfmpegInfo) -> Option<VideoFilter> {
         // we always need to keep this filter
-        Some(VideoFilter::Hardware(Box::new(self.clone())))
+        Some(self.clone().into())
     }
 
     fn apply_to(&self, state: &mut FrameState) {
         state.surface = FrameSurface::Cuda;
     }
 
-    fn required_surface(&self) -> FrameSurface {
+    fn required_surface(&self) -> Option<FrameSurface> {
         // saying cuda because we don't want the pipeline to download before uploading
-        FrameSurface::Cuda
+        Some(FrameSurface::Cuda)
     }
 
     fn as_arg(&self) -> Option<String> {
@@ -328,14 +330,14 @@ impl HwVideoFilter for HwUploadCudaWorkaround {
 }
 
 #[derive(Clone)]
-struct Libplacebo {
-    algorithm: Option<String>,
-    format: PixelFormat,
+pub struct LibplaceboCuda {
+    /// algorithm to use for tonemapping
+    pub(crate) algorithm: Option<String>,
+    pub(crate) format: PixelFormat,
 }
 
-impl HwVideoFilter for Libplacebo {
-    fn evaluate(&self, _state: &FrameState) -> Option<VideoFilter> {
-        // called before this is used
+impl VideoFilterOp for LibplaceboCuda {
+    fn evaluate(&self, _state: &FrameState, _ffmpeg_info: &FfmpegInfo) -> Option<VideoFilter> {
         None
     }
 
@@ -345,8 +347,8 @@ impl HwVideoFilter for Libplacebo {
         state.surface = FrameSurface::Cuda;
     }
 
-    fn required_surface(&self) -> FrameSurface {
-        FrameSurface::Vulkan
+    fn required_surface(&self) -> Option<FrameSurface> {
+        Some(FrameSurface::Vulkan)
     }
 
     fn as_arg(&self) -> Option<String> {
@@ -370,8 +372,8 @@ impl HwVideoFilter for Libplacebo {
 }
 
 #[derive(Clone)]
-struct DeinterlaceCuda {
-    filter: CudaDeinterlaceFilter,
+pub struct DeinterlaceCuda {
+    pub(crate) filter: CudaDeinterlaceFilter,
 }
 
 #[derive(Clone, Copy)]
@@ -391,9 +393,8 @@ impl TryFrom<&KnownVideoFilter> for CudaDeinterlaceFilter {
     }
 }
 
-impl HwVideoFilter for DeinterlaceCuda {
-    fn evaluate(&self, _state: &FrameState) -> Option<VideoFilter> {
-        // called before this is used
+impl VideoFilterOp for DeinterlaceCuda {
+    fn evaluate(&self, _state: &FrameState, _ffmpeg_info: &FfmpegInfo) -> Option<VideoFilter> {
         None
     }
 
@@ -402,8 +403,8 @@ impl HwVideoFilter for DeinterlaceCuda {
         state.surface = FrameSurface::Cuda;
     }
 
-    fn required_surface(&self) -> FrameSurface {
-        FrameSurface::Cuda
+    fn required_surface(&self) -> Option<FrameSurface> {
+        Some(FrameSurface::Cuda)
     }
 
     fn as_arg(&self) -> Option<String> {

--- a/crates/ffpipeline/src/accel/opencl.rs
+++ b/crates/ffpipeline/src/accel/opencl.rs
@@ -1,5 +1,6 @@
+use crate::ffmpeg_info::FfmpegInfo;
 use crate::pipeline::{FrameState, FrameSurface, PixelFormat};
-use crate::video_filter::{HwVideoFilter, VideoFilter};
+use crate::video_filter::{VideoFilter, VideoFilterOp};
 
 #[derive(Clone)]
 pub struct TonemapOpencl {
@@ -12,8 +13,8 @@ pub struct TonemapOpencl {
     pub output_format: PixelFormat,
 }
 
-impl HwVideoFilter for TonemapOpencl {
-    fn evaluate(&self, _state: &FrameState) -> Option<VideoFilter> {
+impl VideoFilterOp for TonemapOpencl {
+    fn evaluate(&self, _state: &FrameState, _ffmpeg_info: &FfmpegInfo) -> Option<VideoFilter> {
         None
     }
 
@@ -23,8 +24,8 @@ impl HwVideoFilter for TonemapOpencl {
         state.surface = FrameSurface::OpenCL;
     }
 
-    fn required_surface(&self) -> FrameSurface {
-        FrameSurface::OpenCL
+    fn required_surface(&self) -> Option<FrameSurface> {
+        Some(FrameSurface::OpenCL)
     }
 
     fn as_arg(&self) -> Option<String> {

--- a/crates/ffpipeline/src/accel/qsv.rs
+++ b/crates/ffpipeline/src/accel/qsv.rs
@@ -5,7 +5,7 @@ use crate::frame_size::FrameSize;
 use crate::hw_accel::HwAccel;
 use crate::pipeline::{FrameState, FrameSurface, PixelFormat, VideoFormat};
 use crate::video_codec::VideoCodec;
-use crate::video_filter::{HwVideoFilter, VideoFilter};
+use crate::video_filter::{ScaleFilter, VideoFilter, VideoFilterOp};
 
 #[derive(Debug, Clone)]
 pub struct Qsv {
@@ -20,14 +20,10 @@ impl HwAccel for Qsv {
         _current_state: &FrameState,
     ) -> VideoFilter {
         match video_filter {
-            VideoFilter::Scale { size, .. }
+            VideoFilter::Scale(ScaleFilter { size, .. })
                 if ffmpeg_info.has_video_filter(&KnownVideoFilter::VppQsv) =>
             {
-                VideoFilter::Hardware(Box::new(ScaleQsv {
-                    size: size.clone(),
-                    //input_is_anamorphic: *input_is_anamorphic,
-                    //force_original_aspect_ratio: force_original_aspect_ratio.clone(),
-                }))
+                ScaleQsv { size: size.clone() }.into()
             }
             _ => video_filter.clone(),
         }
@@ -85,9 +81,12 @@ impl HwAccel for Qsv {
     }
 
     fn format_filter(&self, pixel_format: &PixelFormat) -> Option<VideoFilter> {
-        Some(VideoFilter::Hardware(Box::new(FormatQsv {
-            format: pixel_format.clone(),
-        })))
+        Some(
+            FormatQsv {
+                format: pixel_format.clone(),
+            }
+            .into(),
+        )
     }
 
     fn initialize(&self, _ffmpeg_info: &FfmpegInfo, _is_hdr: bool) -> Self {
@@ -108,13 +107,12 @@ impl HwAccel for Qsv {
 }
 
 #[derive(Clone)]
-struct ScaleQsv {
-    size: Option<FrameSize>,
+pub struct ScaleQsv {
+    pub(crate) size: Option<FrameSize>,
 }
 
-impl HwVideoFilter for ScaleQsv {
-    fn evaluate(&self, _state: &FrameState) -> Option<VideoFilter> {
-        // called before this is used
+impl VideoFilterOp for ScaleQsv {
+    fn evaluate(&self, _state: &FrameState, _ffmpeg_info: &FfmpegInfo) -> Option<VideoFilter> {
         None
     }
 
@@ -126,8 +124,8 @@ impl HwVideoFilter for ScaleQsv {
         }
     }
 
-    fn required_surface(&self) -> FrameSurface {
-        FrameSurface::Qsv
+    fn required_surface(&self) -> Option<FrameSurface> {
+        Some(FrameSurface::Qsv)
     }
 
     fn as_arg(&self) -> Option<String> {
@@ -138,13 +136,12 @@ impl HwVideoFilter for ScaleQsv {
 }
 
 #[derive(Clone)]
-struct FormatQsv {
-    format: PixelFormat,
+pub struct FormatQsv {
+    pub(crate) format: PixelFormat,
 }
 
-impl HwVideoFilter for FormatQsv {
-    fn evaluate(&self, _state: &FrameState) -> Option<VideoFilter> {
-        // called before this is used
+impl VideoFilterOp for FormatQsv {
+    fn evaluate(&self, _state: &FrameState, _ffmpeg_info: &FfmpegInfo) -> Option<VideoFilter> {
         None
     }
 
@@ -153,8 +150,8 @@ impl HwVideoFilter for FormatQsv {
         state.surface = FrameSurface::Qsv;
     }
 
-    fn required_surface(&self) -> FrameSurface {
-        FrameSurface::Qsv
+    fn required_surface(&self) -> Option<FrameSurface> {
+        Some(FrameSurface::Qsv)
     }
 
     fn as_arg(&self) -> Option<String> {

--- a/crates/ffpipeline/src/accel/vaapi.rs
+++ b/crates/ffpipeline/src/accel/vaapi.rs
@@ -8,7 +8,10 @@ use crate::frame_size::FrameSize;
 use crate::hw_accel::HwAccel;
 use crate::pipeline::{FrameState, FrameSurface, PixelFormat, VideoFormat};
 use crate::video_codec::VideoCodec;
-use crate::video_filter::{ForceOriginalAspectRatio, HwVideoFilter, VideoFilter};
+use crate::video_filter::{
+    ForceOriginalAspectRatio, HwMapFilter, PadFilter, ScaleFilter, ToneMapFilter, VideoFilter,
+    VideoFilterOp,
+};
 
 #[derive(Debug, Clone)]
 pub enum VaapiDriver {
@@ -43,40 +46,37 @@ impl HwAccel for Vaapi {
         _current_state: &FrameState,
     ) -> VideoFilter {
         match video_filter {
-            VideoFilter::Scale {
+            VideoFilter::Scale(ScaleFilter {
                 size,
                 input_is_anamorphic,
                 force_original_aspect_ratio,
-            } if ffmpeg_info.has_video_filter(&KnownVideoFilter::ScaleVaapi) => {
-                VideoFilter::Hardware(Box::new(ScaleVaapi {
-                    size: size.clone(),
-                    input_is_anamorphic: *input_is_anamorphic,
-                    force_original_aspect_ratio: force_original_aspect_ratio.clone(),
-                }))
+            }) if ffmpeg_info.has_video_filter(&KnownVideoFilter::ScaleVaapi) => ScaleVaapi {
+                size: size.clone(),
+                input_is_anamorphic: *input_is_anamorphic,
+                force_original_aspect_ratio: force_original_aspect_ratio.clone(),
             }
-            VideoFilter::Pad { size }
+            .into(),
+            VideoFilter::Pad(PadFilter { size })
                 if ffmpeg_info.has_video_filter(&KnownVideoFilter::PadVaapi) =>
             {
-                VideoFilter::Hardware(Box::new(PadVaapi { size: size.clone() }))
+                PadVaapi { size: size.clone() }.into()
             }
 
-            VideoFilter::ToneMap { algorithm, format } => {
+            VideoFilter::ToneMap(ToneMapFilter { algorithm, format }) => {
                 if let Some(hw_filter) = ffmpeg_info.find_best_fit(&[
                     KnownVideoFilter::TonemapOpencl,
                     KnownVideoFilter::TonemapVaapi,
                 ]) {
                     match hw_filter {
-                        KnownVideoFilter::TonemapOpencl => {
-                            VideoFilter::Hardware(Box::new(TonemapOpencl {
-                                algorithm: algorithm.clone(),
-                                output_format: match format.bit_depth() {
-                                    10 => PixelFormat::P010le,
-                                    _ => PixelFormat::Nv12,
-                                },
-                            }))
+                        KnownVideoFilter::TonemapOpencl => TonemapOpencl {
+                            algorithm: algorithm.clone(),
+                            output_format: match format.bit_depth() {
+                                10 => PixelFormat::P010le,
+                                _ => PixelFormat::Nv12,
+                            },
                         }
+                        .into(),
                         // TODO: Implement tonemap vaapi
-                        // KnownVideoFilter::TonemapVaapi => VideoFilter::Hardware(Box::new())
                         _ => video_filter.clone(),
                     }
                 } else {
@@ -173,24 +173,33 @@ impl HwAccel for Vaapi {
 
     fn hw_map_filter(&self, from: &FrameSurface, to: &FrameSurface) -> Option<VideoFilter> {
         match (from, to) {
-            (FrameSurface::Vaapi, FrameSurface::OpenCL) => Some(VideoFilter::HwMap {
-                from_surface: from.clone(),
-                to_surface: to.clone(),
-                reverse: false,
-            }),
-            (FrameSurface::OpenCL, FrameSurface::Vaapi) => Some(VideoFilter::HwMap {
-                from_surface: from.clone(),
-                to_surface: to.clone(),
-                reverse: true,
-            }),
+            (FrameSurface::Vaapi, FrameSurface::OpenCL) => Some(
+                HwMapFilter {
+                    from_surface: from.clone(),
+                    to_surface: to.clone(),
+                    reverse: false,
+                }
+                .into(),
+            ),
+            (FrameSurface::OpenCL, FrameSurface::Vaapi) => Some(
+                HwMapFilter {
+                    from_surface: from.clone(),
+                    to_surface: to.clone(),
+                    reverse: true,
+                }
+                .into(),
+            ),
             _ => None,
         }
     }
 
     fn format_filter(&self, pixel_format: &PixelFormat) -> Option<VideoFilter> {
-        Some(VideoFilter::Hardware(Box::new(FormatVaapi {
-            format: pixel_format.clone(),
-        })))
+        Some(
+            FormatVaapi {
+                format: pixel_format.clone(),
+            }
+            .into(),
+        )
     }
 
     fn initialize(&self, ffmpeg_info: &FfmpegInfo, is_hdr: bool) -> Self {
@@ -233,15 +242,14 @@ impl HwAccel for Vaapi {
 }
 
 #[derive(Clone)]
-struct ScaleVaapi {
-    size: Option<FrameSize>,
-    input_is_anamorphic: bool,
-    force_original_aspect_ratio: Option<ForceOriginalAspectRatio>,
+pub struct ScaleVaapi {
+    pub(crate) size: Option<FrameSize>,
+    pub(crate) input_is_anamorphic: bool,
+    pub(crate) force_original_aspect_ratio: Option<ForceOriginalAspectRatio>,
 }
 
-impl HwVideoFilter for ScaleVaapi {
-    fn evaluate(&self, _state: &FrameState) -> Option<VideoFilter> {
-        // called before this is used
+impl VideoFilterOp for ScaleVaapi {
+    fn evaluate(&self, _state: &FrameState, _ffmpeg_info: &FfmpegInfo) -> Option<VideoFilter> {
         None
     }
 
@@ -255,8 +263,8 @@ impl HwVideoFilter for ScaleVaapi {
         }
     }
 
-    fn required_surface(&self) -> FrameSurface {
-        FrameSurface::Vaapi
+    fn required_surface(&self) -> Option<FrameSurface> {
+        Some(FrameSurface::Vaapi)
     }
 
     fn as_arg(&self) -> Option<String> {
@@ -284,13 +292,12 @@ impl HwVideoFilter for ScaleVaapi {
 }
 
 #[derive(Clone)]
-struct PadVaapi {
-    size: Option<FrameSize>,
+pub struct PadVaapi {
+    pub(crate) size: Option<FrameSize>,
 }
 
-impl HwVideoFilter for PadVaapi {
-    fn evaluate(&self, _state: &FrameState) -> Option<VideoFilter> {
-        // called before this is used
+impl VideoFilterOp for PadVaapi {
+    fn evaluate(&self, _state: &FrameState, _ffmpeg_info: &FfmpegInfo) -> Option<VideoFilter> {
         None
     }
 
@@ -301,8 +308,8 @@ impl HwVideoFilter for PadVaapi {
         }
     }
 
-    fn required_surface(&self) -> FrameSurface {
-        FrameSurface::Vaapi
+    fn required_surface(&self) -> Option<FrameSurface> {
+        Some(FrameSurface::Vaapi)
     }
 
     fn as_arg(&self) -> Option<String> {
@@ -313,13 +320,12 @@ impl HwVideoFilter for PadVaapi {
 }
 
 #[derive(Clone)]
-struct FormatVaapi {
-    format: PixelFormat,
+pub struct FormatVaapi {
+    pub(crate) format: PixelFormat,
 }
 
-impl HwVideoFilter for FormatVaapi {
-    fn evaluate(&self, _state: &FrameState) -> Option<VideoFilter> {
-        // called before this is used
+impl VideoFilterOp for FormatVaapi {
+    fn evaluate(&self, _state: &FrameState, _ffmpeg_info: &FfmpegInfo) -> Option<VideoFilter> {
         None
     }
 
@@ -327,8 +333,8 @@ impl HwVideoFilter for FormatVaapi {
         state.pixel_format = self.format.clone();
     }
 
-    fn required_surface(&self) -> FrameSurface {
-        FrameSurface::Vaapi
+    fn required_surface(&self) -> Option<FrameSurface> {
+        Some(FrameSurface::Vaapi)
     }
 
     fn as_arg(&self) -> Option<String> {

--- a/crates/ffpipeline/src/accel/vulkan.rs
+++ b/crates/ffpipeline/src/accel/vulkan.rs
@@ -4,7 +4,7 @@ use crate::frame_size::FrameSize;
 use crate::hw_accel::HwAccel;
 use crate::pipeline::{FrameState, FrameSurface, PixelFormat, VideoFormat};
 use crate::video_codec::VideoCodec;
-use crate::video_filter::{HwVideoFilter, VideoFilter};
+use crate::video_filter::{ScaleFilter, ToneMapFilter, VideoFilter, VideoFilterOp};
 
 #[derive(Debug, Clone)]
 pub struct Vulkan;
@@ -17,29 +17,30 @@ impl HwAccel for Vulkan {
         current_state: &FrameState,
     ) -> VideoFilter {
         match video_filter {
-            VideoFilter::Scale {
+            VideoFilter::Scale(ScaleFilter {
                 size,
                 input_is_anamorphic,
                 ..
-            } if ffmpeg_info.has_video_filter(&KnownVideoFilter::ScaleVulkan)
+            }) if ffmpeg_info.has_video_filter(&KnownVideoFilter::ScaleVulkan)
                 && current_state.pixel_format.bit_depth() == 8 =>
             {
-                VideoFilter::Hardware(Box::new(ScaleVulkan {
+                ScaleVulkan {
                     size: size.clone(),
                     input_is_anamorphic: *input_is_anamorphic,
-                    //force_original_aspect_ratio: force_original_aspect_ratio.clone(),
-                }))
+                }
+                .into()
             }
-            VideoFilter::ToneMap { algorithm, format }
+            VideoFilter::ToneMap(ToneMapFilter { algorithm, format })
                 if ffmpeg_info.has_video_filter(&KnownVideoFilter::LibPlacebo) =>
             {
-                VideoFilter::Hardware(Box::new(Libplacebo {
+                LibplaceboVulkan {
                     algorithm: algorithm.clone(),
                     format: match format {
                         PixelFormat::Yuv420p10le => PixelFormat::P010le,
                         _ => PixelFormat::Nv12,
                     },
-                }))
+                }
+                .into()
             }
             _ => video_filter.clone(),
         }
@@ -78,9 +79,12 @@ impl HwAccel for Vulkan {
     }
 
     fn format_filter(&self, pixel_format: &PixelFormat) -> Option<VideoFilter> {
-        Some(VideoFilter::Hardware(Box::new(FormatVulkan {
-            format: pixel_format.clone(),
-        })))
+        Some(
+            FormatVulkan {
+                format: pixel_format.clone(),
+            }
+            .into(),
+        )
     }
 
     fn initialize(&self, _ffmpeg_info: &FfmpegInfo, _is_hdr: bool) -> Self {
@@ -97,13 +101,12 @@ impl HwAccel for Vulkan {
 }
 
 #[derive(Clone)]
-struct FormatVulkan {
-    format: PixelFormat,
+pub struct FormatVulkan {
+    pub(crate) format: PixelFormat,
 }
 
-impl HwVideoFilter for FormatVulkan {
-    fn evaluate(&self, _state: &FrameState) -> Option<VideoFilter> {
-        // called before this is used
+impl VideoFilterOp for FormatVulkan {
+    fn evaluate(&self, _state: &FrameState, _ffmpeg_info: &FfmpegInfo) -> Option<VideoFilter> {
         None
     }
 
@@ -111,8 +114,8 @@ impl HwVideoFilter for FormatVulkan {
         state.pixel_format = self.format.clone();
     }
 
-    fn required_surface(&self) -> FrameSurface {
-        FrameSurface::Vulkan
+    fn required_surface(&self) -> Option<FrameSurface> {
+        Some(FrameSurface::Vulkan)
     }
 
     fn as_arg(&self) -> Option<String> {
@@ -121,14 +124,13 @@ impl HwVideoFilter for FormatVulkan {
 }
 
 #[derive(Clone)]
-struct Libplacebo {
-    algorithm: Option<String>,
-    format: PixelFormat,
+pub struct LibplaceboVulkan {
+    pub(crate) algorithm: Option<String>,
+    pub(crate) format: PixelFormat,
 }
 
-impl HwVideoFilter for Libplacebo {
-    fn evaluate(&self, _state: &FrameState) -> Option<VideoFilter> {
-        // called before this is used
+impl VideoFilterOp for LibplaceboVulkan {
+    fn evaluate(&self, _state: &FrameState, _ffmpeg_info: &FfmpegInfo) -> Option<VideoFilter> {
         None
     }
 
@@ -137,8 +139,8 @@ impl HwVideoFilter for Libplacebo {
         state.is_hdr = false;
     }
 
-    fn required_surface(&self) -> FrameSurface {
-        FrameSurface::Vulkan
+    fn required_surface(&self) -> Option<FrameSurface> {
+        Some(FrameSurface::Vulkan)
     }
 
     fn as_arg(&self) -> Option<String> {
@@ -151,15 +153,13 @@ impl HwVideoFilter for Libplacebo {
 }
 
 #[derive(Clone)]
-struct ScaleVulkan {
-    size: Option<FrameSize>,
-    input_is_anamorphic: bool,
-    //force_original_aspect_ratio: Option<ForceOriginalAspectRatio>,
+pub struct ScaleVulkan {
+    pub(crate) size: Option<FrameSize>,
+    pub(crate) input_is_anamorphic: bool,
 }
 
-impl HwVideoFilter for ScaleVulkan {
-    fn evaluate(&self, _state: &FrameState) -> Option<VideoFilter> {
-        // called before this is used
+impl VideoFilterOp for ScaleVulkan {
+    fn evaluate(&self, _state: &FrameState, _ffmpeg_info: &FfmpegInfo) -> Option<VideoFilter> {
         None
     }
 
@@ -173,17 +173,12 @@ impl HwVideoFilter for ScaleVulkan {
         }
     }
 
-    fn required_surface(&self) -> FrameSurface {
-        FrameSurface::Vulkan
+    fn required_surface(&self) -> Option<FrameSurface> {
+        Some(FrameSurface::Vulkan)
     }
 
     fn as_arg(&self) -> Option<String> {
         if let Some(size) = &self.size {
-            // let aspect_ratio = self
-            //     .force_original_aspect_ratio
-            //     .as_ref()
-            //     .map_or(String::new(), |f| f.as_arg());
-            //
             if self.input_is_anamorphic {
                 Some(format!(
                     "scale_vulkan=iw*sar:ih,setsar=1,scale_vulkan={}:{}",

--- a/crates/ffpipeline/src/filter_chain.rs
+++ b/crates/ffpipeline/src/filter_chain.rs
@@ -3,7 +3,9 @@ use crate::audio_filter::AudioFilter;
 use crate::ffmpeg_info::FfmpegInfo;
 use crate::hw_accel::{HardwareAccel, HwAccel};
 use crate::pipeline::{FrameState, FrameSurface, PixelFormat};
-use crate::video_filter::VideoFilter;
+use crate::video_filter::{
+    FormatFilter, HwDownloadFilter, HwUploadFilter, VideoFilter, VideoFilterOp,
+};
 
 #[derive(Clone)]
 pub enum PipelineFilter {
@@ -150,9 +152,10 @@ impl FilterChain {
 
             match (&current_state.surface, accel) {
                 (FrameSurface::System, _) => {
-                    let format = VideoFilter::Format {
+                    let format: VideoFilter = FormatFilter {
                         format: pixel_format.to_owned(),
-                    };
+                    }
+                    .into();
                     format.apply_to(&mut current_state);
                     resolved.push(PipelineFilter::Video(format))
                 }
@@ -183,9 +186,10 @@ impl FilterChain {
                 _ => PixelFormat::Nv12,
             };
 
-            let download = VideoFilter::HwDownload {
+            let download: VideoFilter = HwDownloadFilter {
                 target_pixel_format,
-            };
+            }
+            .into();
             download.apply_to(current_state);
             resolved.push(PipelineFilter::Video(download))
         } else {
@@ -195,10 +199,11 @@ impl FilterChain {
             };
 
             if is_format_supported {
-                let upload = VideoFilter::HwUpload {
+                let upload: VideoFilter = HwUploadFilter {
                     target_surface: required.clone(),
                     source_format: current_state.pixel_format.clone(),
-                };
+                }
+                .into();
                 upload.apply_to(current_state);
                 resolved.push(PipelineFilter::Video(upload));
             } else if current_state.surface == FrameSurface::System {
@@ -208,16 +213,18 @@ impl FilterChain {
                         .is_some_and(|pf| pf.bit_depth() == 8);
 
                 if can_convert_down {
-                    let format = VideoFilter::Format {
+                    let format: VideoFilter = FormatFilter {
                         format: PixelFormat::Nv12,
-                    };
+                    }
+                    .into();
                     format.apply_to(current_state);
                     resolved.push(PipelineFilter::Video(format));
 
-                    let upload = VideoFilter::HwUpload {
+                    let upload: VideoFilter = HwUploadFilter {
                         target_surface: required,
                         source_format: current_state.pixel_format.clone(),
-                    };
+                    }
+                    .into();
                     upload.apply_to(current_state);
                     resolved.push(PipelineFilter::Video(upload));
                 } else {
@@ -241,8 +248,8 @@ impl FilterChain {
         if let Some(tonemap_index) = self
             .filters
             .iter()
-            .position(|f| matches!(f, PipelineFilter::Video(VideoFilter::ToneMap { .. })))
-            && let Some(PipelineFilter::Video(VideoFilter::Scale { .. })) =
+            .position(|f| matches!(f, PipelineFilter::Video(VideoFilter::ToneMap(_))))
+            && let Some(PipelineFilter::Video(VideoFilter::Scale(_))) =
                 self.filters.get(tonemap_index + 1)
         {
             log::debug!("swapping software scale filter before software tonemap filter");
@@ -345,6 +352,7 @@ mod tests {
     use crate::capabilities::vaapi::VaapiCapabilities;
     use crate::frame_size::FrameSize;
     use crate::hw_accel::HardwareAccel;
+    use crate::video_filter::HwMapFilter;
 
     fn vaapi_accel() -> HardwareAccel {
         HardwareAccel::Vaapi(Vaapi {
@@ -381,10 +389,11 @@ mod tests {
         let initial_state = hdr_vaapi_state();
         let ffmpeg_info = FfmpegInfo::default();
 
-        let tonemap = VideoFilter::Hardware(Box::new(TonemapOpencl {
+        let tonemap: VideoFilter = TonemapOpencl {
             algorithm: Some(String::from("hable")),
             output_format: PixelFormat::Nv12,
-        }));
+        }
+        .into();
 
         let mut chain = FilterChain::new(vec![PipelineFilter::Video(tonemap)]);
 
@@ -414,28 +423,28 @@ mod tests {
         assert!(
             matches!(
                 video_filters[0],
-                VideoFilter::HwMap {
+                VideoFilter::HwMap(HwMapFilter {
                     from_surface: FrameSurface::Vaapi,
                     to_surface: FrameSurface::OpenCL,
                     reverse: false
-                }
+                })
             ),
             "first filter should be HwMap from Vaapi to OpenCL"
         );
 
         assert!(
-            matches!(video_filters[1], VideoFilter::Hardware(_)),
-            "second filter should be the tonemap Hardware filter"
+            matches!(video_filters[1], VideoFilter::TonemapOpencl(_)),
+            "second filter should be the tonemap opencl filter"
         );
 
         assert!(
             matches!(
                 video_filters[2],
-                VideoFilter::HwMap {
+                VideoFilter::HwMap(HwMapFilter {
                     from_surface: FrameSurface::OpenCL,
                     to_surface: FrameSurface::Vaapi,
                     reverse: true,
-                }
+                })
             ),
             "third filter should be HwMap from OpenCL back to Vaapi"
         );
@@ -447,10 +456,11 @@ mod tests {
         let initial_state = hdr_vaapi_state();
         let ffmpeg_info = FfmpegInfo::default();
 
-        let tonemap = VideoFilter::Hardware(Box::new(TonemapOpencl {
+        let tonemap: VideoFilter = TonemapOpencl {
             algorithm: Some(String::from("hable")),
             output_format: PixelFormat::Nv12,
-        }));
+        }
+        .into();
 
         let mut chain = FilterChain::new(vec![PipelineFilter::Video(tonemap)]);
 
@@ -494,9 +504,10 @@ mod tests {
         let initial_state = hdr_vaapi_state();
         let ffmpeg_info = FfmpegInfo::default();
 
-        let format_filter = VideoFilter::Format {
+        let format_filter: VideoFilter = FormatFilter {
             format: PixelFormat::Nv12,
-        };
+        }
+        .into();
 
         let mut chain = FilterChain::new(vec![PipelineFilter::Video(format_filter)]);
 
@@ -511,7 +522,7 @@ mod tests {
         let has_hwmap = chain
             .filters
             .iter()
-            .any(|f| matches!(f, PipelineFilter::Video(VideoFilter::HwMap { .. })));
+            .any(|f| matches!(f, PipelineFilter::Video(VideoFilter::HwMap(_))));
 
         assert!(
             !has_hwmap,

--- a/crates/ffpipeline/src/pipeline.rs
+++ b/crates/ffpipeline/src/pipeline.rs
@@ -20,7 +20,10 @@ use crate::output_settings::OutputSettings;
 use crate::probe::{ProbeResultAudioStream, ProbeResultStream, ProbeResultVideoStream};
 use crate::video_codec::VideoCodec;
 use crate::video_decoder::VideoDecoder;
-use crate::video_filter::{SoftwareDeinterlaceFilter, VideoFilter};
+use crate::video_filter::{
+    DeinterlaceFilter, LoopFilter, PadFilter, ScaleFilter, SoftwareDeinterlaceFilter,
+    ToneMapFilter, VideoFilterOp,
+};
 
 pub const KEYFRAME_INTERVAL_SECONDS: u32 = 2;
 pub const SEGMENT_SECONDS: u32 = 4;
@@ -293,28 +296,43 @@ impl Pipeline {
         filters.extend(video_decoder.filters());
 
         filters.extend([
-            PipelineFilter::Video(VideoFilter::Loop {
-                codec: video_stream.codec.to_owned(),
-            }),
-            PipelineFilter::Video(VideoFilter::ToneMap {
-                algorithm: final_output_settings.tonemap_algorithm.clone(),
-                format: match final_output_settings.bit_depth {
-                    Some(10) => PixelFormat::Yuv420p10le,
-                    _ => PixelFormat::Yuv420p,
-                },
-            }),
-            PipelineFilter::Video(VideoFilter::Deinterlace {
-                filter: SoftwareDeinterlaceFilter::Yadif,
-                input_is_interlaced: initial_state.is_interlaced,
-            }),
-            PipelineFilter::Video(VideoFilter::Scale {
-                size: initial_scaled_size,
-                input_is_anamorphic: initial_state.is_anamorphic,
-                force_original_aspect_ratio: None,
-            }),
-            PipelineFilter::Video(VideoFilter::Pad {
-                size: final_output_settings.video_size.to_owned(),
-            }),
+            PipelineFilter::Video(
+                LoopFilter {
+                    codec: video_stream.codec.to_owned(),
+                }
+                .into(),
+            ),
+            PipelineFilter::Video(
+                ToneMapFilter {
+                    algorithm: final_output_settings.tonemap_algorithm.clone(),
+                    format: match final_output_settings.bit_depth {
+                        Some(10) => PixelFormat::Yuv420p10le,
+                        _ => PixelFormat::Yuv420p,
+                    },
+                }
+                .into(),
+            ),
+            PipelineFilter::Video(
+                DeinterlaceFilter {
+                    filter: SoftwareDeinterlaceFilter::Yadif,
+                    input_is_interlaced: initial_state.is_interlaced,
+                }
+                .into(),
+            ),
+            PipelineFilter::Video(
+                ScaleFilter {
+                    size: initial_scaled_size,
+                    input_is_anamorphic: initial_state.is_anamorphic,
+                    force_original_aspect_ratio: None,
+                }
+                .into(),
+            ),
+            PipelineFilter::Video(
+                PadFilter {
+                    size: final_output_settings.video_size.to_owned(),
+                }
+                .into(),
+            ),
         ]);
 
         Ok(Pipeline {

--- a/crates/ffpipeline/src/video_filter.rs
+++ b/crates/ffpipeline/src/video_filter.rs
@@ -1,5 +1,6 @@
-use dyn_clone::DynClone;
+use enum_dispatch::enum_dispatch;
 
+use crate::accel;
 use crate::ffmpeg_info::{FfmpegInfo, KnownVideoFilter};
 use crate::frame_size::FrameSize;
 use crate::pipeline::{FrameState, FrameSurface, PixelFormat};
@@ -30,160 +31,134 @@ pub enum SoftwareDeinterlaceFilter {
     W3fdif,
 }
 
-impl TryFrom<&KnownVideoFilter> for SoftwareDeinterlaceFilter {
-    type Error = String;
-    fn try_from(known_filter: &KnownVideoFilter) -> Result<SoftwareDeinterlaceFilter, Self::Error> {
-        match known_filter {
-            KnownVideoFilter::Bwdif => Ok(SoftwareDeinterlaceFilter::Bwdif),
-            KnownVideoFilter::Yadif => Ok(SoftwareDeinterlaceFilter::Yadif),
-            KnownVideoFilter::W3fdif => Ok(SoftwareDeinterlaceFilter::W3fdif),
-            _ => Err(format!(
-                "Unknown software deinterlace filter: {}",
-                known_filter
-            )),
+#[enum_dispatch]
+pub trait VideoFilterOp {
+    fn evaluate(&self, state: &FrameState, ffmpeg_info: &FfmpegInfo) -> Option<VideoFilter>;
+    fn apply_to(&self, state: &mut FrameState);
+    fn required_surface(&self) -> Option<FrameSurface>;
+    fn as_arg(&self) -> Option<String>;
+}
+
+#[derive(Clone)]
+#[enum_dispatch(VideoFilterOp)]
+pub enum VideoFilter {
+    HwUpload(HwUploadFilter),
+    HwDownload(HwDownloadFilter),
+    Scale(ScaleFilter),
+    Pad(PadFilter),
+    Loop(LoopFilter),
+    Format(FormatFilter),
+    ToneMap(ToneMapFilter),
+    Deinterlace(DeinterlaceFilter),
+    HwMap(HwMapFilter),
+    // CUDA hardware filters
+    ScaleCuda(accel::cuda::ScaleCuda),
+    PadCuda(accel::cuda::PadCuda),
+    FormatCuda(accel::cuda::FormatCuda),
+    HwUploadCudaWorkaround(accel::cuda::HwUploadCudaWorkaround),
+    LibplaceboCuda(accel::cuda::LibplaceboCuda),
+    DeinterlaceCuda(accel::cuda::DeinterlaceCuda),
+    // VAAPI hardware filters
+    ScaleVaapi(accel::vaapi::ScaleVaapi),
+    PadVaapi(accel::vaapi::PadVaapi),
+    FormatVaapi(accel::vaapi::FormatVaapi),
+    // OpenCL hardware filters
+    TonemapOpencl(accel::opencl::TonemapOpencl),
+    // QSV hardware filters
+    ScaleQsv(accel::qsv::ScaleQsv),
+    FormatQsv(accel::qsv::FormatQsv),
+    // Vulkan hardware filters
+    ScaleVulkan(accel::vulkan::ScaleVulkan),
+    FormatVulkan(accel::vulkan::FormatVulkan),
+    LibplaceboVulkan(accel::vulkan::LibplaceboVulkan),
+}
+
+// --- Software filter structs ---
+
+#[derive(Clone)]
+pub struct HwUploadFilter {
+    pub target_surface: FrameSurface,
+    pub source_format: PixelFormat,
+}
+
+impl VideoFilterOp for HwUploadFilter {
+    fn evaluate(&self, _state: &FrameState, _ffmpeg_info: &FfmpegInfo) -> Option<VideoFilter> {
+        None
+    }
+
+    fn apply_to(&self, state: &mut FrameState) {
+        state.surface = self.target_surface.clone();
+        state.pixel_format = match &state.pixel_format {
+            PixelFormat::Yuv420p => PixelFormat::Nv12,
+            PixelFormat::Yuv420p10le => PixelFormat::P010le,
+            other => other.clone(),
+        }
+    }
+
+    fn required_surface(&self) -> Option<FrameSurface> {
+        None
+    }
+
+    fn as_arg(&self) -> Option<String> {
+        let target_format = match self.source_format.bit_depth() {
+            10 => PixelFormat::P010le,
+            _ => PixelFormat::Nv12,
+        };
+
+        let format_filter = if self.source_format == target_format {
+            String::new()
+        } else {
+            format!("format={},", target_format.as_arg())
+        };
+
+        match &self.target_surface {
+            FrameSurface::Cuda => Some(format!("{format_filter}hwupload_cuda")),
+            FrameSurface::Qsv => Some(format!("{format_filter}hwupload=extra_hw_frames=64")),
+            FrameSurface::Vaapi => Some(format!("{format_filter}hwupload")),
+            FrameSurface::Vulkan => Some(format!("{format_filter}hwupload")),
+            _ => None,
         }
     }
 }
 
-pub trait HwVideoFilter: DynClone {
-    /// Evaluates the current state of a video frame and determines the
-    /// appropriate video filter to be applied.
-    ///
-    /// # Parameters
-    /// - `&self`: A reference to the instance of the containing type.
-    /// - `state`: A reference to the current `FrameState` which contains
-    ///   information about the video frame to be evaluated.
-    ///
-    /// # Returns
-    /// - `Option<VideoFilter>`: Returns `Some(VideoFilter)` if a suitable video
-    ///   filter is determined based on the frame state. Returns `None` if no filter
-    ///   is applicable.
-    ///
-    /// # Usage
-    /// This function is designed to analyze the provided `FrameState` to determine
-    /// whether a filter should be applied to the video frame and, if so, what type
-    /// of filter it should be. It returns `None` when no filtering logic is necessary.
-    ///
-    /// # Example
-    /// ```rust,ignore
-    /// let frame_state = FrameState::new(...);
-    /// let filter = hw_filter.evaluate(&frame_state);
-    /// ```
-    fn evaluate(&self, state: &FrameState) -> Option<VideoFilter>;
-    /// Applies the current object's logic or transformations to the given `FrameState` object.
-    ///
-    /// This method modifies the provided `FrameState` in place. Implementations of this function
-    /// define the specific behavior to be applied to the state, such as updating properties,
-    /// performing calculations, or appending data.
-    ///
-    /// # Parameters
-    /// - `state`: A mutable reference to a `FrameState` object that represents the current state
-    ///   of the frame. The function alters this object directly.
-    ///
-    /// # Example
-    /// ```rust,ignore
-    /// let mut frame_state = FrameState::new();
-    /// some_object.apply_to(&mut frame_state);
-    /// // The frame_state is now modified based on the logic of `apply_to`.
-    /// ```
-    ///
-    /// # Note
-    /// This method assumes that the caller has properly instantiated and initialized the
-    /// `FrameState` object before invoking this function.
-    fn apply_to(&self, state: &mut FrameState);
-    /// Returns the `FrameSurface` that is required for the current context.
-    ///
-    /// This method determines and returns the necessary `FrameSurface` that
-    /// corresponds to the operations or rendering tasks associated with the
-    /// object it is called on.
-    ///
-    /// # Returns
-    ///
-    /// * `FrameSurface` - Specifies the type of frame surface that is necessary for this filter's operations
-    ///   to be executed, based on the underlying implementation or hardware requirements.
-    fn required_surface(&self) -> FrameSurface;
-    /// Converts the implementer into an optional `String` representation.
-    ///
-    /// # Returns
-    /// - `Some(String)` if the implementer can be represented as a `String`.
-    /// - `None` if the implementer cannot be converted to a `String`.
-    ///
-    /// # Examples
-    /// ```rust
-    /// struct MyType;
-    ///
-    /// impl MyType {
-    ///     fn as_arg(&self) -> Option<String> {
-    ///         Some("example".to_string())
-    ///     }
-    /// }
-    ///
-    /// let my_obj = MyType;
-    /// assert_eq!(my_obj.as_arg(), Some("example".to_string()));
-    /// ```
-    fn as_arg(&self) -> Option<String>;
+#[derive(Clone)]
+pub struct HwDownloadFilter {
+    pub target_pixel_format: PixelFormat,
 }
 
-dyn_clone::clone_trait_object!(HwVideoFilter);
+impl VideoFilterOp for HwDownloadFilter {
+    fn evaluate(&self, _state: &FrameState, _ffmpeg_info: &FfmpegInfo) -> Option<VideoFilter> {
+        None
+    }
+
+    fn apply_to(&self, state: &mut FrameState) {
+        state.surface = FrameSurface::System;
+        state.pixel_format = self.target_pixel_format.clone();
+    }
+
+    fn required_surface(&self) -> Option<FrameSurface> {
+        None
+    }
+
+    fn as_arg(&self) -> Option<String> {
+        Some(format!(
+            "hwdownload,format={}",
+            self.target_pixel_format.as_arg()
+        ))
+    }
+}
 
 #[derive(Clone)]
-pub enum VideoFilter {
-    HwUpload {
-        target_surface: FrameSurface,
-        source_format: PixelFormat,
-    },
-    HwDownload {
-        target_pixel_format: PixelFormat,
-    },
-    Scale {
-        size: Option<FrameSize>,
-        input_is_anamorphic: bool,
-        force_original_aspect_ratio: Option<ForceOriginalAspectRatio>,
-    },
-    Pad {
-        size: Option<FrameSize>,
-    },
-    Loop {
-        codec: String,
-    },
-    Format {
-        format: PixelFormat,
-    },
-    ToneMap {
-        algorithm: Option<String>,
-        format: PixelFormat,
-    },
-    Deinterlace {
-        filter: SoftwareDeinterlaceFilter,
-        input_is_interlaced: bool,
-    },
-    HwMap {
-        from_surface: FrameSurface,
-        to_surface: FrameSurface,
-        reverse: bool,
-    },
-    Hardware(Box<dyn HwVideoFilter>),
+pub struct ScaleFilter {
+    pub size: Option<FrameSize>,
+    pub input_is_anamorphic: bool,
+    pub force_original_aspect_ratio: Option<ForceOriginalAspectRatio>,
 }
 
-impl VideoFilter {
-    /// Determines whether the filter is needed given the input frame state.
-    pub(crate) fn evaluate(
-        &self,
-        state: &FrameState,
-        ffmpeg_info: &FfmpegInfo,
-    ) -> Option<VideoFilter> {
-        match self {
-            // hardware filters aren't present at the point where this is called
-            VideoFilter::HwUpload { .. } => None,
-            VideoFilter::HwDownload { .. } => None,
-            VideoFilter::HwMap { .. } => None,
-            VideoFilter::Format { .. } => None,
-
-            VideoFilter::Hardware(filter) => filter.evaluate(state),
-
-            VideoFilter::Scale {
-                size: Some(target), ..
-            } => {
+impl VideoFilterOp for ScaleFilter {
+    fn evaluate(&self, state: &FrameState, _ffmpeg_info: &FfmpegInfo) -> Option<VideoFilter> {
+        match &self.size {
+            Some(target) => {
                 if state.size == *target {
                     None
                 } else {
@@ -194,222 +169,250 @@ impl VideoFilter {
                         Some(ForceOriginalAspectRatio::Decrease)
                     };
 
-                    Some(VideoFilter::Scale {
-                        size: Some(actual.clone()),
-                        input_is_anamorphic: state.is_anamorphic,
-                        force_original_aspect_ratio,
-                    })
+                    Some(
+                        ScaleFilter {
+                            size: Some(actual.clone()),
+                            input_is_anamorphic: state.is_anamorphic,
+                            force_original_aspect_ratio,
+                        }
+                        .into(),
+                    )
                 }
             }
-            VideoFilter::Scale { size: None, .. } => None,
-            VideoFilter::Pad { size: Some(target) } => {
-                if state.size == *target {
-                    None
-                } else {
-                    Some(self.clone())
-                }
-            }
-            VideoFilter::Pad { size: None } => None,
-            VideoFilter::Loop { codec } if codec == "png" => Some(self.clone()),
-            VideoFilter::Loop { .. } => None,
-            VideoFilter::ToneMap { .. } => {
-                if !state.is_hdr {
-                    None
-                } else {
-                    Some(self.clone())
-                }
-            }
-            VideoFilter::Deinterlace {
-                input_is_interlaced,
-                ..
-            } => {
-                if *input_is_interlaced {
-                    let best_software_deinterlace_filter = ffmpeg_info
-                        .find_best_fit(&[
-                            KnownVideoFilter::Yadif,
-                            KnownVideoFilter::Bwdif,
-                            KnownVideoFilter::W3fdif,
-                        ])
-                        .and_then(|known_filter| {
-                            SoftwareDeinterlaceFilter::try_from(known_filter).ok()
-                        });
-
-                    if let Some(best_software_deinterlace_filter) = best_software_deinterlace_filter
-                    {
-                        return Some(VideoFilter::Deinterlace {
-                            filter: best_software_deinterlace_filter,
-                            input_is_interlaced: *input_is_interlaced,
-                        });
-                    }
-                }
-
-                None
-            }
+            None => None,
         }
     }
 
-    pub(crate) fn apply_to(&self, state: &mut FrameState) {
-        match self {
-            VideoFilter::HwUpload { target_surface, .. } => {
-                state.surface = target_surface.clone();
-                state.pixel_format = match &state.pixel_format {
-                    PixelFormat::Yuv420p => PixelFormat::Nv12,
-                    PixelFormat::Yuv420p10le => PixelFormat::P010le,
-                    other => other.clone(),
-                }
-            }
-            VideoFilter::HwDownload {
-                target_pixel_format,
-            } => {
-                state.surface = FrameSurface::System;
-                state.pixel_format = target_pixel_format.clone();
-            }
-            VideoFilter::HwMap { to_surface, .. } => {
-                state.surface = to_surface.clone();
-            }
-            VideoFilter::Hardware(hardware_filter) => {
-                hardware_filter.apply_to(state);
-            }
-            VideoFilter::Scale {
-                size: Some(size), ..
-            } => {
-                state.size = size.clone();
-                state.is_anamorphic = false;
-                state.sample_aspect_ratio = Some(String::from("1:1"));
-                state.display_aspect_ratio = None;
-            }
-            VideoFilter::Scale { size: None, .. } => {}
-            VideoFilter::Pad { size: Some(size) } => {
-                state.size = size.clone();
-                state.surface = FrameSurface::System;
-            }
-            VideoFilter::Pad { size: None } => {}
-            VideoFilter::Loop { .. } => {}
-            VideoFilter::Format { format } => {
-                state.pixel_format = format.clone();
-            }
-            VideoFilter::ToneMap { format, .. } => {
-                state.pixel_format = format.clone();
-                state.is_hdr = false;
-            }
-            VideoFilter::Deinterlace { .. } => {
-                state.is_interlaced = false;
-                state.pixel_format = match state.pixel_format.bit_depth() {
-                    10 => PixelFormat::Yuv420p10le,
-                    _ => PixelFormat::Yuv420p,
-                }
-            }
+    fn apply_to(&self, state: &mut FrameState) {
+        if let Some(size) = &self.size {
+            state.size = size.clone();
+            state.is_anamorphic = false;
+            state.sample_aspect_ratio = Some(String::from("1:1"));
+            state.display_aspect_ratio = None;
         }
     }
 
-    pub(crate) fn required_surface(&self) -> Option<FrameSurface> {
-        match self {
-            VideoFilter::HwUpload { .. } => None,
-            VideoFilter::HwDownload { .. } => None,
-            VideoFilter::HwMap { .. } => None,
-            VideoFilter::Hardware(hardware_filter) => Some(hardware_filter.required_surface()),
+    fn required_surface(&self) -> Option<FrameSurface> {
+        Some(FrameSurface::System)
+    }
 
-            VideoFilter::Scale { .. } => Some(FrameSurface::System),
-            VideoFilter::Pad { .. } => Some(FrameSurface::System),
-            VideoFilter::Loop { .. } => Some(FrameSurface::System),
-            VideoFilter::Format { .. } => Some(FrameSurface::System),
-            VideoFilter::ToneMap { .. } => Some(FrameSurface::System),
-            VideoFilter::Deinterlace { .. } => Some(FrameSurface::System),
+    fn as_arg(&self) -> Option<String> {
+        if let Some(size) = &self.size {
+            let aspect_ratio = self
+                .force_original_aspect_ratio
+                .as_ref()
+                .map_or(String::new(), |f| f.as_arg());
+
+            if self.input_is_anamorphic {
+                Some(format!(
+                    "scale=iw*sar:ih,setsar=1,scale={}:{}:flags=fast_bilinear{}",
+                    size.width, size.height, aspect_ratio
+                ))
+            } else {
+                Some(format!(
+                    "scale={}:{}:flags=fast_bilinear{},setsar=1",
+                    size.width, size.height, aspect_ratio
+                ))
+            }
+        } else {
+            None
+        }
+    }
+}
+
+#[derive(Clone)]
+pub struct PadFilter {
+    pub size: Option<FrameSize>,
+}
+
+impl VideoFilterOp for PadFilter {
+    fn evaluate(&self, state: &FrameState, _ffmpeg_info: &FfmpegInfo) -> Option<VideoFilter> {
+        match &self.size {
+            Some(target) if state.size != *target => Some(self.clone().into()),
+            _ => None,
         }
     }
 
-    pub(crate) fn as_arg(&self) -> Option<String> {
-        match self {
-            VideoFilter::HwUpload {
-                target_surface,
-                source_format,
-            } => {
-                let target_format = match source_format.bit_depth() {
-                    10 => PixelFormat::P010le,
-                    _ => PixelFormat::Nv12,
+    fn apply_to(&self, state: &mut FrameState) {
+        if let Some(size) = &self.size {
+            state.size = size.clone();
+            state.surface = FrameSurface::System;
+        }
+    }
+
+    fn required_surface(&self) -> Option<FrameSurface> {
+        Some(FrameSurface::System)
+    }
+
+    fn as_arg(&self) -> Option<String> {
+        self.size
+            .as_ref()
+            .map(|size| format!("pad={}:{}:-1:-1:color=black", size.width, size.height))
+    }
+}
+
+#[derive(Clone)]
+pub struct LoopFilter {
+    pub codec: String,
+}
+
+impl VideoFilterOp for LoopFilter {
+    fn evaluate(&self, _state: &FrameState, _ffmpeg_info: &FfmpegInfo) -> Option<VideoFilter> {
+        if self.codec == "png" {
+            Some(self.clone().into())
+        } else {
+            None
+        }
+    }
+
+    fn apply_to(&self, _state: &mut FrameState) {}
+
+    fn required_surface(&self) -> Option<FrameSurface> {
+        Some(FrameSurface::System)
+    }
+
+    fn as_arg(&self) -> Option<String> {
+        Some(String::from("loop=-1:1"))
+    }
+}
+
+#[derive(Clone)]
+pub struct FormatFilter {
+    pub format: PixelFormat,
+}
+
+impl VideoFilterOp for FormatFilter {
+    fn evaluate(&self, _state: &FrameState, _ffmpeg_info: &FfmpegInfo) -> Option<VideoFilter> {
+        None
+    }
+
+    fn apply_to(&self, state: &mut FrameState) {
+        state.pixel_format = self.format.clone();
+    }
+
+    fn required_surface(&self) -> Option<FrameSurface> {
+        Some(FrameSurface::System)
+    }
+
+    fn as_arg(&self) -> Option<String> {
+        Some(format!("format={}", self.format.as_arg()))
+    }
+}
+
+#[derive(Clone)]
+pub struct ToneMapFilter {
+    pub algorithm: Option<String>,
+    pub format: PixelFormat,
+}
+
+impl VideoFilterOp for ToneMapFilter {
+    fn evaluate(&self, state: &FrameState, _ffmpeg_info: &FfmpegInfo) -> Option<VideoFilter> {
+        if state.is_hdr {
+            Some(self.clone().into())
+        } else {
+            None
+        }
+    }
+
+    fn apply_to(&self, state: &mut FrameState) {
+        state.pixel_format = self.format.clone();
+        state.is_hdr = false;
+    }
+
+    fn required_surface(&self) -> Option<FrameSurface> {
+        Some(FrameSurface::System)
+    }
+
+    fn as_arg(&self) -> Option<String> {
+        Some(format!(
+            "zscale=transfer=linear,tonemap={},zscale=transfer=bt709,format={}",
+            self.algorithm.as_deref().unwrap_or("linear"),
+            self.format.as_arg()
+        ))
+    }
+}
+
+#[derive(Clone)]
+pub struct DeinterlaceFilter {
+    pub filter: SoftwareDeinterlaceFilter,
+    pub input_is_interlaced: bool,
+}
+
+impl VideoFilterOp for DeinterlaceFilter {
+    fn evaluate(&self, _state: &FrameState, ffmpeg_info: &FfmpegInfo) -> Option<VideoFilter> {
+        if self.input_is_interlaced {
+            let best = ffmpeg_info.find_best_fit(&[
+                KnownVideoFilter::Yadif,
+                KnownVideoFilter::Bwdif,
+                KnownVideoFilter::W3fdif,
+            ]);
+
+            if let Some(known_filter) = best {
+                let software_filter = match known_filter {
+                    KnownVideoFilter::Yadif => SoftwareDeinterlaceFilter::Yadif,
+                    KnownVideoFilter::Bwdif => SoftwareDeinterlaceFilter::Bwdif,
+                    KnownVideoFilter::W3fdif => SoftwareDeinterlaceFilter::W3fdif,
+                    _ => return None,
                 };
-
-                let format_filter = if source_format == &target_format {
-                    String::new()
-                } else {
-                    format!("format={},", target_format.as_arg())
-                };
-
-                match target_surface {
-                    // TODO: refactor this into each hwaccel, maybe a hw_upload_filter() fn?
-                    FrameSurface::Cuda => Some(format!("{format_filter}hwupload_cuda")),
-                    FrameSurface::Qsv => {
-                        Some(format!("{format_filter}hwupload=extra_hw_frames=64"))
+                return Some(
+                    DeinterlaceFilter {
+                        filter: software_filter,
+                        input_is_interlaced: self.input_is_interlaced,
                     }
-                    FrameSurface::Vaapi => Some(format!("{format_filter}hwupload")),
-                    FrameSurface::Vulkan => Some(format!("{format_filter}hwupload")),
-                    _ => None,
-                }
+                    .into(),
+                );
             }
-            VideoFilter::HwDownload {
-                target_pixel_format,
-            } => Some(format!(
-                "hwdownload,format={}",
-                target_pixel_format.as_arg()
-            )),
-            VideoFilter::HwMap {
-                to_surface,
-                reverse,
-                ..
-            } => {
-                let reverse_part = if *reverse { ":reverse=1" } else { "" };
-                to_surface
-                    .device_name()
-                    .map(|name| format!("hwmap=derive_device={name}{reverse_part}"))
-            }
-            VideoFilter::Hardware(hardware_filter) => hardware_filter.as_arg(),
-            VideoFilter::Scale {
-                size: Some(size),
-                input_is_anamorphic,
-                force_original_aspect_ratio,
-            } => {
-                let aspect_ratio = force_original_aspect_ratio
-                    .as_ref()
-                    .map_or(String::new(), |f| f.as_arg());
-
-                if *input_is_anamorphic {
-                    Some(format!(
-                        "scale=iw*sar:ih,setsar=1,scale={}:{}:flags=fast_bilinear{}",
-                        size.width, size.height, aspect_ratio
-                    ))
-                } else {
-                    Some(format!(
-                        "scale={}:{}:flags=fast_bilinear{},setsar=1",
-                        size.width, size.height, aspect_ratio
-                    ))
-                }
-            }
-            VideoFilter::Scale { .. } => None,
-            VideoFilter::Pad { size: Some(size) } => Some(format!(
-                "pad={}:{}:-1:-1:color=black",
-                size.width, size.height
-            )),
-            VideoFilter::Pad { .. } => None,
-            VideoFilter::Loop { .. } => Some(String::from("loop=-1:1")),
-            VideoFilter::Format { format } => Some(format!("format={}", format.as_arg())),
-            VideoFilter::ToneMap { algorithm, format } => Some(format!(
-                "zscale=transfer=linear,tonemap={},zscale=transfer=bt709,format={}",
-                algorithm.as_deref().unwrap_or("linear"),
-                format.as_arg()
-            )),
-            VideoFilter::Deinterlace {
-                filter: SoftwareDeinterlaceFilter::Yadif,
-                ..
-            } => Some(String::from("yadif=1")),
-            VideoFilter::Deinterlace {
-                filter: SoftwareDeinterlaceFilter::Bwdif,
-                ..
-            } => Some(String::from("bwdif=1")),
-            VideoFilter::Deinterlace {
-                filter: SoftwareDeinterlaceFilter::W3fdif,
-                ..
-            } => Some(String::from("w3fdif=1")),
         }
+
+        None
+    }
+
+    fn apply_to(&self, state: &mut FrameState) {
+        state.is_interlaced = false;
+        state.pixel_format = match state.pixel_format.bit_depth() {
+            10 => PixelFormat::Yuv420p10le,
+            _ => PixelFormat::Yuv420p,
+        }
+    }
+
+    fn required_surface(&self) -> Option<FrameSurface> {
+        Some(FrameSurface::System)
+    }
+
+    fn as_arg(&self) -> Option<String> {
+        match &self.filter {
+            SoftwareDeinterlaceFilter::Yadif => Some(String::from("yadif=1")),
+            SoftwareDeinterlaceFilter::Bwdif => Some(String::from("bwdif=1")),
+            SoftwareDeinterlaceFilter::W3fdif => Some(String::from("w3fdif=1")),
+        }
+    }
+}
+
+#[derive(Clone)]
+pub struct HwMapFilter {
+    pub from_surface: FrameSurface,
+    pub to_surface: FrameSurface,
+    pub reverse: bool,
+}
+
+impl VideoFilterOp for HwMapFilter {
+    fn evaluate(&self, _state: &FrameState, _ffmpeg_info: &FfmpegInfo) -> Option<VideoFilter> {
+        None
+    }
+
+    fn apply_to(&self, state: &mut FrameState) {
+        state.surface = self.to_surface.clone();
+    }
+
+    fn required_surface(&self) -> Option<FrameSurface> {
+        None
+    }
+
+    fn as_arg(&self) -> Option<String> {
+        let reverse_part = if self.reverse { ":reverse=1" } else { "" };
+        self.to_surface
+            .device_name()
+            .map(|name| format!("hwmap=derive_device={name}{reverse_part}"))
     }
 }
 
@@ -419,11 +422,12 @@ mod tests {
 
     #[test]
     fn hw_map_as_arg_produces_derive_device() {
-        let filter = VideoFilter::HwMap {
+        let filter: VideoFilter = HwMapFilter {
             from_surface: FrameSurface::Vaapi,
             to_surface: FrameSurface::OpenCL,
             reverse: false,
-        };
+        }
+        .into();
         assert_eq!(
             filter.as_arg(),
             Some(String::from("hwmap=derive_device=opencl"))
@@ -432,11 +436,12 @@ mod tests {
 
     #[test]
     fn hw_map_as_arg_reverse_direction() {
-        let filter = VideoFilter::HwMap {
+        let filter: VideoFilter = HwMapFilter {
             from_surface: FrameSurface::OpenCL,
             to_surface: FrameSurface::Vaapi,
             reverse: true,
-        };
+        }
+        .into();
         assert_eq!(
             filter.as_arg(),
             Some(String::from("hwmap=derive_device=vaapi:reverse=1"))
@@ -445,11 +450,12 @@ mod tests {
 
     #[test]
     fn hw_map_as_arg_returns_none_for_system() {
-        let filter = VideoFilter::HwMap {
+        let filter: VideoFilter = HwMapFilter {
             from_surface: FrameSurface::Vaapi,
             to_surface: FrameSurface::System,
             reverse: false,
-        };
+        }
+        .into();
         assert_eq!(filter.as_arg(), None);
     }
 
@@ -469,11 +475,12 @@ mod tests {
             is_hdr: true,
         };
 
-        let filter = VideoFilter::HwMap {
+        let filter: VideoFilter = HwMapFilter {
             from_surface: FrameSurface::Vaapi,
             to_surface: FrameSurface::OpenCL,
             reverse: false,
-        };
+        }
+        .into();
         filter.apply_to(&mut state);
 
         assert_eq!(state.surface, FrameSurface::OpenCL);
@@ -483,11 +490,12 @@ mod tests {
 
     #[test]
     fn hw_map_required_surface_is_none() {
-        let filter = VideoFilter::HwMap {
+        let filter: VideoFilter = HwMapFilter {
             from_surface: FrameSurface::Vaapi,
             to_surface: FrameSurface::OpenCL,
             reverse: false,
-        };
+        }
+        .into();
         assert_eq!(filter.required_surface(), None);
     }
 }


### PR DESCRIPTION
Rather than housing all of the (sometimes complex) logic for video
filters in a single impl that matched over the VideoFilter enum, break
component methods out to traits and have each video filter implement the
trait. When impls for enums become large and veer towards non-trivial
match-case statements, it's more idiomatic to break things out this way.
We may also want to start breaking each of the filters out to individual
files (with local testing)
