### PR TITLE
refactor: build hw accel decode all at once

### DIFF
--- a/crates/ffpipeline/src/accel/cuda.rs
+++ b/crates/ffpipeline/src/accel/cuda.rs
@@ -3,7 +3,7 @@ use crate::capabilities::nvidia::NvidiaCapabilities;
 use crate::ffmpeg_info::{FfmpegInfo, KnownHardwareAccel, KnownVideoFilter};
 use crate::filter_chain::PipelineFilter;
 use crate::frame_size::FrameSize;
-use crate::hw_accel::HwAccel;
+use crate::hw_accel::{HwAccel, HwDecoder};
 use crate::overlay_filter::{OverlayFilter, OverlayKind, OverlayKindOp};
 use crate::pipeline::{FrameState, FrameSurface, PixelFormat, SurfaceSet, VideoFormat};
 use crate::video_codec::VideoCodec;
@@ -15,15 +15,11 @@ use crate::video_filter::{
 #[derive(Debug, Clone)]
 pub struct Cuda {
     pub capabilities: NvidiaCapabilities,
-    is_vulkan_hdr: bool,
 }
 
 impl Cuda {
     pub fn new(capabilities: NvidiaCapabilities) -> Cuda {
-        Cuda {
-            capabilities,
-            is_vulkan_hdr: false,
-        }
+        Cuda { capabilities }
     }
 }
 
@@ -57,14 +53,16 @@ impl HwAccel for Cuda {
             VideoFilter::ToneMap(ToneMapFilter {
                 algorithm,
                 output_format: format,
-            }) if self.is_vulkan_hdr => LibplaceboCuda {
-                algorithm: algorithm.clone(),
-                format: match format {
-                    PixelFormat::Yuv420p10le => PixelFormat::P010le,
-                    _ => PixelFormat::Nv12,
-                },
+            }) if current_state.is_hdr && current_state.surface == FrameSurface::Vulkan => {
+                LibplaceboCuda {
+                    algorithm: algorithm.clone(),
+                    format: match format {
+                        PixelFormat::Yuv420p10le => PixelFormat::P010le,
+                        _ => PixelFormat::Nv12,
+                    },
+                }
+                .into()
             }
-            .into(),
             VideoFilter::Deinterlace(DeinterlaceFilter { .. }) => {
                 let best_cuda_filter = ffmpeg_info
                     .find_best_fit(&[KnownVideoFilter::YadifCuda, KnownVideoFilter::BwdifCuda])
@@ -154,43 +152,6 @@ impl HwAccel for Cuda {
         }
     }
 
-    fn decoder_arg(&self) -> ArgVec {
-        log::debug!("decoder arg, is_hdr: {}", self.is_vulkan_hdr);
-
-        if self.is_vulkan_hdr {
-            args![
-                "-hwaccel",
-                KnownHardwareAccel::Vulkan,
-                "-hwaccel_output_format",
-                KnownHardwareAccel::Vulkan,
-            ]
-        } else {
-            args![
-                "-hwaccel",
-                KnownHardwareAccel::Cuda,
-                "-hwaccel_output_format",
-                KnownHardwareAccel::Cuda,
-            ]
-        }
-    }
-
-    fn decoder_filters(&self) -> Vec<PipelineFilter> {
-        // can't work around fallback to software decode with HDR
-        if self.is_vulkan_hdr {
-            Vec::new()
-        } else {
-            vec![PipelineFilter::Video(HwUploadCudaWorkaround.into())]
-        }
-    }
-
-    fn decoder_frame_surface(&self) -> FrameSurface {
-        if self.is_vulkan_hdr {
-            FrameSurface::Vulkan
-        } else {
-            FrameSurface::Cuda
-        }
-    }
-
     fn format_filter(&self, pixel_format: &PixelFormat) -> Option<VideoFilter> {
         Some(
             FormatCuda {
@@ -198,15 +159,6 @@ impl HwAccel for Cuda {
             }
             .into(),
         )
-    }
-
-    fn initialize(&self, ffmpeg_info: &FfmpegInfo, is_hdr: bool) -> Self {
-        Cuda {
-            capabilities: self.capabilities.clone(),
-            is_vulkan_hdr: is_hdr
-                && ffmpeg_info.has_hw_accel(&KnownHardwareAccel::Vulkan)
-                && ffmpeg_info.has_video_filter(&KnownVideoFilter::LibPlacebo),
-        }
     }
 
     fn init_hw_device(&self, surfaces: &SurfaceSet) -> ArgVec {
@@ -224,6 +176,37 @@ impl HwAccel for Cuda {
 
     fn known_accel(&self) -> &KnownHardwareAccel {
         &KnownHardwareAccel::Cuda
+    }
+
+    fn make_decoder(&self, ffmpeg_info: &FfmpegInfo, is_hdr: bool) -> HwDecoder {
+        let is_vulkan_hdr = is_hdr
+            && ffmpeg_info.has_hw_accel(&KnownHardwareAccel::Vulkan)
+            && ffmpeg_info.has_video_filter(&KnownVideoFilter::LibPlacebo);
+
+        if is_vulkan_hdr {
+            HwDecoder {
+                args: args![
+                    "-hwaccel",
+                    KnownHardwareAccel::Vulkan,
+                    "-hwaccel_output_format",
+                    KnownHardwareAccel::Vulkan,
+                ],
+                surface: FrameSurface::Vulkan,
+                // can't work around fallback to software decode with HDR
+                filters: Vec::new(),
+            }
+        } else {
+            HwDecoder {
+                args: args![
+                    "-hwaccel",
+                    KnownHardwareAccel::Cuda,
+                    "-hwaccel_output_format",
+                    KnownHardwareAccel::Cuda,
+                ],
+                surface: FrameSurface::Cuda,
+                filters: vec![PipelineFilter::Video(HwUploadCudaWorkaround.into())],
+            }
+        }
     }
 }
 

--- a/crates/ffpipeline/src/accel/qsv.rs
+++ b/crates/ffpipeline/src/accel/qsv.rs
@@ -2,7 +2,7 @@ use crate::ArgVec;
 use crate::capabilities::qsv::QsvCapabilities;
 use crate::ffmpeg_info::{FfmpegInfo, KnownHardwareAccel, KnownVideoFilter};
 use crate::frame_size::FrameSize;
-use crate::hw_accel::HwAccel;
+use crate::hw_accel::{HwAccel, HwDecoder};
 use crate::pipeline::{FrameState, FrameSurface, PixelFormat, SurfaceSet, VideoFormat};
 use crate::video_codec::VideoCodec;
 use crate::video_filter::{DeinterlaceFilter, ScaleFilter, VideoFilter, VideoFilterOp};
@@ -81,14 +81,6 @@ impl HwAccel for Qsv {
         }
     }
 
-    fn decoder_arg(&self) -> ArgVec {
-        args!["-hwaccel", "qsv", "-hwaccel_output_format", "qsv",]
-    }
-
-    fn decoder_frame_surface(&self) -> FrameSurface {
-        FrameSurface::Qsv
-    }
-
     fn format_filter(&self, pixel_format: &PixelFormat) -> Option<VideoFilter> {
         Some(
             FormatQsv {
@@ -98,16 +90,20 @@ impl HwAccel for Qsv {
         )
     }
 
-    fn initialize(&self, _ffmpeg_info: &FfmpegInfo, _is_hdr: bool) -> Self {
-        self.clone()
-    }
-
     fn init_hw_device(&self, _surfaces: &SurfaceSet) -> ArgVec {
         args!["-init_hw_device", "qsv=hw", "-filter_hw_device", "hw",]
     }
 
     fn known_accel(&self) -> &KnownHardwareAccel {
         &KnownHardwareAccel::Qsv
+    }
+
+    fn make_decoder(&self, _ffmpeg_info: &FfmpegInfo, _is_hdr: bool) -> HwDecoder {
+        HwDecoder {
+            args: args!["-hwaccel", "qsv", "-hwaccel_output_format", "qsv",],
+            surface: FrameSurface::Qsv,
+            filters: Vec::new(),
+        }
     }
 
     fn supports_pixel_format(&self, pixel_format: &PixelFormat) -> bool {

--- a/crates/ffpipeline/src/accel/vaapi.rs
+++ b/crates/ffpipeline/src/accel/vaapi.rs
@@ -4,7 +4,7 @@ use crate::capabilities::opencl::OpenCLCapabilities;
 use crate::capabilities::vaapi::VaapiCapabilities;
 use crate::ffmpeg_info::{FfmpegInfo, KnownHardwareAccel, KnownVideoFilter};
 use crate::frame_size::FrameSize;
-use crate::hw_accel::HwAccel;
+use crate::hw_accel::{HwAccel, HwDecoder};
 use crate::pipeline::{
     FrameState, FrameSurface, HwPixelFormat, PixelFormat, SurfaceSet, VideoFormat,
 };
@@ -165,21 +165,17 @@ impl HwAccel for Vaapi {
         }
     }
 
-    fn decoder_arg(&self) -> ArgVec {
-        args![
-            "-hwaccel",
-            KnownHardwareAccel::Vaapi,
-            "-hwaccel_output_format",
-            KnownHardwareAccel::Vaapi,
-        ]
-    }
-
-    fn decoder_frame_surface(&self) -> FrameSurface {
-        FrameSurface::Vaapi
-    }
-
     fn envs(&self) -> Vec<(String, String)> {
         vec![(String::from("LIBVA_DRIVER_NAME"), self.driver.to_string())]
+    }
+
+    fn format_filter(&self, pixel_format: &PixelFormat) -> Option<VideoFilter> {
+        Some(
+            FormatVaapi {
+                format: *pixel_format,
+            }
+            .into(),
+        )
     }
 
     fn hw_map_filter(&self, from: &FrameSurface, to: &FrameSurface) -> Option<VideoFilter> {
@@ -204,19 +200,6 @@ impl HwAccel for Vaapi {
         }
     }
 
-    fn format_filter(&self, pixel_format: &PixelFormat) -> Option<VideoFilter> {
-        Some(
-            FormatVaapi {
-                format: *pixel_format,
-            }
-            .into(),
-        )
-    }
-
-    fn initialize(&self, _ffmpeg_info: &FfmpegInfo, _is_hdr: bool) -> Self {
-        self.clone()
-    }
-
     fn init_hw_device(&self, surfaces: &SurfaceSet) -> ArgVec {
         if surfaces.contains(&FrameSurface::OpenCL) {
             args![
@@ -234,6 +217,19 @@ impl HwAccel for Vaapi {
 
     fn known_accel(&self) -> &KnownHardwareAccel {
         &KnownHardwareAccel::Vaapi
+    }
+
+    fn make_decoder(&self, _ffmpeg_info: &FfmpegInfo, _is_hdr: bool) -> HwDecoder {
+        HwDecoder {
+            args: args![
+                "-hwaccel",
+                KnownHardwareAccel::Vaapi,
+                "-hwaccel_output_format",
+                KnownHardwareAccel::Vaapi,
+            ],
+            surface: FrameSurface::Vaapi,
+            filters: Vec::new(),
+        }
     }
 
     fn supports_pixel_format(&self, pixel_format: &PixelFormat) -> bool {

--- a/crates/ffpipeline/src/accel/video_toolbox.rs
+++ b/crates/ffpipeline/src/accel/video_toolbox.rs
@@ -2,7 +2,7 @@ use crate::ArgVec;
 use crate::capabilities::videotoolbox::VideoToolboxCapabilities;
 use crate::ffmpeg_info::{FfmpegInfo, KnownHardwareAccel, KnownVideoFilter};
 use crate::frame_size::FrameSize;
-use crate::hw_accel::HwAccel;
+use crate::hw_accel::{HwAccel, HwDecoder};
 use crate::pipeline::{FrameState, FrameSurface, PixelFormat, SurfaceSet, VideoFormat};
 use crate::video_codec::VideoCodec;
 use crate::video_filter::{ScaleFilter, VideoFilter, VideoFilterOp};
@@ -78,29 +78,25 @@ impl HwAccel for VideoToolbox {
         }
     }
 
-    fn decoder_arg(&self) -> ArgVec {
-        args![
-            "-hwaccel",
-            "videotoolbox",
-            "-hwaccel_output_format",
-            "videotoolbox_vld",
-        ]
-    }
-
-    fn decoder_frame_surface(&self) -> FrameSurface {
-        FrameSurface::VideoToolbox
-    }
-
-    fn initialize(&self, _ffmpeg_info: &FfmpegInfo, _is_hdr: bool) -> Self {
-        self.clone()
-    }
-
     fn init_hw_device(&self, _surfaces: &SurfaceSet) -> ArgVec {
         args!["-init_hw_device", "videotoolbox"]
     }
 
     fn known_accel(&self) -> &KnownHardwareAccel {
         &KnownHardwareAccel::VideoToolbox
+    }
+
+    fn make_decoder(&self, _ffmpeg_info: &FfmpegInfo, _is_hdr: bool) -> HwDecoder {
+        HwDecoder {
+            args: args![
+                "-hwaccel",
+                "videotoolbox",
+                "-hwaccel_output_format",
+                "videotoolbox_vld",
+            ],
+            surface: FrameSurface::VideoToolbox,
+            filters: Vec::new(),
+        }
     }
 }
 

--- a/crates/ffpipeline/src/accel/vulkan.rs
+++ b/crates/ffpipeline/src/accel/vulkan.rs
@@ -1,7 +1,7 @@
 use crate::ArgVec;
 use crate::ffmpeg_info::{FfmpegInfo, KnownHardwareAccel, KnownVideoFilter};
 use crate::frame_size::FrameSize;
-use crate::hw_accel::HwAccel;
+use crate::hw_accel::{HwAccel, HwDecoder};
 use crate::pipeline::{FrameState, FrameSurface, PixelFormat, SurfaceSet, VideoFormat};
 use crate::video_codec::VideoCodec;
 use crate::video_filter::{ScaleFilter, ToneMapFilter, VideoFilter, VideoFilterOp};
@@ -69,14 +69,6 @@ impl HwAccel for Vulkan {
         }
     }
 
-    fn decoder_arg(&self) -> ArgVec {
-        args!["-hwaccel", "vulkan", "-hwaccel_output_format", "vulkan",]
-    }
-
-    fn decoder_frame_surface(&self) -> FrameSurface {
-        FrameSurface::Vulkan
-    }
-
     fn format_filter(&self, pixel_format: &PixelFormat) -> Option<VideoFilter> {
         Some(
             FormatVulkan {
@@ -86,16 +78,20 @@ impl HwAccel for Vulkan {
         )
     }
 
-    fn initialize(&self, _ffmpeg_info: &FfmpegInfo, _is_hdr: bool) -> Self {
-        self.clone()
-    }
-
     fn init_hw_device(&self, _surfaces: &SurfaceSet) -> ArgVec {
         args!["-init_hw_device", "vulkan"]
     }
 
     fn known_accel(&self) -> &KnownHardwareAccel {
         &KnownHardwareAccel::Vulkan
+    }
+
+    fn make_decoder(&self, _ffmpeg_info: &FfmpegInfo, _is_hdr: bool) -> HwDecoder {
+        HwDecoder {
+            args: args!["-hwaccel", "vulkan", "-hwaccel_output_format", "vulkan"],
+            surface: FrameSurface::Vulkan,
+            filters: Vec::new(),
+        }
     }
 }
 

--- a/crates/ffpipeline/src/hw_accel.rs
+++ b/crates/ffpipeline/src/hw_accel.rs
@@ -48,11 +48,6 @@ pub trait HwAccel {
         format: &VideoFormat,
         video_size: Option<FrameSize>,
     ) -> Option<VideoCodec>;
-    fn decoder_arg(&self) -> ArgVec;
-    fn decoder_filters(&self) -> Vec<PipelineFilter> {
-        Vec::new()
-    }
-    fn decoder_frame_surface(&self) -> FrameSurface;
     fn envs(&self) -> Vec<(String, String)> {
         Vec::new()
     }
@@ -62,9 +57,9 @@ pub trait HwAccel {
     fn hw_map_filter(&self, _from: &FrameSurface, _to: &FrameSurface) -> Option<VideoFilter> {
         None
     }
-    fn initialize(&self, ffmpeg_info: &FfmpegInfo, is_hdr: bool) -> Self;
     fn init_hw_device(&self, surfaces: &SurfaceSet) -> ArgVec;
     fn known_accel(&self) -> &KnownHardwareAccel;
+    fn make_decoder(&self, ffmpeg_info: &FfmpegInfo, is_hdr: bool) -> HwDecoder;
     fn output_format(&self, source_pixel_format: &PixelFormat) -> HwPixelFormat {
         match source_pixel_format.bit_depth() {
             10 => HwPixelFormat::P010le,
@@ -85,4 +80,10 @@ pub enum HardwareAccel {
     Vaapi(accel::vaapi::Vaapi),
     VideoToolbox(accel::video_toolbox::VideoToolbox),
     Vulkan(accel::vulkan::Vulkan),
+}
+
+pub struct HwDecoder {
+    pub args: ArgVec,
+    pub filters: Vec<PipelineFilter>,
+    pub surface: FrameSurface,
 }

--- a/crates/ffpipeline/src/pipeline.rs
+++ b/crates/ffpipeline/src/pipeline.rs
@@ -259,10 +259,6 @@ impl Pipeline {
         let audio_stream = Self::select_audio_stream(&input_settings)?;
         let subtitle_stream = Self::select_subtitle_stream(&input_settings);
 
-        final_output_settings.accel = final_output_settings
-            .accel
-            .map(|a| a.initialize(ffmpeg_info, video_stream.color_params.is_hdr()));
-
         // TODO: add target profile to config
         let video_codec = match (
             final_output_settings.accel.as_ref(),
@@ -284,7 +280,12 @@ impl Pipeline {
         let output_path = final_output_settings.format.path();
 
         let is_still_image = input_settings.video_input.probe_result.is_still_image();
-        let video_decoder = VideoDecoder::new(video_stream, is_still_image, &final_output_settings);
+        let video_decoder = VideoDecoder::new(
+            ffmpeg_info,
+            video_stream,
+            is_still_image,
+            &final_output_settings,
+        );
 
         let initial_state = FrameState {
             size: FrameSize {

--- a/crates/ffpipeline/src/video_decoder.rs
+++ b/crates/ffpipeline/src/video_decoder.rs
@@ -1,6 +1,7 @@
 use crate::ArgVec;
+use crate::ffmpeg_info::FfmpegInfo;
 use crate::filter_chain::PipelineFilter;
-use crate::hw_accel::{HardwareAccel, HwAccel};
+use crate::hw_accel::{HardwareAccel, HwAccel, HwDecoder};
 use crate::output_settings::OutputSettings;
 use crate::pipeline::{FrameSurface, PixelFormat};
 use crate::probe::ProbeResultVideoStream;
@@ -8,11 +9,15 @@ use crate::probe::ProbeResultVideoStream;
 pub enum VideoDecoder {
     None,
     Software,
-    HardwareAccel { accel: Box<HardwareAccel> },
+    HardwareAccel {
+        accel: Box<HardwareAccel>,
+        decoder: HwDecoder,
+    },
 }
 
 impl VideoDecoder {
     pub(crate) fn new(
+        ffmpeg_info: &FfmpegInfo,
         video_stream: &ProbeResultVideoStream,
         is_still_image: bool,
         output_settings: &OutputSettings,
@@ -32,6 +37,8 @@ impl VideoDecoder {
                 ) {
                     VideoDecoder::HardwareAccel {
                         accel: Box::new(accel.clone()),
+                        decoder: accel
+                            .make_decoder(ffmpeg_info, video_stream.color_params.is_hdr()),
                     }
                 } else {
                     VideoDecoder::Software
@@ -43,7 +50,7 @@ impl VideoDecoder {
 
     pub(crate) fn filters(&self) -> Vec<PipelineFilter> {
         match self {
-            VideoDecoder::HardwareAccel { accel } => accel.decoder_filters(),
+            VideoDecoder::HardwareAccel { decoder, .. } => decoder.filters.clone(),
             _ => Vec::new(),
         }
     }
@@ -52,7 +59,7 @@ impl VideoDecoder {
         match self {
             VideoDecoder::None => FrameSurface::System,
             VideoDecoder::Software => FrameSurface::System,
-            VideoDecoder::HardwareAccel { accel } => accel.decoder_frame_surface(),
+            VideoDecoder::HardwareAccel { decoder, .. } => decoder.surface,
         }
     }
 
@@ -60,7 +67,7 @@ impl VideoDecoder {
         match self {
             VideoDecoder::None => *source_pixel_format,
             VideoDecoder::Software => *source_pixel_format,
-            VideoDecoder::HardwareAccel { accel } => {
+            VideoDecoder::HardwareAccel { accel, .. } => {
                 accel.output_format(source_pixel_format).into()
             }
         }
@@ -70,7 +77,7 @@ impl VideoDecoder {
         match self {
             VideoDecoder::None => Vec::new(),
             VideoDecoder::Software => Vec::new(),
-            VideoDecoder::HardwareAccel { accel } => accel.decoder_arg(),
+            VideoDecoder::HardwareAccel { decoder, .. } => decoder.args.clone(),
         }
     }
 

--- a/crates/ffpipeline/tests/common/mod.rs
+++ b/crates/ffpipeline/tests/common/mod.rs
@@ -38,8 +38,19 @@ pub async fn test_env() -> Option<&'static TestEnv> {
                 .try_init()
                 .ok();
 
+            let disabled_filters: Vec<String> = std::env::var("ETV_TEST_DISABLED_FILTERS")
+                .ok()
+                .map(|v| {
+                    v.split(',')
+                        .map(str::trim)
+                        .filter(|s| !s.is_empty())
+                        .map(String::from)
+                        .collect()
+                })
+                .unwrap_or_default();
+
             let (ffmpeg, ffprobe) = find_binaries().expect("ffmpeg/ffprobe not found");
-            let ffmpeg_info = load_ffmpeg_info(&ffmpeg).await;
+            let ffmpeg_info = load_ffmpeg_info(&ffmpeg, &disabled_filters).await;
             Some(TestEnv {
                 ffmpeg,
                 ffprobe,
@@ -95,8 +106,8 @@ pub fn find_binaries() -> Option<(PathBuf, PathBuf)> {
     Some((find_ffmpeg()?, find_ffprobe()?))
 }
 
-pub async fn load_ffmpeg_info(ffmpeg: &Path) -> FfmpegInfo {
-    FfmpegInfo::load(ffmpeg, &[], &[])
+pub async fn load_ffmpeg_info(ffmpeg: &Path, disabled_filters: &[String]) -> FfmpegInfo {
+    FfmpegInfo::load(ffmpeg, disabled_filters, &[])
         .await
         .expect("failed to load ffmpeg info")
 }


### PR DESCRIPTION
Depends on #102 

This removes the `is_vulkan_hdr` state from cuda by adding `make_decoder` where that decision can be made a single time. In `best_filter` - the decision is implied from the content being HDR and the current surface being vulkan (due to the decoder).

Also added `ETV_TEST_DISABLED_FILTERS` env var to integration tests so you can see with/without vulkan, e.g. `ETV_TEST_DISABLED_FILTERS=libplacebo cargo test ...`.