### PR TITLE
feat: probe opencl capabilities

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -617,6 +617,7 @@ dependencies = [
  "derive_more",
  "enum_dispatch",
  "env_logger",
+ "libcl-sys",
  "libnvidia-sys",
  "libva-sys",
  "libvpl-sys",
@@ -1144,6 +1145,13 @@ name = "libc"
 version = "0.2.185"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
+
+[[package]]
+name = "libcl-sys"
+version = "0.1.0"
+dependencies = [
+ "libloading",
+]
 
 [[package]]
 name = "libloading"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ members = [
     "crates/ersatztv-playout",
     "crates/ersatztv-playout-generator",
     "crates/ffpipeline",
+    "crates/libcl-sys",
     "crates/libnvidia-sys",
     "crates/libva-sys",
     "crates/libvpl-sys",
@@ -25,6 +26,7 @@ ersatztv-playout = { path = "crates/ersatztv-playout" }
 ffpipeline = { path = "crates/ffpipeline" }
 filetime = "0.2"
 libloading = "0.9"
+libcl-sys = { path = "crates/libcl-sys" }
 libnvidia-sys = { path = "crates/libnvidia-sys" }
 libva-sys = { path = "crates/libva-sys" }
 libvpl-sys = { path = "crates/libvpl-sys" }

--- a/crates/ersatztv-channel/src/config.rs
+++ b/crates/ersatztv-channel/src/config.rs
@@ -213,11 +213,16 @@ impl HardwareAccel {
                                     capabilities.vendor()
                                 );
 
+                                let opencl_capabilities =
+                                    ffpipeline::capabilities::opencl::OpenCLCapabilities::probe()
+                                        .unwrap_or_default();
+
                                 Some(ffpipeline::hw_accel::HardwareAccel::Vaapi(
                                     ffpipeline::accel::vaapi::Vaapi {
                                         device: vaapi_device.to_str()?.to_owned(),
                                         driver: vaapi_driver.clone().into(),
                                         capabilities,
+                                        opencl_capabilities,
                                         needs_opencl_device: false,
                                     },
                                 ))

--- a/crates/ffpipeline/Cargo.toml
+++ b/crates/ffpipeline/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2024"
 [dependencies]
 derive_more = { workspace = true }
 enum_dispatch = { workspace = true }
+libcl-sys = { workspace = true }
 libnvidia-sys = { workspace = true }
 libva-sys = { workspace = true }
 libvpl-sys = { workspace = true }

--- a/crates/ffpipeline/src/accel/vaapi.rs
+++ b/crates/ffpipeline/src/accel/vaapi.rs
@@ -1,5 +1,6 @@
 use crate::ArgVec;
 use crate::accel::opencl::TonemapOpencl;
+use crate::capabilities::opencl::OpenCLCapabilities;
 use crate::capabilities::vaapi::VaapiCapabilities;
 use crate::ffmpeg_info::{FfmpegInfo, KnownHardwareAccel, KnownVideoFilter};
 use crate::frame_size::FrameSize;
@@ -26,6 +27,7 @@ pub struct Vaapi {
     pub device: String,
     pub driver: VaapiDriver,
     pub capabilities: VaapiCapabilities,
+    pub opencl_capabilities: OpenCLCapabilities,
     pub needs_opencl_device: bool,
 }
 
@@ -69,10 +71,7 @@ impl HwAccel for Vaapi {
                 };
 
                 let mut tonemap_options = vec![KnownVideoFilter::TonemapVaapi];
-                // Pipeline only supports OpenCL for the iHD driver currently.
-                // In the future, we may want to support OpenCL for Radeon as well, but
-                // we will need to implement proper OpenCL capability detection.
-                if self.driver == VaapiDriver::Ihd {
+                if self.opencl_capabilities.can_tonemap() {
                     // Prepend because OpenCL is preferred.
                     tonemap_options.insert(0, KnownVideoFilter::TonemapOpencl);
                 }
@@ -229,10 +228,11 @@ impl HwAccel for Vaapi {
             device: self.device.clone(),
             driver: self.driver.clone(),
             capabilities: self.capabilities.clone(),
+            opencl_capabilities: self.opencl_capabilities.clone(),
             // Logic is a bit disjoint. It would be better if "best" filter could
             // append state around the pipeline.
             needs_opencl_device: is_hdr
-                && self.driver == VaapiDriver::Ihd
+                && self.opencl_capabilities.can_tonemap()
                 && ffmpeg_info
                     .find_best_fit(&[
                         KnownVideoFilter::TonemapOpencl,

--- a/crates/ffpipeline/src/capabilities/mod.rs
+++ b/crates/ffpipeline/src/capabilities/mod.rs
@@ -1,4 +1,5 @@
 pub mod nvidia;
+pub mod opencl;
 pub mod qsv;
 pub mod vaapi;
 pub mod videotoolbox;

--- a/crates/ffpipeline/src/capabilities/opencl/cl.rs
+++ b/crates/ffpipeline/src/capabilities/opencl/cl.rs
@@ -1,0 +1,59 @@
+use libcl_sys::{CL_DEVICE_TYPE_GPU, CL_SUCCESS, ClLib, cl_platform_id};
+
+use crate::capabilities::opencl::OpenCLCapabilities;
+use crate::error::FFPipelineError;
+
+impl OpenCLCapabilities {
+    pub fn probe() -> Result<OpenCLCapabilities, FFPipelineError> {
+        let cl = ClLib::load().map_err(|e| {
+            FFPipelineError::OpenCLCapabilitiesError(format!("libOpenCL not found: {e}"))
+        })?;
+
+        let (platform_count, gpu_device_count) = get_platform_and_gpu_device_count(cl);
+
+        Ok(OpenCLCapabilities {
+            platform_count,
+            gpu_device_count,
+        })
+    }
+}
+
+fn get_platform_and_gpu_device_count(cl: ClLib) -> (u32, u32) {
+    let mut platform_count: u32 = 0;
+    let mut gpu_device_count: u32 = 0;
+    let mut result: i32;
+
+    // get platform count
+    unsafe {
+        result = (cl.clGetPlatformIDs)(0, std::ptr::null_mut(), &mut platform_count);
+    };
+
+    if result == CL_SUCCESS && platform_count > 0 {
+        let mut platforms: Vec<cl_platform_id> = vec![0 as cl_platform_id; platform_count as usize];
+        // get platforms
+        unsafe {
+            result =
+                (cl.clGetPlatformIDs)(platform_count, platforms.as_mut_ptr(), std::ptr::null_mut());
+        }
+        if result == CL_SUCCESS {
+            for platform in platforms {
+                // get device count
+                unsafe {
+                    let mut count: u32 = 0;
+                    result = (cl.clGetDeviceIDs)(
+                        platform,
+                        CL_DEVICE_TYPE_GPU,
+                        0,
+                        std::ptr::null_mut(),
+                        &mut count,
+                    );
+                    if result == CL_SUCCESS {
+                        gpu_device_count += count;
+                    }
+                }
+            }
+        }
+    }
+
+    (platform_count, gpu_device_count)
+}

--- a/crates/ffpipeline/src/capabilities/opencl/cl.rs
+++ b/crates/ffpipeline/src/capabilities/opencl/cl.rs
@@ -29,7 +29,8 @@ fn get_platform_and_gpu_device_count(cl: ClLib) -> (u32, u32) {
     };
 
     if result == CL_SUCCESS && platform_count > 0 {
-        let mut platforms: Vec<cl_platform_id> = vec![0 as cl_platform_id; platform_count as usize];
+        let mut platforms: Vec<cl_platform_id> =
+            vec![std::ptr::null_mut(); platform_count as usize];
         // get platforms
         unsafe {
             result =

--- a/crates/ffpipeline/src/capabilities/opencl/mod.rs
+++ b/crates/ffpipeline/src/capabilities/opencl/mod.rs
@@ -1,0 +1,23 @@
+#[cfg(all(
+    any(target_os = "linux", target_os = "windows"),
+    any(target_arch = "x86", target_arch = "x86_64")
+))]
+pub(crate) mod cl;
+
+#[cfg(not(all(
+    any(target_os = "linux", target_os = "windows"),
+    any(target_arch = "x86", target_arch = "x86_64")
+)))]
+pub(crate) mod stub;
+
+#[derive(Debug, Clone, Default)]
+pub struct OpenCLCapabilities {
+    pub(crate) platform_count: u32,
+    pub(crate) gpu_device_count: u32,
+}
+
+impl OpenCLCapabilities {
+    pub fn can_tonemap(&self) -> bool {
+        self.platform_count > 0 && self.gpu_device_count > 0
+    }
+}

--- a/crates/ffpipeline/src/capabilities/opencl/stub.rs
+++ b/crates/ffpipeline/src/capabilities/opencl/stub.rs
@@ -1,0 +1,11 @@
+use crate::capabilities::opencl::OpenCLCapabilities;
+use crate::error::FFPipelineError;
+
+impl OpenCLCapabilities {
+    pub fn probe() -> Result<OpenCLCapabilities, FFPipelineError> {
+        Ok(OpenCLCapabilities {
+            platform_count: 0,
+            gpu_device_count: 0,
+        })
+    }
+}

--- a/crates/ffpipeline/src/error.rs
+++ b/crates/ffpipeline/src/error.rs
@@ -12,12 +12,14 @@ pub enum FFPipelineError {
     AudioInputIsRequired,
     #[error("video input is required")]
     VideoInputIsRequired,
-    #[error("error detecting vaapi capabilities: {0}")]
-    VaapiCapabilitiesError(String),
-    #[error("error detecting qsv capabilities: {0}")]
-    QsvCapabilitiesError(String),
     #[error("error detecting nvidia capabilities: {0}")]
     NvidiaCapabilitiesError(String),
+    #[error("error detecting opencl capabilities: {0}")]
+    OpenCLCapabilitiesError(String),
+    #[error("error detecting qsv capabilities: {0}")]
+    QsvCapabilitiesError(String),
+    #[error("error detecting vaapi capabilities: {0}")]
+    VaapiCapabilitiesError(String),
     #[error("error detecting videotoolbox capabilities: {0}")]
     VideoToolboxCapabilitiesError(String),
 }

--- a/crates/ffpipeline/src/filter_chain.rs
+++ b/crates/ffpipeline/src/filter_chain.rs
@@ -527,7 +527,12 @@ mod tests {
         })
     }
 
