### PR TITLE
feat: generate playout for 48h; don't overwrite

### DIFF
--- a/crates/ersatztv-channel/src/playout_loader.rs
+++ b/crates/ersatztv-channel/src/playout_loader.rs
@@ -1,6 +1,6 @@
 use ersatztv_channel::config::ChannelConfig;
 use ersatztv_channel::error::ChannelError;
-use ersatztv_playout::playout::{DATE_FORMAT, PlayoutItem, PlayoutLoadResult};
+use ersatztv_playout::playout::{PlayoutItem, PlayoutLoadResult, parse_playout_filename};
 use time::OffsetDateTime;
 
 pub struct PlayoutLoader {
@@ -66,35 +66,11 @@ impl PlayoutLoader {
                     ChannelError::ChannelConfigFailure(String::from("os string error"))
                 })?;
 
-                if path.ends_with(".json") {
-                    let split: Vec<&str> = file_name.split("_").collect();
-                    if split.len() == 2 {
-                        let maybe_start = OffsetDateTime::parse(split[0], &DATE_FORMAT)
-                            .ok()
-                            .or_else(|| parse_unix_timestamp(split[0]));
-
-                        let maybe_finish = OffsetDateTime::parse(split[1], &DATE_FORMAT)
-                            .ok()
-                            .or_else(|| parse_unix_timestamp(split[1]));
-
-                        match (maybe_start, maybe_finish) {
-                            (Some(start), Some(finish)) => {
-                                log::trace!(
-                                    "Successfully parsed playout date range ({}, {}).",
-                                    start,
-                                    finish
-                                );
-                                if now >= &start && now < &finish {
-                                    return Ok(path);
-                                }
-                            }
-                            _ => {
-                                log::debug!(
-                                    "Could not parse start and end time for filename {file_name}"
-                                )
-                            }
-                        }
-                    }
+                if let Some((start, finish)) = parse_playout_filename(file_name.as_str())
+                    && now >= &start
+                    && now < &finish
+                {
+                    return Ok(path);
                 }
             }
         }
@@ -113,19 +89,5 @@ impl PlayoutLoader {
             .iter()
             .find(|i| &i.start > now)
             .map(|i| i.start)
-    }
-}
-
-fn parse_unix_timestamp(timestamp: &str) -> Option<OffsetDateTime> {
-    let maybe_epoch = timestamp
-        .parse::<i64>()
-        .map(|i| if timestamp.len() > 10 { i / 1000 } else { i });
-
-    if let Ok(epoch) = maybe_epoch {
-        // TODO: Could use more logging maybe
-        OffsetDateTime::from_unix_timestamp(epoch).ok()
-    } else {
-        log::trace!("Couldn't parse Unix timestamp ({})", timestamp);
-        None
     }
 }

--- a/crates/ersatztv-playout-generator/src/error.rs
+++ b/crates/ersatztv-playout-generator/src/error.rs
@@ -19,7 +19,4 @@ pub enum PlayoutGeneratorError {
 
     #[error("no source content was found")]
     NoSourceContent,
-
-    #[error("failed to scan existing playout json files")]
-    ScanHorizonFailure,
 }

--- a/crates/ersatztv-playout-generator/src/error.rs
+++ b/crates/ersatztv-playout-generator/src/error.rs
@@ -19,4 +19,7 @@ pub enum PlayoutGeneratorError {
 
     #[error("no source content was found")]
     NoSourceContent,
+
+    #[error("failed to scan existing playout json files")]
+    ScanHorizonFailure,
 }

--- a/crates/ersatztv-playout-generator/src/generate.rs
+++ b/crates/ersatztv-playout-generator/src/generate.rs
@@ -1,8 +1,9 @@
 use std::collections::HashMap;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use ersatztv_playout::playout::{
     DATE_FORMAT, Playout, PlayoutItem, PlayoutItemSource, PlayoutItemTracks, TrackSelection,
+    parse_playout_filename,
 };
 use ffpipeline::probe::{ProbeResult, ProbeResultStream};
 use rand::RngExt;
@@ -13,10 +14,50 @@ use walkdir::WalkDir;
 use crate::error::PlayoutGeneratorError;
 use crate::{IMAGE_EXTENSIONS, is_image_extension, is_video_extension, to_probe_result};
 
