### PR TITLE
fix: use hwupload and init_hw_device for videotoolbox

### DIFF
--- a/crates/ffpipeline/src/accel/video_toolbox.rs
+++ b/crates/ffpipeline/src/accel/video_toolbox.rs
@@ -96,7 +96,7 @@ impl HwAccel for VideoToolbox {
     }
 
     fn init_hw_device(&self) -> ArgVec {
-        Vec::new()
+        args!["-init_hw_device", "videotoolbox"]
     }
 
     fn known_accel(&self) -> &KnownHardwareAccel {

--- a/crates/ffpipeline/src/video_filter.rs
+++ b/crates/ffpipeline/src/video_filter.rs
@@ -126,6 +126,7 @@ impl VideoFilterOp for HwUploadFilter {
             FrameSurface::Qsv => Some(format!("{format_filter}hwupload=extra_hw_frames=64")),
             FrameSurface::Vaapi => Some(format!("{format_filter}hwupload")),
             FrameSurface::Vulkan => Some(format!("{format_filter}hwupload")),
+            FrameSurface::VideoToolbox => Some(format!("{format_filter}hwupload")),
             _ => None,
         }
     }


### PR DESCRIPTION
This fixes playback when software decode attempts to use hardware scale.