### PR TITLE
fix: multiple fixes for slow-starting streams

### DIFF
--- a/crates/ersatztv-channel/src/channel_session.rs
+++ b/crates/ersatztv-channel/src/channel_session.rs
@@ -21,7 +21,8 @@ use ffpipeline::input::{
 };
 use ffpipeline::output_settings::{AudioOutputSettings, OutputSettings};
 use ffpipeline::pipeline::{AudioFormat, Hz, Kbps, PtsOffset, SEGMENT_SECONDS, VideoFormat};
-use ffpipeline::probe::{ProbeResult, Probeable};
+use ffpipeline::probe::{ProbeResult, ProbeResultVideoStream, Probeable};
+use ffpipeline::web_vtt::Cue;
 use ffpipeline::{pipeline, probe};
 use time::OffsetDateTime;
 use tokio::sync::Mutex;
@@ -77,6 +78,8 @@ pub struct ChannelSession {
     state: ChannelSessionState,
 
     timeout_notify: Arc<tokio::sync::Notify>,
+
+    cached_subtitles: Option<(String, Arc<Vec<Cue>>)>,
 }
 
 impl ChannelSession {
@@ -162,6 +165,7 @@ impl ChannelSession {
             start_time_offset,
             state: ChannelSessionState::SeekAndWorkAhead,
             timeout_notify: Arc::new(tokio::sync::Notify::new()),
+            cached_subtitles: None,
         })
     }
 
@@ -558,22 +562,19 @@ impl ChannelSession {
             && let Some(subtitle_stream) = input_settings.select_subtitle_stream()
             && !subtitle_stream.is_subtitle_image()
             && let Some(input) = input_settings.subtitle_input.as_ref()
-        {
-            match ffpipeline::web_vtt::convert_to_vtt(&self.ffmpeg_path, input, subtitle_stream)
-                .await
-            {
-                Ok(temp_file) => match ffpipeline::web_vtt::parse_file(temp_file.path()).await {
-                    Ok(cues) => {
-                        subtitle_source = Some(SubtitleSource {
-                            cues,
-                            cursor: 0,
-                            next_segment_source_offset: input.in_point,
-                        })
-                    }
-                    Err(err) => log::warn!("error parsing converted vtt: {err}"),
-                },
-                Err(err) => log::warn!("error converting subtitle to vtt: {err}"),
+            && let Some(cues) = match &self.cached_subtitles {
+                Some((id, c)) if id == &current_item.id => Some(Arc::clone(c)),
+                _ => {
+                    self.extract_and_convert_subs(input, subtitle_stream, current_item)
+                        .await
+                }
             }
+        {
+            subtitle_source = Some(SubtitleSource {
+                cues,
+                cursor: 0,
+                next_segment_source_offset: input.in_point,
+            });
         }
 
         let pts_offset = output_settings.pts_offset;
@@ -812,6 +813,35 @@ impl ChannelSession {
             .and_then(pick)
             .and_then(|sel| sel.source.clone())
             .or_else(|| item.source.clone())
+    }
+
+    async fn extract_and_convert_subs(
+        &mut self,
+        input: &ProbedInput,
+        subtitle_stream: &ProbeResultVideoStream,
+        current_item: &PlayoutItem,
+    ) -> Option<Arc<Vec<Cue>>> {
+        {
+            match ffpipeline::web_vtt::convert_to_vtt(&self.ffmpeg_path, input, subtitle_stream)
+                .await
+            {
+                Ok(temp_file) => match ffpipeline::web_vtt::parse_file(temp_file.path()).await {
+                    Ok(extracted_cues) => {
+                        let arc = Arc::new(extracted_cues);
+                        self.cached_subtitles = Some((current_item.id.clone(), Arc::clone(&arc)));
+                        Some(arc)
+                    }
+                    Err(err) => {
+                        log::warn!("error parsing converted vtt: {err}");
+                        None
+                    }
+                },
+                Err(err) => {
+                    log::warn!("error converting subtitle to vtt: {err}");
+                    None
+                }
+            }
+        }
     }
 }
 

--- a/crates/ersatztv-channel/src/playlist_manager.rs
+++ b/crates/ersatztv-channel/src/playlist_manager.rs
@@ -1,5 +1,6 @@
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 use std::time::Duration;
 
 use ersatztv_channel::error::ChannelError;
@@ -13,7 +14,7 @@ const MIN_SEGMENTS: usize = 4;
 
 #[derive(Clone)]
 pub struct SubtitleSource {
-    pub cues: Vec<Cue>,
+    pub cues: Arc<Vec<Cue>>,
     pub(crate) cursor: usize,
     pub next_segment_source_offset: Duration,
 }

--- a/crates/ersatztv-channel/src/playlist_manager.rs
+++ b/crates/ersatztv-channel/src/playlist_manager.rs
@@ -31,6 +31,7 @@ pub struct PlaylistManager {
     segments: VecDeque<Segment>,
     discontinuity_before: HashSet<String>,
     media_sequence: u64,
+    last_served_media_sequence: u64,
     discontinuity_sequence: u64,
     target_duration: u32,
     target_duration_f64: f64,
@@ -79,6 +80,7 @@ impl PlaylistManager {
             segments: VecDeque::new(),
             discontinuity_before: HashSet::new(),
             media_sequence: 0,
+            last_served_media_sequence: 0,
             discontinuity_sequence: 0,
             target_duration,
             target_duration_f64: target_duration as f64,
@@ -251,7 +253,7 @@ impl PlaylistManager {
     }
 
     fn generate_playlist(
-        &self,
+        &mut self,
         path_map: fn(&str) -> String,
         max_segments: Option<usize>,
     ) -> Result<String, ChannelError> {
@@ -264,12 +266,21 @@ impl PlaylistManager {
             Some(max) => {
                 let anchor = OffsetDateTime::now_utc()
                     - Duration::from_secs(ffpipeline::pipeline::SEGMENT_SECONDS as u64 * 5u64);
-                let start = self
+
+                let candidate_skip = self
                     .segments
                     .iter()
                     .position(|s| s.program_date_time >= anchor)
-                    .unwrap_or(0);
-                (start, max)
+                    .unwrap_or_else(|| self.segments.len().saturating_sub(max));
+
+                // monotonic clamp
+                let candidate_ms = self.media_sequence + candidate_skip as u64;
+                let clamped_ms = candidate_ms.max(self.last_served_media_sequence);
+                self.last_served_media_sequence = clamped_ms;
+
+                let skip = (clamped_ms - self.media_sequence) as usize;
+                let skip = skip.min(self.segments.len());
+                (skip, max)
             }
             None => (0, self.segments.len()),
         };


### PR DESCRIPTION
- Media sequence shouldn't ever decrease; this could happen if there is a long delay between segments (e.g. due to duplicate subtitle extraction)
- Extracted subtitles for the current playout item should be cached so when ffmpeg is invoked multiple times (to work ahead, and eventually to throttle to realtime), it re-uses the already extracted subtitles