### PR TITLE
feat: support converting subtitles from http source

### DIFF
--- a/crates/ersatztv-channel/src/channel_session.rs
+++ b/crates/ersatztv-channel/src/channel_session.rs
@@ -559,8 +559,10 @@ impl ChannelSession {
             && !subtitle_stream.is_subtitle_image()
             && let Some(input) = input_settings.subtitle_input.as_ref()
         {
-            match crate::web_vtt::convert_to_vtt(&self.ffmpeg_path, input, subtitle_stream).await {
-                Ok(temp_file) => match crate::web_vtt::parse_file(temp_file.path()).await {
+            match ffpipeline::web_vtt::convert_to_vtt(&self.ffmpeg_path, input, subtitle_stream)
+                .await
+            {
+                Ok(temp_file) => match ffpipeline::web_vtt::parse_file(temp_file.path()).await {
                     Ok(cues) => {
                         subtitle_source = Some(SubtitleSource {
                             cues,

--- a/crates/ersatztv-channel/src/channel_session.rs
+++ b/crates/ersatztv-channel/src/channel_session.rs
@@ -677,6 +677,7 @@ impl ChannelSession {
                 timeout_us,
                 reconnect,
                 reconnect_delay_max,
+                keep_alive,
                 ..
             } => {
                 let expanded_uri = expand_template(&uri)?;
@@ -695,6 +696,7 @@ impl ChannelSession {
                         timeout_us,
                         reconnect: reconnect.unwrap_or(true),
                         reconnect_delay_max,
+                        keep_alive,
                     },
                 }))
             }

--- a/crates/ersatztv-channel/src/error.rs
+++ b/crates/ersatztv-channel/src/error.rs
@@ -56,10 +56,4 @@ pub enum ChannelError {
 
     #[error("channel {0} terminated after idle timeout")]
     IdleTimeout(String),
-
-    #[error("failed to convert subtitle")]
-    FailedToConvertSubtitle,
-
-    #[error("failed to parse subtitle")]
-    FailedToParseSubtitle,
 }

--- a/crates/ersatztv-channel/src/main.rs
+++ b/crates/ersatztv-channel/src/main.rs
@@ -2,7 +2,6 @@ mod channel_session;
 mod playlist_manager;
 mod playout_loader;
 mod pts_scanner;
-mod web_vtt;
 
 use std::path::{Path, PathBuf};
 

--- a/crates/ersatztv-channel/src/playlist_manager.rs
+++ b/crates/ersatztv-channel/src/playlist_manager.rs
@@ -5,10 +5,9 @@ use std::time::Duration;
 use ersatztv_channel::error::ChannelError;
 use ersatztv_core::{HEARTBEAT_FILE_NAME, HEARTBEAT_FILE_TIMEOUT};
 use ffpipeline::pipeline::PtsOffset;
+use ffpipeline::web_vtt::{Cue, format_vtt_ts};
 use time::OffsetDateTime;
 use time::macros::format_description;
-
-use crate::web_vtt::{Cue, format_vtt_ts};
 
 const MIN_SEGMENTS: usize = 4;
 

--- a/crates/ersatztv-playout/src/playout.rs
+++ b/crates/ersatztv-playout/src/playout.rs
@@ -200,6 +200,9 @@ pub enum PlayoutItemSource {
         /// Maps directly to the reconnect_delay_max ffmpeg option
         #[serde(skip_serializing_if = "Option::is_none")]
         reconnect_delay_max: Option<u32>,
+        /// Enable persistent connections in ffmpeg (default: false)
+        #[serde(skip_serializing_if = "Option::is_none")]
+        keep_alive: Option<bool>,
     },
 }
 

--- a/crates/ersatztv/src/channel_session.rs
+++ b/crates/ersatztv/src/channel_session.rs
@@ -37,7 +37,7 @@ impl ChannelSession {
             let ready_file_clone = ready_file.clone();
             let watcher = tokio::spawn(async move {
                 loop {
-                    if ready_file_clone.exists() {
+                    if tokio::fs::metadata(&ready_file_clone).await.is_ok() {
                         let _ = ready_sender.send(true);
                         return;
                     }

--- a/crates/ersatztv/src/channel_session.rs
+++ b/crates/ersatztv/src/channel_session.rs
@@ -1,8 +1,9 @@
 use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::Arc;
+use std::time::Duration;
 
-use ersatztv_core::{HEARTBEAT_FILE_NAME, READY_FILE_NAME, READY_FILE_TIMEOUT, wait_for_file};
+use ersatztv_core::{HEARTBEAT_FILE_NAME, READY_FILE_NAME};
 use tokio::sync::{Mutex, watch};
 
 use crate::channel_model::ChannelModel;
@@ -28,20 +29,24 @@ impl ChannelSession {
             .map_err(LineupError::Io)?;
 
         let (ready_sender, ready_receiver) = watch::channel(false);
-
-        let ready_file = channel.output_folder().join(READY_FILE_NAME);
-        tokio::spawn(async move {
-            if wait_for_file(&ready_file, READY_FILE_TIMEOUT).await {
-                let _ = ready_sender.send(true);
-            }
-        });
-
-        let channel_number = channel.number().to_owned();
-
         let ready_file = channel.output_folder().join(READY_FILE_NAME);
         let heartbeat_file = channel.output_folder().join(HEARTBEAT_FILE_NAME);
+        let channel_number = channel.number().to_owned();
+
         tokio::spawn(async move {
+            let ready_file_clone = ready_file.clone();
+            let watcher = tokio::spawn(async move {
+                loop {
+                    if ready_file_clone.exists() {
+                        let _ = ready_sender.send(true);
+                        return;
+                    }
+                    tokio::time::sleep(Duration::from_millis(200)).await;
+                }
+            });
+
             let _ = child.wait().await;
+            watcher.abort();
             log::debug!("channel {} exited", &channel_number);
             active.lock().await.remove(&channel_number);
 

--- a/crates/ersatztv/src/error.rs
+++ b/crates/ersatztv/src/error.rs
@@ -18,14 +18,24 @@ pub enum LineupError {
 
     #[error("unable to find channel with number {0}")]
     ChannelNotFound(String),
+
+    #[error("channel is not yet ready")]
+    ChannelNotReady,
 }
 
 impl IntoResponse for LineupError {
     fn into_response(self) -> Response {
-        let status = match self {
-            LineupError::ChannelNotFound(_) => StatusCode::NOT_FOUND,
-            _ => StatusCode::INTERNAL_SERVER_ERROR,
-        };
-        (status, self.to_string()).into_response()
+        match self {
+            LineupError::ChannelNotFound(_) => {
+                (StatusCode::NOT_FOUND, self.to_string()).into_response()
+            }
+            LineupError::ChannelNotReady => (
+                StatusCode::SERVICE_UNAVAILABLE,
+                [(axum::http::header::RETRY_AFTER, "5")],
+                "channel not ready",
+            )
+                .into_response(),
+            _ => (StatusCode::INTERNAL_SERVER_ERROR, self.to_string()).into_response(),
+        }
     }
 }

--- a/crates/ersatztv/src/main.rs
+++ b/crates/ersatztv/src/main.rs
@@ -10,7 +10,7 @@ use axum::extract::{Path, State};
 use axum::response::IntoResponse;
 use axum::{Router, routing::get};
 use clap::Parser;
-use ersatztv_core::{HEARTBEAT_FILE_NAME, empty_folder};
+use ersatztv_core::{HEARTBEAT_FILE_NAME, READY_FILE_TIMEOUT, empty_folder};
 use tokio::signal;
 use tokio::sync::Mutex;
 use tower::ServiceBuilder;
@@ -151,10 +151,12 @@ async fn stream(
         }
     };
 
-    ready_receiver
-        .wait_for(|&ready| ready)
-        .await
-        .map_err(|_| LineupError::ChannelNotFound(String::from("channel timeout")))?;
+    let wait = ready_receiver.wait_for(|&r| r);
+    match tokio::time::timeout(READY_FILE_TIMEOUT, wait).await {
+        Ok(Ok(_)) => {}
+        Ok(Err(_)) => return Err(LineupError::ChannelNotReady), // child died
+        Err(_) => return Err(LineupError::ChannelNotReady),     // 30s deadline
+    }
 
     let content = get_multi_variant(channel, request);
 

--- a/crates/ffpipeline/Cargo.toml
+++ b/crates/ffpipeline/Cargo.toml
@@ -19,6 +19,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 simple-expand-tilde = { workspace = true }
 strum = { workspace = true }
+tempfile = { workspace = true }
 thiserror = { workspace = true }
 time = { workspace = true }
 tokio = { workspace = true }

--- a/crates/ffpipeline/src/error.rs
+++ b/crates/ffpipeline/src/error.rs
@@ -24,4 +24,8 @@ pub enum FFPipelineError {
     VideoToolboxCapabilitiesError(String),
     #[error("error detecting vulkan capabilities: {0}")]
     VulkanCapabilitiesError(String),
+    #[error("failed to convert subtitle")]
+    FailedToConvertSubtitle,
+    #[error("failed to parse subtitle")]
+    FailedToParseSubtitle,
 }

--- a/crates/ffpipeline/src/input.rs
+++ b/crates/ffpipeline/src/input.rs
@@ -216,6 +216,7 @@ pub struct HttpInputOptions {
     pub timeout_us: Option<u64>,
     pub reconnect: bool,
     pub reconnect_delay_max: Option<u32>,
+    pub keep_alive: Option<bool>,
 }
 
 #[derive(Debug, Clone)]
@@ -280,12 +281,14 @@ impl FfmpegInputArgs for HttpInputSource {
                 "1",
                 "-reconnect_streamed",
                 "1",
-                "-multiple_requests",
-                "1",
             ]);
             if let Some(max_delay) = self.options.reconnect_delay_max {
                 args.extend(args!["-reconnect_delay_max", max_delay.to_string()]);
             }
+        }
+
+        if self.options.keep_alive.is_some_and(|ka| ka) {
+            args.extend(args!["-multiple_requests", "1"])
         }
 
         if let Some(timeout) = self.options.timeout_us {

--- a/crates/ffpipeline/src/lib.rs
+++ b/crates/ffpipeline/src/lib.rs
@@ -26,3 +26,4 @@ pub mod probe;
 pub mod video_codec;
 pub mod video_decoder;
 pub mod video_filter;
+pub mod web_vtt;

--- a/crates/ffpipeline/src/web_vtt.rs
+++ b/crates/ffpipeline/src/web_vtt.rs
@@ -1,11 +1,12 @@
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
-use ersatztv_channel::error::ChannelError;
-use ffpipeline::input::{InputSource, ProbedInput};
-use ffpipeline::probe::{CodecType, ProbeResultStream, ProbeResultVideoStream};
 use tempfile::NamedTempFile;
 use tokio::process::Command;
+
+use crate::error::FFPipelineError;
+use crate::input::{InputSource, ProbedInput};
+use crate::probe::{CodecType, ProbeResultStream, ProbeResultVideoStream};
 
 #[derive(Clone)]
 pub struct Cue {
@@ -14,11 +15,11 @@ pub struct Cue {
     pub text: String,
 }
 
-pub(crate) async fn convert_to_vtt(
+pub async fn convert_to_vtt(
     ffmpeg_path: &PathBuf,
     input: &ProbedInput,
     subtitle_stream: &ProbeResultVideoStream,
-) -> Result<NamedTempFile, ChannelError> {
+) -> Result<NamedTempFile, FFPipelineError> {
     match &input.input_source {
         InputSource::Local(local) => {
             // find index of subtitle *within subtitle streams*
@@ -31,9 +32,10 @@ pub(crate) async fn convert_to_vtt(
                     _ => None,
                 })
                 .position(|v| v.stream_index == subtitle_stream.stream_index)
-                .ok_or(ChannelError::FailedToConvertSubtitle)?;
+                .ok_or(FFPipelineError::FailedToConvertSubtitle)?;
 
-            let temp_file = NamedTempFile::with_suffix(".vtt")?;
+            let temp_file = NamedTempFile::with_suffix(".vtt")
+                .map_err(|_| FFPipelineError::FailedToConvertSubtitle)?;
             let file_name = temp_file.path().to_string_lossy();
             let mut ffmpeg = Command::new(ffmpeg_path)
                 .args([
@@ -53,29 +55,34 @@ pub(crate) async fn convert_to_vtt(
                 .stdout(std::process::Stdio::piped())
                 .stderr(std::process::Stdio::null())
                 .spawn()
-                .map_err(|_| ChannelError::FailedToConvertSubtitle)?;
+                .map_err(|_| FFPipelineError::FailedToConvertSubtitle)?;
 
-            let result = ffmpeg.wait().await?;
+            let result = ffmpeg
+                .wait()
+                .await
+                .map_err(|_| FFPipelineError::FailedToConvertSubtitle)?;
             if result.success() {
                 Ok(temp_file)
             } else {
-                Err(ChannelError::FailedToConvertSubtitle)
+                Err(FFPipelineError::FailedToConvertSubtitle)
             }
         }
-        _ => Err(ChannelError::FailedToConvertSubtitle),
+        _ => Err(FFPipelineError::FailedToConvertSubtitle),
     }
 }
 
-pub(crate) async fn parse_file(path: &Path) -> Result<Vec<Cue>, ChannelError> {
+pub async fn parse_file(path: &Path) -> Result<Vec<Cue>, FFPipelineError> {
     if path.exists() {
-        let contents = tokio::fs::read_to_string(&path).await?;
+        let contents = tokio::fs::read_to_string(&path)
+            .await
+            .map_err(|_| FFPipelineError::FailedToParseSubtitle)?;
         return parse_internal(&contents);
     }
 
-    Err(ChannelError::FailedToParseSubtitle)
+    Err(FFPipelineError::FailedToParseSubtitle)
 }
 
-pub(crate) fn format_vtt_ts(duration: Duration) -> String {
+pub fn format_vtt_ts(duration: Duration) -> String {
     format!(
         "{:02}:{:02}:{:02}.{:03}",
         duration.as_secs() / 3600,
@@ -92,7 +99,7 @@ enum ParseState {
     Cue,
 }
 
-fn parse_internal(body: &str) -> Result<Vec<Cue>, ChannelError> {
+fn parse_internal(body: &str) -> Result<Vec<Cue>, FFPipelineError> {
     let mut result = Vec::new();
     let mut parse_state = ParseState::Header;
     let mut start = Duration::ZERO;

--- a/crates/ffpipeline/src/web_vtt.rs
+++ b/crates/ffpipeline/src/web_vtt.rs
@@ -59,7 +59,7 @@ pub async fn convert_to_vtt(
 
     let mut ffmpeg = Command::new(ffmpeg_path)
         .args(args.iter().map(Cow::as_ref))
-        .stdout(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::null())
         .stderr(std::process::Stdio::null())
         .spawn()
         .map_err(|_| FFPipelineError::FailedToConvertSubtitle)?;
@@ -76,14 +76,10 @@ pub async fn convert_to_vtt(
 }
 
 pub async fn parse_file(path: &Path) -> Result<Vec<Cue>, FFPipelineError> {
-    if path.exists() {
-        let contents = tokio::fs::read_to_string(&path)
-            .await
-            .map_err(|_| FFPipelineError::FailedToParseSubtitle)?;
-        return parse_internal(&contents);
-    }
-
-    Err(FFPipelineError::FailedToParseSubtitle)
+    let contents = tokio::fs::read_to_string(path)
+        .await
+        .map_err(|_| FFPipelineError::FailedToParseSubtitle)?;
+    parse_internal(&contents)
 }
 
 pub fn format_vtt_ts(duration: Duration) -> String {

--- a/crates/ffpipeline/src/web_vtt.rs
+++ b/crates/ffpipeline/src/web_vtt.rs
@@ -1,11 +1,13 @@
+use std::borrow::Cow;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
 use tempfile::NamedTempFile;
 use tokio::process::Command;
 
+use crate::ArgVec;
 use crate::error::FFPipelineError;
-use crate::input::{InputSource, ProbedInput};
+use crate::input::{FfmpegInputArgs, InputSource, ProbedInput};
 use crate::probe::{CodecType, ProbeResultStream, ProbeResultVideoStream};
 
 #[derive(Clone)]
@@ -20,54 +22,56 @@ pub async fn convert_to_vtt(
     input: &ProbedInput,
     subtitle_stream: &ProbeResultVideoStream,
 ) -> Result<NamedTempFile, FFPipelineError> {
-    match &input.input_source {
-        InputSource::Local(local) => {
-            // find index of subtitle *within subtitle streams*
-            let subtitle_index = input
-                .probe_result
-                .streams
-                .iter()
-                .filter_map(|s| match s {
-                    ProbeResultStream::Video(v) if v.codec_type == CodecType::Subtitle => Some(v),
-                    _ => None,
-                })
-                .position(|v| v.stream_index == subtitle_stream.stream_index)
-                .ok_or(FFPipelineError::FailedToConvertSubtitle)?;
+    let input_path = match &input.input_source {
+        InputSource::Local(local) => Ok(local.path.clone()),
+        InputSource::Http(http) => Ok(http.uri.clone()),
+        InputSource::Lavfi(_) => Err(FFPipelineError::FailedToConvertSubtitle),
+    }?;
 
-            let temp_file = NamedTempFile::with_suffix(".vtt")
-                .map_err(|_| FFPipelineError::FailedToConvertSubtitle)?;
-            let file_name = temp_file.path().to_string_lossy();
-            let mut ffmpeg = Command::new(ffmpeg_path)
-                .args([
-                    "-nostdin",
-                    "-hide_banner",
-                    "-loglevel",
-                    "error",
-                    "-i",
-                    local.path.as_str(),
-                    "-map",
-                    &format!("0:s:{}", subtitle_index),
-                    "-c:s",
-                    "webvtt",
-                    "-y",
-                    &file_name,
-                ])
-                .stdout(std::process::Stdio::piped())
-                .stderr(std::process::Stdio::null())
-                .spawn()
-                .map_err(|_| FFPipelineError::FailedToConvertSubtitle)?;
+    // find index of subtitle *within subtitle streams*
+    let subtitle_index = input
+        .probe_result
+        .streams
+        .iter()
+        .filter_map(|s| match s {
+            ProbeResultStream::Video(v) if v.codec_type == CodecType::Subtitle => Some(v),
+            _ => None,
+        })
+        .position(|v| v.stream_index == subtitle_stream.stream_index)
+        .ok_or(FFPipelineError::FailedToConvertSubtitle)?;
 
-            let result = ffmpeg
-                .wait()
-                .await
-                .map_err(|_| FFPipelineError::FailedToConvertSubtitle)?;
-            if result.success() {
-                Ok(temp_file)
-            } else {
-                Err(FFPipelineError::FailedToConvertSubtitle)
-            }
-        }
-        _ => Err(FFPipelineError::FailedToConvertSubtitle),
+    let temp_file =
+        NamedTempFile::with_suffix(".vtt").map_err(|_| FFPipelineError::FailedToConvertSubtitle)?;
+    let file_name = temp_file.path().to_string_lossy().into_owned();
+
+    let mut args: ArgVec = args!["-nostdin", "-hide_banner", "-loglevel", "error"];
+    args.extend(input.input_source.args_for_input());
+    args.extend(args![
+        "-i",
+        input_path,
+        "-map",
+        format!("0:s:{}", subtitle_index),
+        "-c:s",
+        "webvtt",
+        "-y",
+        file_name
+    ]);
+
+    let mut ffmpeg = Command::new(ffmpeg_path)
+        .args(args.iter().map(Cow::as_ref))
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::null())
+        .spawn()
+        .map_err(|_| FFPipelineError::FailedToConvertSubtitle)?;
+
+    let result = ffmpeg
+        .wait()
+        .await
+        .map_err(|_| FFPipelineError::FailedToConvertSubtitle)?;
+    if result.success() {
+        Ok(temp_file)
+    } else {
+        Err(FFPipelineError::FailedToConvertSubtitle)
     }
 }
 

--- a/schema/playout.json
+++ b/schema/playout.json
@@ -452,6 +452,13 @@
           ],
           "minimum": 0,
           "description": "Maximum reconnect delay in seconds. Maps to ffmpeg's `reconnect_delay_max`."
+        },
+        "keep_alive": {
+          "type": [
+            "boolean",
+            "null"
+          ],
+          "description": "Enable persistent connections in ffmpeg. Default: false."
         }
       }
     }


### PR DESCRIPTION
- Moves `web_vtt.rs` down into `ffpipeline` so that it can directly use `ArgVec`.
- Uses `args_for_input()` when extracting subtitles
- Separates `multiple_requests` ffmpeg option into its own http source option `keep_alive`. Disabled by default since it causes issues when URLs 302.
- Reworks startup process a bit to handle slow channel startup (503 after 30s, but still allow channel to start in the background).