+const BUILD_UNDER: time::Duration = time::Duration::hours(36);
+const TO_BUILD: time::Duration = time::Duration::hours(48);
+const TO_RETAIN: time::Duration = time::Duration::days(1);
+
 pub async fn generate_playout(
-    content_folder: &PathBuf,
+    content_folder: &Path,
     output_folder: &PathBuf,
 ) -> Result<(), PlayoutGeneratorError> {
+    let video_list = probe_content(content_folder).await?;
+    if video_list.is_empty() {
+        return Err(PlayoutGeneratorError::NoSourceContent);
+    }
+
+    if !output_folder.exists() {
+        tokio::fs::create_dir_all(output_folder).await?;
+    }
+
+    let now = OffsetDateTime::now_local()?;
+    let threshold = now + BUILD_UNDER;
+    let target = now + TO_BUILD;
+    let horizon = scan_horizon(output_folder).await?;
+
+    if let Some(h) = horizon
+        && h >= threshold
+    {
+        log::debug!("nothing to add before {target}");
+        return Ok(());
+    }
+
+    let gen_start = horizon.filter(|h| *h > now).unwrap_or(now);
+
+    let mut rng = rand::rng();
+    let playout_items = build_items(gen_start, target, &video_list, &mut rng).await;
+
+    write_playout_file(output_folder, playout_items).await?;
+
+    gc_old_playouts(output_folder, now - TO_RETAIN).await?;
+
+    Ok(())
+}
+
+async fn probe_content(
+    content_folder: &Path,
+) -> Result<Vec<(PathBuf, ProbeResult)>, PlayoutGeneratorError> {
     // find all available video files
     let mut video_paths: HashMap<PathBuf, ProbeResult> = HashMap::new();
     for dir_entry in WalkDir::new(content_folder)
@@ -31,29 +72,52 @@ pub async fn generate_playout(
         }
     }
 
-    if video_paths.is_empty() {
-        return Err(PlayoutGeneratorError::NoSourceContent);
+    Ok(video_paths.into_iter().collect())
+}
+
+async fn scan_horizon(
+    output_folder: &Path,
+) -> Result<Option<OffsetDateTime>, PlayoutGeneratorError> {
+    let mut result = None;
+
+    let mut entries = tokio::fs::read_dir(output_folder)
+        .await
+        .map_err(PlayoutGeneratorError::IoFailure)?;
+
+    while let Ok(Some(entry)) = entries.next_entry().await {
+        if let Some(file_name_os) = entry.path().file_stem() {
+            let file_name = file_name_os
+                .to_os_string()
+                .into_string()
+                .map_err(|_| PlayoutGeneratorError::ScanHorizonFailure)?;
+
+            if let Some((_, finish)) = parse_playout_filename(file_name.as_str())
+                && (result.is_none() || result.is_some_and(|max| finish > max))
+            {
+                result = Some(finish);
+            }
+        }
     }
 
-    // generate output file name
-    let start = OffsetDateTime::now_local()?.truncate_to_day();
-    let formatted_start = start.format(&DATE_FORMAT)?;
-    let finish = start + time::Duration::days(1) - time::Duration::seconds(1);
+    Ok(result)
+}
 
