### PR TITLE
fix: properly probe certain decoders for videotoolbox

### DIFF
--- a/crates/libvt-sys/src/probe.rs
+++ b/crates/libvt-sys/src/probe.rs
@@ -19,6 +19,7 @@ const ENCODER_LIST_IS_HW_ACCELERATED: &str = "IsHardwareAccelerated";
 
 #[link(name = "VideoToolbox", kind = "framework")]
 unsafe extern "C" {
+    fn VTRegisterSupplementalVideoDecoderIfAvailable(codec_type: u32);
     fn VTIsHardwareDecodeSupported(codec_type: u32) -> u8;
     fn VTCopyVideoEncoderList(
         options: *const core_foundation::base::CFTypeRef,
@@ -28,7 +29,10 @@ unsafe extern "C" {
 
 /// Returns true if the given codec type has hardware decode support.
 pub fn is_hardware_decode_supported(codec_type: u32) -> bool {
-    unsafe { VTIsHardwareDecodeSupported(codec_type) != 0 }
+    unsafe {
+        VTRegisterSupplementalVideoDecoderIfAvailable(codec_type);
+        VTIsHardwareDecodeSupported(codec_type) != 0
+    }
 }
 
 /// Returns the FourCC string for a codec type (e.g. 0x61766331 -> "avc1").

--- a/crates/libvt-sys/src/probe.rs
+++ b/crates/libvt-sys/src/probe.rs
@@ -30,7 +30,9 @@ unsafe extern "C" {
 /// Returns true if the given codec type has hardware decode support.
 pub fn is_hardware_decode_supported(codec_type: u32) -> bool {
     unsafe {
-        VTRegisterSupplementalVideoDecoderIfAvailable(codec_type);
+        if codec_type == kCMVideoCodecType_VP9 || codec_type == kCMVideoCodecType_AV1 {
+            VTRegisterSupplementalVideoDecoderIfAvailable(codec_type);
+        }
         VTIsHardwareDecodeSupported(codec_type) != 0
     }
 }


### PR DESCRIPTION
This fixes VP9 decode detection on my 2018 MBP.

Before this change:

```bash
% cargo test --quiet -p libvt-sys -- --ignored --nocapture

running 1 test

=== VideoToolbox Hardware Decode Support ===
  H.264    (0x61766331): YES
  HEVC     (0x68766331): YES
  VP9      (0x76703039): no
  AV1      (0x61763031): no
```

After this change:

```bash
% cargo test --quiet -p libvt-sys -- --ignored --nocapture

running 1 test

=== VideoToolbox Hardware Decode Support ===
  H.264    (0x61766331): YES
  HEVC     (0x68766331): YES
  VP9      (0x76703039): YES
  AV1      (0x61763031): no
```