### PR TITLE
feat: add support for pad_opencl

### DIFF
--- a/crates/ffpipeline/src/accel/opencl.rs
+++ b/crates/ffpipeline/src/accel/opencl.rs
@@ -1,4 +1,5 @@
 use crate::ffmpeg_info::FfmpegInfo;
+use crate::frame_size::FrameSize;
 use crate::pipeline::{FrameState, FrameSurface, HwPixelFormat};
 use crate::video_filter::{VideoFilter, VideoFilterOp};
 
@@ -35,5 +36,33 @@ impl VideoFilterOp for TonemapOpencl {
             self.output_format.as_arg()
         )
         .into()
+    }
+}
+
+#[derive(Clone)]
+pub struct PadOpencl {
+    pub(crate) size: Option<FrameSize>,
+}
+
+impl VideoFilterOp for PadOpencl {
+    fn evaluate(&self, _state: &FrameState, _ffmpeg_info: &FfmpegInfo) -> Option<VideoFilter> {
+        None
+    }
+
+    fn apply_to(&self, state: &mut FrameState) {
+        if let Some(size) = &self.size {
+            state.size = *size;
+            state.surface = FrameSurface::OpenCL;
+        }
+    }
+
+    fn required_surface(&self) -> Option<FrameSurface> {
+        Some(FrameSurface::OpenCL)
+    }
+
+    fn as_arg(&self) -> Option<String> {
+        self.size
+            .as_ref()
+            .map(|s| format!("pad_opencl={}:{}:-1:-1:color=black", s.width, s.height))
     }
 }

--- a/crates/ffpipeline/src/accel/vaapi.rs
+++ b/crates/ffpipeline/src/accel/vaapi.rs
@@ -244,6 +244,8 @@ impl HwAccel for Vaapi {
                 "-init_hw_device",
                 "opencl=ocl@va",
                 "-hwaccel_device",
+                "va",
+                "-filter_hw_device",
                 "va"
             ]
         } else {

--- a/crates/ffpipeline/src/accel/vaapi.rs
+++ b/crates/ffpipeline/src/accel/vaapi.rs
@@ -1,5 +1,5 @@
 use crate::ArgVec;
-use crate::accel::opencl::TonemapOpencl;
+use crate::accel::opencl::{PadOpencl, TonemapOpencl};
 use crate::capabilities::opencl::OpenCLCapabilities;
 use crate::capabilities::vaapi::VaapiCapabilities;
 use crate::ffmpeg_info::{FfmpegInfo, KnownHardwareAccel, KnownVideoFilter};
@@ -55,10 +55,20 @@ impl HwAccel for Vaapi {
                 }
                 .into()
             }