-    let video_list: Vec<(PathBuf, ProbeResult)> = video_paths.into_iter().collect();
-
-    // fill output file with content
+async fn build_items(
+    start: OffsetDateTime,
+    finish: OffsetDateTime,
+    video_list: &[(PathBuf, ProbeResult)],
+    rng: &mut impl rand::Rng,
+) -> Vec<PlayoutItem> {
     let mut playout_items: Vec<PlayoutItem> = Vec::new();
     let mut current_time = start;
-    let mut rng = rand::rng();
-    let mut shuffled = video_list.clone();
-    shuffled.shuffle(&mut rng);
+    let mut shuffled = video_list.to_vec();
+    shuffled.shuffle(rng);
     let mut cursor = 0;
 
     while current_time < finish {
         if cursor >= shuffled.len() {
             let last = shuffled.last().cloned();
-            shuffled.shuffle(&mut rng);
+            shuffled.shuffle(rng);
             if shuffled.len() > 1
                 && let Some(ref last) = last
                 && shuffled[0].0 == last.0
@@ -180,18 +244,54 @@ pub async fn generate_playout(
         }
     }
 
-    let formatted_finish = current_time.format(&DATE_FORMAT)?;
-    let output_file = format!("{formatted_start}_{formatted_finish}.json");
-    log::debug!("output_file: {output_file}");
+    playout_items
+}
 
-    if !output_folder.exists() {
-        tokio::fs::create_dir_all(output_folder).await?;
+async fn write_playout_file(
+    output_folder: &Path,
+    items: Vec<PlayoutItem>,
+) -> Result<(), PlayoutGeneratorError> {
+    if let Some(first) = items.first()
+        && let Some(last) = items.last()
+    {
+        // generate output file name
+        let formatted_start = first.start.format(&DATE_FORMAT)?;
+        let formatted_finish = last.finish.format(&DATE_FORMAT)?;
+
+        let output_file = format!("{formatted_start}_{formatted_finish}.json");
+        log::debug!("output_file: {output_file}");
+
+        let output_path = output_folder.join(&output_file);
+        let playout = Playout::new(items);
+        let output_string = serde_json::to_string_pretty(&playout)?;
+        tokio::fs::write(&output_path, output_string).await?;
     }
 
-    let output_path = output_folder.join(&output_file);
-    let playout = Playout::new(playout_items);
-    let output_string = serde_json::to_string_pretty(&playout)?;
-    tokio::fs::write(&output_path, output_string).await?;
+    Ok(())
+}
+
+async fn gc_old_playouts(
+    output_folder: &Path,
+    before: OffsetDateTime,
+) -> Result<(), PlayoutGeneratorError> {
+    let mut entries = tokio::fs::read_dir(output_folder)
+        .await
+        .map_err(PlayoutGeneratorError::IoFailure)?;
+
+    while let Ok(Some(entry)) = entries.next_entry().await {
+        if let Some(file_name_os) = entry.path().file_stem() {
+            let file_name = file_name_os
+                .to_os_string()
+                .into_string()
+                .map_err(|_| PlayoutGeneratorError::ScanHorizonFailure)?;
+
+            if let Some((_, finish)) = parse_playout_filename(file_name.as_str())
+                && finish < before
+            {
+                tokio::fs::remove_file(entry.path()).await?;
+            }
+        }
+    }
 
     Ok(())
 }

--- a/crates/ersatztv-playout-generator/src/generate.rs
+++ b/crates/ersatztv-playout-generator/src/generate.rs
@@ -39,7 +39,7 @@ pub async fn generate_playout(
     if let Some(h) = horizon
         && h >= threshold
     {
-        log::debug!("nothing to add before {target}");
+        log::info!("nothing to add before {target}");
         return Ok(());
     }
 
@@ -86,12 +86,9 @@ async fn scan_horizon(
 
     while let Ok(Some(entry)) = entries.next_entry().await {
         if let Some(file_name_os) = entry.path().file_stem() {
-            let file_name = file_name_os
-                .to_os_string()
-                .into_string()
-                .map_err(|_| PlayoutGeneratorError::ScanHorizonFailure)?;
+            let file_name = file_name_os.to_string_lossy();
 
-            if let Some((_, finish)) = parse_playout_filename(file_name.as_str())
+            if let Some((_, finish)) = parse_playout_filename(&file_name)
                 && (result.is_none() || result.is_some_and(|max| finish > max))
             {
                 result = Some(finish);
@@ -259,7 +256,7 @@ async fn write_playout_file(
         let formatted_finish = last.finish.format(&DATE_FORMAT)?;
 
         let output_file = format!("{formatted_start}_{formatted_finish}.json");
-        log::debug!("output_file: {output_file}");
+        log::info!("output_file: {output_file}");
 
         let output_path = output_folder.join(&output_file);
         let playout = Playout::new(items);
@@ -280,15 +277,17 @@ async fn gc_old_playouts(
 
     while let Ok(Some(entry)) = entries.next_entry().await {
         if let Some(file_name_os) = entry.path().file_stem() {
-            let file_name = file_name_os
-                .to_os_string()
-                .into_string()
-                .map_err(|_| PlayoutGeneratorError::ScanHorizonFailure)?;
+            let file_name = file_name_os.to_string_lossy();
 
-            if let Some((_, finish)) = parse_playout_filename(file_name.as_str())
+            if let Some((_, finish)) = parse_playout_filename(&file_name)
                 && finish < before
+                && let Err(e) = tokio::fs::remove_file(entry.path()).await
             {
-                tokio::fs::remove_file(entry.path()).await?;
+                log::warn!(
+                    "Failed to remove old playout file {:?}: {}",
+                    entry.path(),
+                    e
+                );
             }
         }
     }

--- a/crates/ersatztv-playout-generator/src/main.rs
+++ b/crates/ersatztv-playout-generator/src/main.rs
@@ -45,7 +45,7 @@ enum Commands {
 
 #[tokio::main]
 pub async fn main() {
-    env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("debug"))
+    env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info"))
         .filter_module("sqlx", log::LevelFilter::Warn)
         .init();
 

--- a/crates/ersatztv-playout/src/playout.rs
+++ b/crates/ersatztv-playout/src/playout.rs
@@ -210,3 +210,35 @@ pub async fn from_file(path: &str) -> Result<PlayoutLoadResult, PlayoutError> {
 
     Ok(PlayoutLoadResult { playout })
 }
+
+pub fn parse_playout_filename(file_stem: &str) -> Option<(OffsetDateTime, OffsetDateTime)> {
+    let split: Vec<&str> = file_stem.split("_").collect();
+    if split.len() == 2 {
+        let maybe_start = OffsetDateTime::parse(split[0], &DATE_FORMAT)
+            .ok()
+            .or_else(|| parse_unix_timestamp(split[0]));
+
+        let maybe_finish = OffsetDateTime::parse(split[1], &DATE_FORMAT)
+            .ok()
+            .or_else(|| parse_unix_timestamp(split[1]));
+
+        return match (maybe_start, maybe_finish) {
+            (Some(start), Some(finish)) => Some((start, finish)),
+            _ => None,
+        };
+    }
+
+    None
+}
+
+fn parse_unix_timestamp(timestamp: &str) -> Option<OffsetDateTime> {
+    let maybe_epoch = timestamp
+        .parse::<i64>()
+        .map(|i| if timestamp.len() > 10 { i / 1000 } else { i });
+
+    if let Ok(epoch) = maybe_epoch {
+        OffsetDateTime::from_unix_timestamp(epoch).ok()
+    } else {
+        None
+    }
+}


### PR DESCRIPTION
This updates the test playout generator so that it extends the existing playout JSON files to now + 48h, when the existing playout JSON ends < now + 36h, which makes it more appropriate to run as a cron job.

The shuffles do not persist across playout JSON files.