### PR TITLE
test: add cuda tests

### DIFF
--- a/crates/ffpipeline/tests/common/mod.rs
+++ b/crates/ffpipeline/tests/common/mod.rs
@@ -33,7 +33,7 @@ pub struct TestCase {
 pub async fn test_env() -> Option<&'static TestEnv> {
     TEST_ENV
         .get_or_init(|| async {
-            env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("error"))
+            env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info"))
                 .is_test(true)
                 .try_init()
                 .ok();
@@ -213,7 +213,7 @@ pub fn build_output(dir: &Path, params: TestOutputParams) -> OutputSettings {
 pub async fn run_ffmpeg_pipeline(ffmpeg: &Path, pipeline: &Pipeline) -> (bool, String) {
     let args = pipeline.args();
     let envs = pipeline.envs();
-    log::debug!("optimized pipeline: {}", args.join(" "));
+    log::info!("optimized pipeline: {}", args.join(" "));
 
     let output = tokio::time::timeout(
         Duration::from_secs(30),

--- a/crates/ffpipeline/tests/cuda.rs
+++ b/crates/ffpipeline/tests/cuda.rs
@@ -1,0 +1,80 @@
+#![cfg(all(
+    any(target_os = "linux", target_os = "windows"),
+    any(target_arch = "x86_64", target_arch = "aarch64")
+))]
+mod common;
+
+use std::str::FromStr;
+
+use common::*;
+use ffpipeline::accel::cuda::Cuda;
+use ffpipeline::capabilities::nvidia::NvidiaCapabilities;
+use ffpipeline::ffmpeg_info::KnownHardwareAccel;
+use ffpipeline::frame_size::FrameSize;
+use ffpipeline::hw_accel::HardwareAccel;
+use ffpipeline::pipeline::{AudioFormat, VideoFormat};
+use rstest::rstest;
+use tokio::sync::OnceCell;
+
+static CUDA_ACCEL: OnceCell<Option<HardwareAccel>> = OnceCell::const_new();
+
+async fn make_cuda_accel() -> Option<&'static HardwareAccel> {
+    CUDA_ACCEL
+        .get_or_init(|| async {
+            let capabilities = NvidiaCapabilities::probe().ok()?;
+            Some(HardwareAccel::Cuda(Cuda::new(capabilities)))
+        })
+        .await
+        .as_ref()
+}
+
+#[rstest]
+#[tokio::test]
+#[ignore]
+async fn pipeline(
+    #[values(
+        "1080p_h264.ts",
+        "720p_h264.ts",
+        "480p_h264.ts",
+        "1080p_hevc_10.ts",
+        "720p_hevc_10.ts",
+        "480p_hevc_10.ts"
+    )]
+    src: &'static str,
+    #[values("1920x1080", "1280x720")] res: FrameSize,
+    #[values(("h264", 8), ("hevc", 8), ("hevc", 10))] vf: (&'static str, u8),
+    #[values("aac", "ac3")] af: AudioFormat,
+) {
+    let (vf_str, bpp) = vf;
+    if let Ok(vf) = VideoFormat::from_str(vf_str) {
+        run_cuda_test_case(TestCase {
+            fixture_name: src,
+            params: TestOutputParams {
+                audio_format: Some(af),
+                video_format: Some(vf),
+                video_size: Some(res.clone()),
+                bit_depth: Some(bpp),
+                ..TestOutputParams::default()
+            },
+            expected_video_codec: vf.to_string(),
+            expected_video_size: res,
+            expected_audio_codec: af.to_string(),
+        })
+        .await;
+    }
+}
+
+async fn run_cuda_test_case(mut test_case: TestCase) {
+    if let Some(env) = test_env().await {
+        if !env.ffmpeg_info.has_hw_accel(&KnownHardwareAccel::Cuda) {
+            panic!("cuda not available in ffmpeg");
+        }
+
+        let Some(accel) = make_cuda_accel().await else {
+            panic!("no usable NVIDIA GPU found");
+        };
+
+        test_case.params.accel = Some(accel.clone());
+        run_test_case(env, test_case).await;
+    }
+}


### PR DESCRIPTION
NOTE: If you have a consumer card, you either need to apply the keylase
patch to run at max parallelism or force to run single-threaded with
--test-threads 1. Enterprise cards should not be subject to the internal
simultaneous limits of dec/enc