-            VideoFilter::Pad(PadFilter { size })
-                if ffmpeg_info.has_video_filter(&KnownVideoFilter::PadVaapi) =>
-            {
-                PadVaapi { size: *size }.into()
+            VideoFilter::Pad(PadFilter { size }) => {
+                let mut pad_options = vec![KnownVideoFilter::PadVaapi];
+                if self.opencl_capabilities.can_pad() {
+                    pad_options.push(KnownVideoFilter::PadOpencl);
+                }
+                if let Some(hw_filter) = ffmpeg_info.find_best_fit(pad_options.as_slice()) {
+                    match hw_filter {
+                        KnownVideoFilter::PadVaapi => PadVaapi { size: *size }.into(),
+                        KnownVideoFilter::PadOpencl => PadOpencl { size: *size }.into(),
+                        _ => video_filter.clone(),
+                    }
+                } else {
+                    video_filter.clone()
+                }
             }
 
             VideoFilter::ToneMap(ToneMapFilter {

--- a/crates/ffpipeline/src/capabilities/opencl/mod.rs
+++ b/crates/ffpipeline/src/capabilities/opencl/mod.rs
@@ -20,4 +20,8 @@ impl OpenCLCapabilities {
     pub fn can_tonemap(&self) -> bool {
         self.platform_count > 0 && self.gpu_device_count > 0
     }
+
+    pub fn can_pad(&self) -> bool {
+        self.platform_count > 0 && self.gpu_device_count > 0
+    }
 }

--- a/crates/ffpipeline/src/ffmpeg_info.rs
+++ b/crates/ffpipeline/src/ffmpeg_info.rs
@@ -58,6 +58,8 @@ pub enum KnownVideoFilter {
     OverlayVaapi,
     #[strum(serialize = "pad_cuda")]
     PadCuda,
+    #[strum(serialize = "pad_opencl")]
+    PadOpencl,
     #[strum(serialize = "pad_vaapi")]
     PadVaapi,
     #[strum(serialize = "scale_cuda")]

--- a/crates/ffpipeline/src/filter_chain.rs
+++ b/crates/ffpipeline/src/filter_chain.rs
@@ -521,15 +521,15 @@ mod tests {
     use std::collections::{HashMap, HashSet};
 
     use super::*;
-    use crate::accel::opencl::TonemapOpencl;
-    use crate::accel::vaapi::{TonemapVaapi, Vaapi, VaapiDriver};
+    use crate::accel::opencl::{PadOpencl, TonemapOpencl};
+    use crate::accel::vaapi::{PadVaapi, TonemapVaapi, Vaapi, VaapiDriver};
     use crate::capabilities::opencl::OpenCLCapabilities;
     use crate::capabilities::vaapi::VaapiCapabilities;
     use crate::ffmpeg_info::KnownVideoFilter;
     use crate::frame_size::FrameSize;
     use crate::hw_accel::HardwareAccel;
     use crate::pipeline::HwPixelFormat;
-    use crate::video_filter::{HwMapFilter, ToneMapFilter};
+    use crate::video_filter::{HwMapFilter, PadFilter, ToneMapFilter};
 
     fn vaapi_accel() -> HardwareAccel {
         HardwareAccel::Vaapi(Vaapi {
@@ -992,6 +992,300 @@ mod tests {
         assert!(
             !filter_complex.contains("hwmap"),
             "filter_complex should not contain hwmap for vaapi tonemap: {filter_complex}"
+        );
+    }
+
+    // -- pad best_filter tests --
+
+    fn vaapi_accel_with_opencl(opencl: bool) -> Vaapi {
+        Vaapi {
+            device: String::from("/dev/dri/renderD128"),
+            driver: VaapiDriver::Ihd,
+            capabilities: VaapiCapabilities {
+                vendor: String::from("test"),
+                supported: HashSet::new(),
+                vpp_pixel_formats: HashSet::new(),
+                can_hdr_to_sdr_tonemap: HashSet::new(),
+                can_hdr_to_hdr_tonemap: HashSet::new(),
+                can_overlay: false,
+            },
+            opencl_capabilities: OpenCLCapabilities {
+                platform_count: if opencl { 1 } else { 0 },
+                gpu_device_count: if opencl { 1 } else { 0 },
+            },
+        }
+    }
+
+    fn sdr_vaapi_state() -> FrameState {
+        FrameState {
+            size: FrameSize {
+                width: 1280,
+                height: 720,
+            },
+            is_anamorphic: false,
+            is_interlaced: false,
+            sample_aspect_ratio: None,
+            display_aspect_ratio: None,
+            surface: FrameSurface::Vaapi,
+            pixel_format: PixelFormat::Nv12,
+            is_hdr: false,
+        }
+    }
+
+    #[test]
+    fn best_filter_selects_pad_vaapi_when_available() {
+        let vaapi = vaapi_accel_with_opencl(true);
+        let ffmpeg_info =
+            ffmpeg_info_with_filters(&[KnownVideoFilter::PadVaapi, KnownVideoFilter::PadOpencl]);
+        let state = sdr_vaapi_state();
+
+        let input: VideoFilter = PadFilter {
+            size: Some(FrameSize {
+                width: 1920,
+                height: 1080,
+            }),
+        }
+        .into();
+
+        let result = vaapi.best_filter(&input, &ffmpeg_info, &state);
+        assert!(
+            matches!(result, VideoFilter::PadVaapi(PadVaapi { .. })),
+            "expected PadVaapi when both pad_vaapi and pad_opencl available, got {:?}",
+            result.as_arg()
+        );
+    }
+
+    #[test]
+    fn best_filter_selects_pad_opencl_when_pad_vaapi_unavailable() {
+        let vaapi = vaapi_accel_with_opencl(true);
+        let ffmpeg_info = ffmpeg_info_with_filters(&[KnownVideoFilter::PadOpencl]);
+        let state = sdr_vaapi_state();
+
+        let input: VideoFilter = PadFilter {
+            size: Some(FrameSize {
+                width: 1920,
+                height: 1080,
+            }),
+        }
+        .into();
+
+        let result = vaapi.best_filter(&input, &ffmpeg_info, &state);
+        assert!(
+            matches!(result, VideoFilter::PadOpencl(PadOpencl { .. })),
+            "expected PadOpencl when pad_vaapi unavailable, got {:?}",
+            result.as_arg()
+        );
+    }
+
+    #[test]
+    fn best_filter_falls_back_to_software_pad_without_hw_filters() {
+        let vaapi = vaapi_accel_with_opencl(false);
+        let ffmpeg_info = ffmpeg_info_with_filters(&[]);
+        let state = sdr_vaapi_state();
+
+        let input: VideoFilter = PadFilter {
+            size: Some(FrameSize {
+                width: 1920,
+                height: 1080,
+            }),
+        }
+        .into();
+
+        let result = vaapi.best_filter(&input, &ffmpeg_info, &state);
+        assert!(
+            matches!(result, VideoFilter::Pad(_)),
+            "expected software Pad fallback, got {:?}",
+            result.as_arg()
+        );
+    }
+
+    #[test]
+    fn best_filter_ignores_pad_opencl_without_opencl_capabilities() {
+        let vaapi = vaapi_accel_with_opencl(false);
+        let ffmpeg_info = ffmpeg_info_with_filters(&[KnownVideoFilter::PadOpencl]);
+        let state = sdr_vaapi_state();
+
+        let input: VideoFilter = PadFilter {
+            size: Some(FrameSize {
+                width: 1920,
+                height: 1080,
+            }),
+        }
+        .into();
+
+        let result = vaapi.best_filter(&input, &ffmpeg_info, &state);
+        assert!(
+            matches!(result, VideoFilter::Pad(_)),
+            "expected software Pad when no OpenCL capabilities, got {:?}",
+            result.as_arg()
+        );
+    }
+
+    #[test]
+    fn resolve_inserts_hwmap_for_opencl_pad_on_vaapi() {
+        let vaapi = vaapi_accel_with_opencl(true);
+        let accel = HardwareAccel::Vaapi(vaapi);
+        let ffmpeg_info = ffmpeg_info_with_filters(&[KnownVideoFilter::PadOpencl]);
+        let initial_state = sdr_vaapi_state();
+
+        let pad: VideoFilter = PadFilter {
+            size: Some(FrameSize {
+                width: 1920,
+                height: 1080,
+            }),
+        }
+        .into();
+
+        let mut chain = FilterChain::new(vec![PipelineFilter::Video(pad)]);
+        chain.resolve(
+            &ffmpeg_info,
+            &Some(accel),
+            &initial_state,
+            &FrameSurface::Vaapi,
+            &Some(PixelFormat::Nv12),
+        );
+
+        let video_filters: Vec<&VideoFilter> = chain
+            .filters
+            .iter()
+            .filter_map(|f| match f {
+                PipelineFilter::Video(vf) => Some(vf),
+                _ => None,
+            })
+            .collect();
+
+        assert!(
+            video_filters.len() >= 3,
+            "expected at least 3 video filters (hwmap + pad + hwmap), got {}",
+            video_filters.len()
+        );
+
+        assert!(
+            matches!(
+                video_filters[0],
+                VideoFilter::HwMap(HwMapFilter {
+                    from_surface: FrameSurface::Vaapi,
+                    to_surface: FrameSurface::OpenCL,
+                    reverse: false
+                })
+            ),
+            "first filter should be HwMap from Vaapi to OpenCL"
+        );
+
+        assert!(
+            matches!(video_filters[1], VideoFilter::PadOpencl(_)),
+            "second filter should be PadOpencl"
+        );
+
+        assert!(
+            matches!(
+                video_filters[2],
+                VideoFilter::HwMap(HwMapFilter {
+                    from_surface: FrameSurface::OpenCL,
+                    to_surface: FrameSurface::Vaapi,
+                    reverse: true,
+                })
+            ),
+            "third filter should be HwMap from OpenCL back to Vaapi"
+        );
+    }
+
+    #[test]
+    fn resolve_pad_vaapi_does_not_insert_hwmap() {
+        let vaapi = vaapi_accel_with_opencl(true);
+        let accel = HardwareAccel::Vaapi(vaapi);
+        let ffmpeg_info =
+            ffmpeg_info_with_filters(&[KnownVideoFilter::PadVaapi, KnownVideoFilter::PadOpencl]);
+        let initial_state = sdr_vaapi_state();
+
+        let pad: VideoFilter = PadFilter {
+            size: Some(FrameSize {
+                width: 1920,
+                height: 1080,
+            }),
+        }
+        .into();
+
+        let mut chain = FilterChain::new(vec![PipelineFilter::Video(pad)]);
+        chain.resolve(
+            &ffmpeg_info,
+            &Some(accel),
+            &initial_state,
+            &FrameSurface::Vaapi,
+            &Some(PixelFormat::Nv12),
+        );
+
+        let video_filters: Vec<&VideoFilter> = chain
+            .filters
+            .iter()
+            .filter_map(|f| match f {
+                PipelineFilter::Video(vf) => Some(vf),
+                _ => None,
+            })
+            .collect();
+
+        let has_hwmap = video_filters
+            .iter()
+            .any(|f| matches!(f, VideoFilter::HwMap(_)));
+        assert!(
+            !has_hwmap,
+            "pad_vaapi stays on VAAPI surface, no HwMap needed"
+        );
+
+        assert!(
+            matches!(video_filters[0], VideoFilter::PadVaapi(_)),
+            "first video filter should be PadVaapi, got {:?}",
+            video_filters[0].as_arg()
+        );
+    }
+
+    #[test]
+    fn resolve_and_build_produces_correct_filter_complex_for_opencl_pad() {
+        let vaapi = vaapi_accel_with_opencl(true);
+        let accel = HardwareAccel::Vaapi(vaapi);
+        let ffmpeg_info = ffmpeg_info_with_filters(&[KnownVideoFilter::PadOpencl]);
+        let initial_state = sdr_vaapi_state();
+
+        let pad: VideoFilter = PadFilter {
+            size: Some(FrameSize {
+                width: 1920,
+                height: 1080,
+            }),
+        }
+        .into();
+
+        let mut chain = FilterChain::new(vec![PipelineFilter::Video(pad)]);
+        chain.resolve(
+            &ffmpeg_info,
+            &Some(accel),
+            &initial_state,
+            &FrameSurface::Vaapi,
+            &Some(PixelFormat::Nv12),
+        );
+        chain.build("0:a", "0:v", None);
+
+        let args = chain.as_arg();
+        assert_eq!(args.len(), 2);
+        assert_eq!(args[0], "-filter_complex");
+
+        let filter_complex = &args[1];
+        assert!(
+            filter_complex.contains("hwmap=derive_device=opencl"),
+            "filter_complex should contain hwmap to opencl: {filter_complex}"
+        );
+        assert!(
+            filter_complex.contains("pad_opencl=1920:1080:-1:-1:color=black"),
+            "filter_complex should contain pad_opencl: {filter_complex}"
+        );
+        assert!(
+            filter_complex.contains("hwmap=derive_device=vaapi"),
+            "filter_complex should contain hwmap back to vaapi: {filter_complex}"
+        );
+
+        let expected_order = "hwmap=derive_device=opencl,pad_opencl=";
+        assert!(
+            filter_complex.contains(expected_order),
+            "hwmap to opencl should appear immediately before pad_opencl: {filter_complex}"
         );
     }
 }

--- a/crates/ffpipeline/src/video_filter.rs
+++ b/crates/ffpipeline/src/video_filter.rs
@@ -64,6 +64,7 @@ pub enum VideoFilter {
     FormatVaapi(accel::vaapi::FormatVaapi),
     TonemapVaapi(accel::vaapi::TonemapVaapi),
     // OpenCL hardware filters
+    PadOpencl(accel::opencl::PadOpencl),
     TonemapOpencl(accel::opencl::TonemapOpencl),
     // QSV hardware filters
     ScaleQsv(accel::qsv::ScaleQsv),

--- a/crates/ffpipeline/tests/vaapi.rs
+++ b/crates/ffpipeline/tests/vaapi.rs
@@ -139,6 +139,63 @@ async fn tonemap(
     }
 }
 
+/// Tests pad with a 4:3 source -> 16:9 target, which forces pad_vaapi or pad_opencl.
+#[rstest]
+#[tokio::test]
+#[ignore]
+async fn pad(
+    #[values("480p_h264.ts")] src: &'static str,
+    #[values(("h264", 8), ("hevc", 8))] vf: (&'static str, u8),
+    #[values("aac")] af: AudioFormat,
+) {
+    let (vf_str, bpp) = vf;
+    if let Ok(vf) = VideoFormat::from_str(vf_str) {
+        run_vaapi_test_case(TestCase {
+            fixture_name: src,
+            params: TestOutputParams {
+                audio_format: Some(af),
+                video_format: Some(vf),
+                video_size: Some(FrameSize::from_str("1920x1080").unwrap()),
+                bit_depth: Some(bpp),
+                ..TestOutputParams::default()
+            },
+            expected_video_codec: vf.to_string(),
+            expected_video_size: FrameSize::from_str("1920x1080").unwrap(),
+            expected_audio_codec: af.to_string(),
+        })
+        .await;
+    }
+}
+
+/// Tests pad_opencl by disabling pad_vaapi via ETV_TEST_DISABLED_FILTERS=pad_vaapi.
+/// Run with: ETV_TEST_DISABLED_FILTERS=pad_vaapi cargo test --package ffpipeline --test vaapi pad_opencl -- --ignored
+#[rstest]
+#[tokio::test]
+#[ignore]
+async fn pad_opencl(
+    #[values("480p_h264.ts")] src: &'static str,
+    #[values(("h264", 8), ("hevc", 8))] vf: (&'static str, u8),
+    #[values("aac")] af: AudioFormat,
+) {
+    let (vf_str, bpp) = vf;
+    if let Ok(vf) = VideoFormat::from_str(vf_str) {
+        run_vaapi_test_case(TestCase {
+            fixture_name: src,
+            params: TestOutputParams {
+                audio_format: Some(af),
+                video_format: Some(vf),
+                video_size: Some(FrameSize::from_str("1920x1080").unwrap()),
+                bit_depth: Some(bpp),
+                ..TestOutputParams::default()
+            },
+            expected_video_codec: vf.to_string(),
+            expected_video_size: FrameSize::from_str("1920x1080").unwrap(),
+            expected_audio_codec: af.to_string(),
+        })
+        .await;
+    }
+}
+
 async fn run_vaapi_test_case(mut test_case: TestCase) {
     if let Some(env) = test_env().await {
         if !env.ffmpeg_info.has_hw_accel(&KnownHardwareAccel::Vaapi) {


### PR DESCRIPTION
Fallback hardware pad support using pad_opencl in the VAAPI pipeline, in
case pad_vaapi is not supported in the provided ffmpeg version.