-    fn vaapi_accel_with_tonemap(driver: VaapiDriver, hdr_to_sdr: bool, hdr_to_hdr: bool) -> Vaapi {
+    fn vaapi_accel_with_tonemap(
+        driver: VaapiDriver,
+        hdr_to_sdr: bool,
+        hdr_to_hdr: bool,
+        opencl: bool,
+    ) -> Vaapi {
         let mut can_hdr_to_sdr_tonemap = HashSet::new();
         let mut can_hdr_to_hdr_tonemap = HashSet::new();
         if hdr_to_sdr {
@@ -546,7 +551,10 @@ mod tests {
                 can_hdr_to_sdr_tonemap,
                 can_hdr_to_hdr_tonemap,
             },
-            opencl_capabilities: OpenCLCapabilities::default(),
+            opencl_capabilities: OpenCLCapabilities {
+                platform_count: if opencl { 1 } else { 0 },
+                gpu_device_count: if opencl { 1 } else { 0 },
+            },
             needs_opencl_device: false,
         }
     }
@@ -730,7 +738,7 @@ mod tests {
 
     #[test]
     fn best_filter_selects_tonemap_vaapi_for_hdr_to_sdr_when_capable() {
-        let vaapi = vaapi_accel_with_tonemap(VaapiDriver::RadeonSI, true, false);
+        let vaapi = vaapi_accel_with_tonemap(VaapiDriver::RadeonSI, true, false, false);
         let ffmpeg_info = ffmpeg_info_with_filters(&[KnownVideoFilter::TonemapVaapi]);
         let state = hdr_vaapi_state();
 
@@ -755,7 +763,7 @@ mod tests {
 
     #[test]
     fn best_filter_selects_tonemap_vaapi_for_hdr_to_hdr_when_capable() {
-        let vaapi = vaapi_accel_with_tonemap(VaapiDriver::RadeonSI, false, true);
+        let vaapi = vaapi_accel_with_tonemap(VaapiDriver::RadeonSI, false, true, false);
         let ffmpeg_info = ffmpeg_info_with_filters(&[KnownVideoFilter::TonemapVaapi]);
         let state = hdr_vaapi_state();
 
@@ -780,7 +788,7 @@ mod tests {
 
     #[test]
     fn best_filter_falls_back_to_software_tonemap_without_vaapi_capability() {
-        let vaapi = vaapi_accel_with_tonemap(VaapiDriver::RadeonSI, false, false);
+        let vaapi = vaapi_accel_with_tonemap(VaapiDriver::RadeonSI, false, false, false);
         let ffmpeg_info = ffmpeg_info_with_filters(&[KnownVideoFilter::TonemapVaapi]);
         let state = hdr_vaapi_state();
 
@@ -799,8 +807,8 @@ mod tests {
     }
 
     #[test]
-    fn best_filter_prefers_opencl_over_vaapi_on_ihd() {
-        let vaapi = vaapi_accel_with_tonemap(VaapiDriver::Ihd, true, false);
+    fn best_filter_prefers_opencl_over_vaapi_when_available() {
+        let vaapi = vaapi_accel_with_tonemap(VaapiDriver::Ihd, true, false, true);
         let ffmpeg_info = ffmpeg_info_with_filters(&[
             KnownVideoFilter::TonemapOpencl,
             KnownVideoFilter::TonemapVaapi,
@@ -822,8 +830,8 @@ mod tests {
     }
 
     #[test]
-    fn best_filter_uses_vaapi_tonemap_on_ihd_when_opencl_unavailable() {
-        let vaapi = vaapi_accel_with_tonemap(VaapiDriver::Ihd, true, false);
+    fn best_filter_uses_vaapi_tonemap_when_opencl_unavailable() {
+        let vaapi = vaapi_accel_with_tonemap(VaapiDriver::Ihd, true, false, false);
         let ffmpeg_info = ffmpeg_info_with_filters(&[KnownVideoFilter::TonemapVaapi]);
         let state = hdr_vaapi_state();
 
@@ -843,7 +851,7 @@ mod tests {
 
     #[test]
     fn best_filter_falls_back_to_software_when_no_hw_tonemap_filter() {
-        let vaapi = vaapi_accel_with_tonemap(VaapiDriver::RadeonSI, true, true);
+        let vaapi = vaapi_accel_with_tonemap(VaapiDriver::RadeonSI, true, true, false);
         let ffmpeg_info = ffmpeg_info_with_filters(&[]);
         let state = hdr_vaapi_state();
 
@@ -863,7 +871,7 @@ mod tests {
 
     #[test]
     fn best_filter_falls_back_for_non_p010le_input() {
-        let vaapi = vaapi_accel_with_tonemap(VaapiDriver::RadeonSI, true, true);
+        let vaapi = vaapi_accel_with_tonemap(VaapiDriver::RadeonSI, true, true, false);
         let ffmpeg_info = ffmpeg_info_with_filters(&[KnownVideoFilter::TonemapVaapi]);
 
         let mut state = hdr_vaapi_state();
@@ -885,7 +893,7 @@ mod tests {
 
     #[test]
     fn resolve_tonemap_vaapi_does_not_insert_hwmap() {
-        let vaapi = vaapi_accel_with_tonemap(VaapiDriver::RadeonSI, true, false);
+        let vaapi = vaapi_accel_with_tonemap(VaapiDriver::RadeonSI, true, false, false);
         let accel = HardwareAccel::Vaapi(vaapi);
         let ffmpeg_info = ffmpeg_info_with_filters(&[KnownVideoFilter::TonemapVaapi]);
         let initial_state = hdr_vaapi_state();
@@ -931,7 +939,7 @@ mod tests {
 
     #[test]
     fn resolve_and_build_produces_correct_filter_complex_for_vaapi_tonemap() {
-        let vaapi = vaapi_accel_with_tonemap(VaapiDriver::RadeonSI, true, false);
+        let vaapi = vaapi_accel_with_tonemap(VaapiDriver::RadeonSI, true, false, false);
         let accel = HardwareAccel::Vaapi(vaapi);
         let ffmpeg_info = ffmpeg_info_with_filters(&[KnownVideoFilter::TonemapVaapi]);
         let initial_state = hdr_vaapi_state();

--- a/crates/ffpipeline/src/filter_chain.rs
+++ b/crates/ffpipeline/src/filter_chain.rs
@@ -503,6 +503,7 @@ mod tests {
     use super::*;
     use crate::accel::opencl::TonemapOpencl;
     use crate::accel::vaapi::{TonemapVaapi, Vaapi, VaapiDriver};
+    use crate::capabilities::opencl::OpenCLCapabilities;
     use crate::capabilities::vaapi::VaapiCapabilities;
     use crate::ffmpeg_info::KnownVideoFilter;
     use crate::frame_size::FrameSize;
@@ -521,6 +522,7 @@ mod tests {
                 can_hdr_to_sdr_tonemap: HashSet::new(),
                 can_hdr_to_hdr_tonemap: HashSet::new(),
             },
+            opencl_capabilities: OpenCLCapabilities::default(),
             needs_opencl_device: true,
         })
     }
@@ -544,6 +546,7 @@ mod tests {
                 can_hdr_to_sdr_tonemap,
                 can_hdr_to_hdr_tonemap,
             },
+            opencl_capabilities: OpenCLCapabilities::default(),
             needs_opencl_device: false,
         }
     }

--- a/crates/ffpipeline/tests/vaapi.rs
+++ b/crates/ffpipeline/tests/vaapi.rs
@@ -6,6 +6,7 @@ use std::str::FromStr;
 
 use common::*;
 use ffpipeline::accel::vaapi::{Vaapi, VaapiDriver};
+use ffpipeline::capabilities::opencl::OpenCLCapabilities;
 use ffpipeline::capabilities::vaapi::VaapiCapabilities;
 use ffpipeline::ffmpeg_info::KnownHardwareAccel;
 use ffpipeline::frame_size::FrameSize;
@@ -36,20 +37,22 @@ fn find_vaapi_driver() -> Option<VaapiDriver> {
     None
 }
 
-fn probe_vaapi() -> Option<(String, VaapiDriver, VaapiCapabilities)> {
+fn probe_vaapi() -> Option<(String, VaapiDriver, VaapiCapabilities, OpenCLCapabilities)> {
     let device = find_vaapi_device()?;
     let device_str = device.to_str()?;
 
     if let Some(driver) = find_vaapi_driver() {
         let caps = VaapiCapabilities::probe(device_str, &driver.to_string()).ok()?;
-        return Some((device_str.to_owned(), driver, caps));
+        let opencl_caps = OpenCLCapabilities::probe().unwrap_or_default();
+        return Some((device_str.to_owned(), driver, caps, opencl_caps));
     }
 
     for driver in [VaapiDriver::Ihd, VaapiDriver::I965, VaapiDriver::RadeonSI] {
         if let Ok(caps) = VaapiCapabilities::probe(device_str, &driver.to_string())
             && caps.count() > 0
         {
-            return Some((device_str.to_owned(), driver, caps));
+            let opencl_caps = OpenCLCapabilities::probe().unwrap_or_default();
+            return Some((device_str.to_owned(), driver, caps, opencl_caps));
         }
     }
 
@@ -59,11 +62,12 @@ fn probe_vaapi() -> Option<(String, VaapiDriver, VaapiCapabilities)> {
 async fn make_vaapi_accel() -> Option<&'static HardwareAccel> {
     VAAPI_ACCEL
         .get_or_init(|| async {
-            let (device, driver, capabilities) = probe_vaapi()?;
+            let (device, driver, capabilities, opencl_capabilities) = probe_vaapi()?;
             Some(HardwareAccel::Vaapi(Vaapi {
                 device,
                 driver,
                 capabilities,
+                opencl_capabilities,
                 needs_opencl_device: false,
             }))
         })

--- a/crates/libcl-sys/Cargo.toml
+++ b/crates/libcl-sys/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "libcl-sys"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+libloading = { workspace = true }

--- a/crates/libcl-sys/src/ffi.rs
+++ b/crates/libcl-sys/src/ffi.rs
@@ -1,0 +1,155 @@
+#![allow(non_camel_case_types)]
+#![allow(non_snake_case)]
+
+use std::ffi::c_void;
+
+use libloading::Library;
+
+pub enum _cl_platform_id {}
+pub type cl_platform_id = *mut _cl_platform_id;
+
+pub type cl_platform_info = u32;
+
+pub enum _cl_device_id {}
+pub type cl_device_id = *mut _cl_device_id;
+pub type cl_device_type = u64;
+
+pub const CL_SUCCESS: i32 = 0;
+pub const CL_PLATFORM_NAME: cl_platform_info = 0x0902;
+pub const CL_DEVICE_TYPE_ALL: cl_device_type = 0xFFFFFFFF;
+pub const CL_DEVICE_TYPE_GPU: cl_device_type = 1 << 2;
+
+pub struct ClLib {
+    _lib: Library,
+    pub clGetPlatformIDs: unsafe extern "C" fn(u32, *mut cl_platform_id, *mut u32) -> i32,
+    pub clGetPlatformInfo: unsafe extern "C" fn(
+        cl_platform_id,
+        cl_platform_info,
+        usize,
+        *mut c_void,
+        *mut usize,
+    ) -> i32,
+    pub clGetDeviceIDs: unsafe extern "C" fn(
+        cl_platform_id,
+        cl_device_type,
+        u32,
+        *mut cl_device_id,
+        *mut u32,
+    ) -> i32,
+}
+
+impl ClLib {
+    pub fn load() -> Result<Self, libloading::Error> {
+        #[cfg(target_os = "linux")]
+        let name = "libOpenCL.so";
+        #[cfg(target_os = "windows")]
+        let name = "OpenCL.dll";
+        unsafe {
+            let lib = Library::new(name)?;
+            let clGetPlatformIDs = *lib.get(b"clGetPlatformIDs\0")?;
+            let clGetPlatformInfo = *lib.get(b"clGetPlatformInfo\0")?;
+            let clGetDeviceIDs = *lib.get(b"clGetDeviceIDs\0")?;
+            Ok(Self {
+                _lib: lib,
+                clGetPlatformIDs,
+                clGetPlatformInfo,
+                clGetDeviceIDs,
+            })
+        }
+    }
+}
+
+#[cfg(all(
+    any(target_os = "linux", target_os = "windows"),
+    any(target_arch = "x86", target_arch = "x86_64")
+))]
+#[cfg(test)]
+mod tests {
+    use std::ffi::{CStr, c_char};
+
+    use super::*;
+
+    #[test]
+    #[ignore]
+    fn get_platforms() {
+        let cl_load = ClLib::load();
+        match cl_load {
+            Ok(cl) => {
+                let mut platform_count: u32 = 0;
+                unsafe {
+                    let result =
+                        (cl.clGetPlatformIDs)(0, std::ptr::null_mut(), &mut platform_count);
+                    assert_eq!(result, CL_SUCCESS);
+                };
+
+                println!("platform count: {platform_count}");
+
+                if platform_count > 0 {
+                    let mut platforms: Vec<cl_platform_id> =
+                        vec![0 as cl_platform_id; platform_count as usize];
+                    unsafe {
+                        let result = (cl.clGetPlatformIDs)(
+                            platform_count,
+                            platforms.as_mut_ptr(),
+                            std::ptr::null_mut(),
+                        );
+                        assert_eq!(result, CL_SUCCESS);
+                    }
+
+                    for platform in platforms {
+                        let mut info_size: usize = 0;
+                        unsafe {
+                            let result = (cl.clGetPlatformInfo)(
+                                platform,
+                                CL_PLATFORM_NAME,
+                                0,
+                                std::ptr::null_mut(),
+                                &mut info_size,
+                            );
+                            assert_eq!(result, CL_SUCCESS);
+                        }
+
+                        println!("info size: {info_size}");
+
+                        let mut info = vec![0 as c_char; info_size];
+                        unsafe {
+                            let result = (cl.clGetPlatformInfo)(
+                                platform,
+                                CL_PLATFORM_NAME,
+                                info_size,
+                                info.as_mut_ptr() as *mut c_void,
+                                std::ptr::null_mut(),
+                            );
+                            assert_eq!(result, CL_SUCCESS);
+                        }
+
+                        let value = unsafe {
+                            CStr::from_ptr(info.as_ptr() as *const c_char)
+                                .to_string_lossy()
+                                .into_owned()
+                        };
+
+                        println!("{value}");
+
+                        let mut count: u32 = 0;
+                        unsafe {
+                            let result = (cl.clGetDeviceIDs)(
+                                platform,
+                                CL_DEVICE_TYPE_GPU,
+                                0,
+                                std::ptr::null_mut(),
+                                &mut count,
+                            );
+                            assert_eq!(result, CL_SUCCESS);
+                        }
+
+                        println!("gpu device count: {count}");
+                    }
+                }
+            }
+            Err(err) => {
+                println!("failed to load OpenCL: {err}");
+            }
+        }
+    }
+}

--- a/crates/libcl-sys/src/ffi.rs
+++ b/crates/libcl-sys/src/ffi.rs
@@ -86,7 +86,7 @@ mod tests {
 
                 if platform_count > 0 {
                     let mut platforms: Vec<cl_platform_id> =
-                        vec![0 as cl_platform_id; platform_count as usize];
+                        vec![std::ptr::null_mut(); platform_count as usize];
                     unsafe {
                         let result = (cl.clGetPlatformIDs)(
                             platform_count,

--- a/crates/libcl-sys/src/lib.rs
+++ b/crates/libcl-sys/src/lib.rs
@@ -1,0 +1,11 @@
+#[cfg(all(
+    any(target_os = "linux", target_os = "windows"),
+    any(target_arch = "x86", target_arch = "x86_64")
+))]
+mod ffi;
+
+#[cfg(all(
+    any(target_os = "linux", target_os = "windows"),
+    any(target_arch = "x86", target_arch = "x86_64")
+))]
+pub use ffi::*;


### PR DESCRIPTION
Resolves #95

Limits `tonemap_opencl` to systems where capabilities detect at least one OpenCL platform and one OpenCL GPU.