### PR TITLE
feat: add typed video filter options to channel config

### DIFF
--- a/crates/ersatztv-channel/src/channel_session.rs
+++ b/crates/ersatztv-channel/src/channel_session.rs
@@ -472,7 +472,7 @@ impl ChannelSession {
             video_buffer: video_norm.buffer_kbps.map(Kbps),
             video_size,
             scaling_mode: video_norm.scaling_mode.into(),
-            tonemap_algorithm: video_norm.tonemap_algorithm.clone(),
+            filter_options: video_norm.filters.clone().into(),
             deinterlace: video_norm.deinterlace,
             accel: self.hw_accel.clone(),
             format: ffpipeline::output_format::OutputFormat::Hls {

--- a/crates/ersatztv-channel/src/config.rs
+++ b/crates/ersatztv-channel/src/config.rs
@@ -116,9 +116,52 @@ pub struct VideoNormalizationConfig {
     pub accel: Option<HardwareAccel>,
     pub vaapi_device: Option<PathBuf>,
     pub vaapi_driver: Option<VaapiDriver>,
-    pub tonemap_algorithm: Option<String>,
     #[serde(default)]
     pub deinterlace: bool,
+    #[serde(default)]
+    pub filters: VideoFilterOptionsConfig,
+}
+
+#[derive(Deserialize, Clone, Debug, Default, JsonSchema)]
+#[serde(default, deny_unknown_fields)]
+pub struct VideoFilterOptionsConfig {
+    pub libplacebo: Option<LibplaceboOptions>,
+    pub tonemap: Option<TonemapOptions>,
+    pub tonemap_opencl: Option<TonemapOpenclOptions>,
+}
+
+#[derive(Deserialize, Clone, Debug, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct TonemapOptions {
+    pub tonemap: Option<String>,
+}
+
+#[derive(Deserialize, Clone, Debug, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct TonemapOpenclOptions {
+    pub tonemap: Option<String>,
+}
+
+#[derive(Deserialize, Clone, Debug, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct LibplaceboOptions {
+    pub tonemapping: Option<String>,
+}
+
+impl From<VideoFilterOptionsConfig> for ffpipeline::output_settings::VideoFilterOptions {
+    fn from(value: VideoFilterOptionsConfig) -> Self {
+        ffpipeline::output_settings::VideoFilterOptions {
+            libplacebo: ffpipeline::output_settings::LibplaceboOptions {
+                tonemapping: value.libplacebo.and_then(|o| o.tonemapping),
+            },
+            tonemap: ffpipeline::output_settings::TonemapOptions {
+                tonemap: value.tonemap.and_then(|o| o.tonemap),
+            },
+            tonemap_opencl: ffpipeline::output_settings::TonemapOpenclOptions {
+                tonemap: value.tonemap_opencl.and_then(|o| o.tonemap),
+            },
+        }
+    }
 }
 
 #[derive(Deserialize, Clone, Copy, Debug, JsonSchema, Default)]

--- a/crates/ffpipeline/src/accel/cuda.rs
+++ b/crates/ffpipeline/src/accel/cuda.rs
@@ -4,6 +4,7 @@ use crate::ffmpeg_info::{FfmpegInfo, KnownHardwareAccel, KnownVideoFilter};
 use crate::filter_chain::PipelineFilter;
 use crate::frame_size::FrameSize;
 use crate::hw_accel::{HwAccel, HwDecoder};
+use crate::output_settings::VideoFilterOptions;
 use crate::overlay_filter::{FramePoint, OverlayFilter, OverlayKind, OverlayKindOp};
 use crate::pipeline::{FrameState, FrameSurface, PixelFormat, SurfaceSet, VideoFormat};
 use crate::probe::ProbeResultVideoStream;
@@ -30,6 +31,7 @@ impl HwAccel for Cuda {
         video_filter: &VideoFilter,
         ffmpeg_info: &FfmpegInfo,
         current_state: &FrameState,
+        filter_options: &VideoFilterOptions,
     ) -> VideoFilter {
         match video_filter {
             VideoFilter::Scale(ScaleFilter {
@@ -53,11 +55,11 @@ impl HwAccel for Cuda {
                 PadCuda { size: *size }.into()
             }
             VideoFilter::ToneMap(ToneMapFilter {
-                algorithm,
                 output_format: format,
+                ..
             }) if current_state.is_hdr && current_state.surface == FrameSurface::Vulkan => {
                 LibplaceboCuda {
-                    algorithm: algorithm.clone(),
+                    algorithm: filter_options.libplacebo.tonemapping.clone(),
                     format: match format {
                         PixelFormat::Yuv420p10le => PixelFormat::P010le,
                         _ => PixelFormat::Nv12,

--- a/crates/ffpipeline/src/accel/qsv.rs
+++ b/crates/ffpipeline/src/accel/qsv.rs
@@ -3,6 +3,7 @@ use crate::capabilities::qsv::QsvCapabilities;
 use crate::ffmpeg_info::{FfmpegInfo, KnownHardwareAccel, KnownVideoFilter};
 use crate::frame_size::FrameSize;
 use crate::hw_accel::{HwAccel, HwDecoder};
+use crate::output_settings::VideoFilterOptions;
 use crate::pipeline::{FrameState, FrameSurface, PixelFormat, SurfaceSet, VideoFormat};
 use crate::probe::ProbeResultVideoStream;
 use crate::video_codec::VideoCodec;
@@ -19,6 +20,7 @@ impl HwAccel for Qsv {
         video_filter: &VideoFilter,
         ffmpeg_info: &FfmpegInfo,
         _current_state: &FrameState,
+        _filter_options: &VideoFilterOptions,
     ) -> VideoFilter {
         match video_filter {
             VideoFilter::Scale(ScaleFilter {

--- a/crates/ffpipeline/src/accel/vaapi.rs
+++ b/crates/ffpipeline/src/accel/vaapi.rs
@@ -5,6 +5,7 @@ use crate::capabilities::vaapi::VaapiCapabilities;
 use crate::ffmpeg_info::{FfmpegInfo, KnownHardwareAccel, KnownVideoFilter};
 use crate::frame_size::FrameSize;
 use crate::hw_accel::{HwAccel, HwDecoder};
+use crate::output_settings::VideoFilterOptions;
 use crate::overlay_filter::{FramePoint, OverlayFilter, OverlayKind, OverlayKindOp};
 use crate::pipeline::{
     FrameState, FrameSurface, HwPixelFormat, PixelFormat, SurfaceSet, VideoFormat,
@@ -40,6 +41,7 @@ impl HwAccel for Vaapi {
         video_filter: &VideoFilter,
         ffmpeg_info: &FfmpegInfo,
         current_state: &FrameState,
+        filter_options: &VideoFilterOptions,
     ) -> VideoFilter {
         match video_filter {
             VideoFilter::Scale(ScaleFilter {
@@ -87,8 +89,8 @@ impl HwAccel for Vaapi {
             }
 
             VideoFilter::ToneMap(ToneMapFilter {
-                algorithm,
                 output_format: format,
+                ..
             }) => {
                 let tonemap_output_format = self.output_format(format);
                 let can_vaapi_tonemap = match (&current_state.pixel_format, tonemap_output_format) {
@@ -109,7 +111,7 @@ impl HwAccel for Vaapi {
                 if let Some(hw_filter) = ffmpeg_info.find_best_fit(tonemap_options.as_slice()) {
                     match hw_filter {
                         KnownVideoFilter::TonemapOpencl => TonemapOpencl {
-                            algorithm: algorithm.clone(),
+                            algorithm: filter_options.tonemap_opencl.tonemap.clone(),
                             output_format: self.output_format(format),
                         }
                         .into(),
@@ -570,13 +572,14 @@ mod tests {
             },
             ..make_frame_state()
         };
+        let filter_options = VideoFilterOptions::default();
 
         let sw_deinterlace = VideoFilter::Deinterlace(DeinterlaceFilter {
             filter: SoftwareDeinterlaceFilter::Yadif,
             input_is_interlaced: true,
         });
 
-        let result = vaapi.best_filter(&sw_deinterlace, &ffmpeg_info, &state);
+        let result = vaapi.best_filter(&sw_deinterlace, &ffmpeg_info, &state, &filter_options);
 
         assert!(
             matches!(
@@ -625,13 +628,14 @@ mod tests {
             is_interlaced: true,
             ..make_frame_state()
         };
+        let filter_options = VideoFilterOptions::default();
 
         let sw_deinterlace = VideoFilter::Deinterlace(DeinterlaceFilter {
             filter: SoftwareDeinterlaceFilter::Yadif,
             input_is_interlaced: true,
         });
 
-        let result = vaapi.best_filter(&sw_deinterlace, &ffmpeg_info, &state);
+        let result = vaapi.best_filter(&sw_deinterlace, &ffmpeg_info, &state, &filter_options);
 
         assert!(
             matches!(&result, VideoFilter::Deinterlace(_)),
@@ -645,13 +649,14 @@ mod tests {
         let vaapi = make_vaapi();
         let ffmpeg_info = make_ffmpeg_info(&[KnownVideoFilter::DeinterlaceVaapi]);
         let state = make_frame_state();
+        let filter_options = VideoFilterOptions::default();
 
         let sw_deinterlace = VideoFilter::Deinterlace(DeinterlaceFilter {
             filter: SoftwareDeinterlaceFilter::Yadif,
             input_is_interlaced: false,
         });
 
-        let result = vaapi.best_filter(&sw_deinterlace, &ffmpeg_info, &state);
+        let result = vaapi.best_filter(&sw_deinterlace, &ffmpeg_info, &state, &filter_options);
 
         assert!(
             matches!(&result, VideoFilter::Deinterlace(_)),

--- a/crates/ffpipeline/src/accel/video_toolbox.rs
+++ b/crates/ffpipeline/src/accel/video_toolbox.rs
@@ -3,6 +3,7 @@ use crate::capabilities::videotoolbox::VideoToolboxCapabilities;
 use crate::ffmpeg_info::{FfmpegInfo, KnownHardwareAccel, KnownVideoFilter};
 use crate::frame_size::FrameSize;
 use crate::hw_accel::{HwAccel, HwDecoder};
+use crate::output_settings::VideoFilterOptions;
 use crate::pipeline::{FrameState, FrameSurface, PixelFormat, SurfaceSet, VideoFormat};
 use crate::probe::ProbeResultVideoStream;
 use crate::video_codec::VideoCodec;
@@ -25,6 +26,7 @@ impl HwAccel for VideoToolbox {
         video_filter: &VideoFilter,
         ffmpeg_info: &FfmpegInfo,
         _current_state: &FrameState,
+        _filter_options: &VideoFilterOptions,
     ) -> VideoFilter {
         match video_filter {
             VideoFilter::Scale(ScaleFilter {

--- a/crates/ffpipeline/src/accel/vulkan.rs
+++ b/crates/ffpipeline/src/accel/vulkan.rs
@@ -3,6 +3,7 @@ use crate::capabilities::vulkan::VulkanCapabilities;
 use crate::ffmpeg_info::{FfmpegInfo, KnownHardwareAccel, KnownVideoFilter};
 use crate::frame_size::FrameSize;
 use crate::hw_accel::{HwAccel, HwDecoder};
+use crate::output_settings::VideoFilterOptions;
 use crate::pipeline::{FrameState, FrameSurface, PixelFormat, SurfaceSet, VideoFormat};
 use crate::probe::ProbeResultVideoStream;
 use crate::video_codec::VideoCodec;
@@ -19,6 +20,7 @@ impl HwAccel for Vulkan {
         video_filter: &VideoFilter,
         ffmpeg_info: &FfmpegInfo,
         current_state: &FrameState,
+        filter_options: &VideoFilterOptions,
     ) -> VideoFilter {
         match video_filter {
             VideoFilter::Scale(ScaleFilter {
@@ -35,10 +37,10 @@ impl HwAccel for Vulkan {
                 .into()
             }
             VideoFilter::ToneMap(ToneMapFilter {
-                algorithm,
                 output_format: format,
+                ..
             }) if ffmpeg_info.has_video_filter(&KnownVideoFilter::LibPlacebo) => LibplaceboVulkan {
-                algorithm: algorithm.clone(),
+                algorithm: filter_options.libplacebo.tonemapping.clone(),
                 format: match format {
                     PixelFormat::Yuv420p10le => PixelFormat::P010le,
                     _ => PixelFormat::Nv12,

--- a/crates/ffpipeline/src/filter_chain.rs
+++ b/crates/ffpipeline/src/filter_chain.rs
@@ -2,6 +2,7 @@ use crate::ArgVec;
 use crate::audio_filter::AudioFilter;
 use crate::ffmpeg_info::FfmpegInfo;
 use crate::hw_accel::{HardwareAccel, HwAccel};
+use crate::output_settings::VideoFilterOptions;
 use crate::overlay_filter::{OverlayFilter, OverlayKindOp, OverlaySource};
 use crate::pipeline::{FrameState, FrameSurface, PixelFormat, SurfaceSet};
 use crate::video_filter::{
@@ -92,6 +93,7 @@ impl FilterChain {
         &mut self,
         ffmpeg_info: &FfmpegInfo,
         accel: &Option<HardwareAccel>,
+        filter_options: &VideoFilterOptions,
         initial_state: &FrameState,
         encoder_surface: &FrameSurface,
         encoder_pixel_format: &Option<PixelFormat>,
@@ -104,7 +106,9 @@ impl FilterChain {
             match filter {
                 PipelineFilter::Video(video_filter) => {
                     let mut best = match accel {
-                        Some(a) => a.best_filter(video_filter, ffmpeg_info, &current_state),
+                        Some(a) => {
+                            a.best_filter(video_filter, ffmpeg_info, &current_state, filter_options)
+                        }
                         _ => video_filter.clone(),
                     };
 
@@ -182,6 +186,7 @@ impl FilterChain {
                     sec.resolve(
                         ffmpeg_info,
                         sec_accel,
+                        filter_options,
                         &best.secondary_initial_state,
                         &sec_req.surface,
                         &Some(sec_req.pixel_format),
@@ -614,6 +619,7 @@ mod tests {
         let accel = vaapi_accel();
         let initial_state = hdr_vaapi_state();
         let ffmpeg_info = FfmpegInfo::default();
+        let filter_options = VideoFilterOptions::default();
 
         let tonemap: VideoFilter = TonemapOpencl {
             algorithm: Some(String::from("hable")),
@@ -626,6 +632,7 @@ mod tests {
         chain.resolve(
             &ffmpeg_info,
             &Some(accel),
+            &filter_options,
             &initial_state,
             &FrameSurface::Vaapi,
             &Some(PixelFormat::Nv12),
@@ -681,6 +688,7 @@ mod tests {
         let accel = vaapi_accel();
         let initial_state = hdr_vaapi_state();
         let ffmpeg_info = FfmpegInfo::default();
+        let filter_options = VideoFilterOptions::default();
 
         let tonemap: VideoFilter = TonemapOpencl {
             algorithm: Some(String::from("hable")),
@@ -693,6 +701,7 @@ mod tests {
         chain.resolve(
             &ffmpeg_info,
             &Some(accel),
+            &filter_options,
             &initial_state,
             &FrameSurface::Vaapi,
             &Some(PixelFormat::Nv12),
@@ -729,6 +738,7 @@ mod tests {
         let accel = vaapi_accel();
         let initial_state = hdr_vaapi_state();
         let ffmpeg_info = FfmpegInfo::default();
+        let filter_options = VideoFilterOptions::default();
 
         let format_filter: VideoFilter = FormatFilter {
             format: PixelFormat::Nv12,
@@ -740,6 +750,7 @@ mod tests {
         chain.resolve(
             &ffmpeg_info,
             &Some(accel),
+            &filter_options,
             &initial_state,
             &FrameSurface::Vaapi,
             &Some(PixelFormat::Nv12),
@@ -763,6 +774,7 @@ mod tests {
         let vaapi = vaapi_accel_with_tonemap(VaapiDriver::RadeonSI, true, false, false);
         let ffmpeg_info = ffmpeg_info_with_filters(&[KnownVideoFilter::TonemapVaapi]);
         let state = hdr_vaapi_state();
+        let filter_options = VideoFilterOptions::default();
 
         let input: VideoFilter = ToneMapFilter {
             algorithm: Some(String::from("hable")),
@@ -770,7 +782,7 @@ mod tests {
         }
         .into();
 
-        let result = vaapi.best_filter(&input, &ffmpeg_info, &state);
+        let result = vaapi.best_filter(&input, &ffmpeg_info, &state, &filter_options);
         assert!(
             matches!(
                 result,
@@ -788,6 +800,7 @@ mod tests {
         let vaapi = vaapi_accel_with_tonemap(VaapiDriver::RadeonSI, false, true, false);
         let ffmpeg_info = ffmpeg_info_with_filters(&[KnownVideoFilter::TonemapVaapi]);
         let state = hdr_vaapi_state();
+        let filter_options = VideoFilterOptions::default();
 
         let input: VideoFilter = ToneMapFilter {
             algorithm: Some(String::from("hable")),
@@ -795,7 +808,7 @@ mod tests {
         }
         .into();
 
-        let result = vaapi.best_filter(&input, &ffmpeg_info, &state);
+        let result = vaapi.best_filter(&input, &ffmpeg_info, &state, &filter_options);
         assert!(
             matches!(
                 result,
@@ -813,6 +826,7 @@ mod tests {
         let vaapi = vaapi_accel_with_tonemap(VaapiDriver::RadeonSI, false, false, false);
         let ffmpeg_info = ffmpeg_info_with_filters(&[KnownVideoFilter::TonemapVaapi]);
         let state = hdr_vaapi_state();
+        let filter_options = VideoFilterOptions::default();
 
         let input: VideoFilter = ToneMapFilter {
             algorithm: Some(String::from("hable")),
@@ -820,7 +834,7 @@ mod tests {
         }
         .into();
 
-        let result = vaapi.best_filter(&input, &ffmpeg_info, &state);
+        let result = vaapi.best_filter(&input, &ffmpeg_info, &state, &filter_options);
         assert!(
             matches!(result, VideoFilter::ToneMap(_)),
             "expected software ToneMap fallback, got {:?}",
@@ -836,6 +850,7 @@ mod tests {
             KnownVideoFilter::TonemapVaapi,
         ]);
         let state = hdr_vaapi_state();
+        let filter_options = VideoFilterOptions::default();
 
         let input: VideoFilter = ToneMapFilter {
             algorithm: Some(String::from("hable")),
@@ -843,7 +858,7 @@ mod tests {
         }
         .into();
 
-        let result = vaapi.best_filter(&input, &ffmpeg_info, &state);
+        let result = vaapi.best_filter(&input, &ffmpeg_info, &state, &filter_options);
         assert!(
             matches!(result, VideoFilter::TonemapOpencl(_)),
             "expected TonemapOpencl on iHD when both are available, got {:?}",
@@ -856,6 +871,7 @@ mod tests {
         let vaapi = vaapi_accel_with_tonemap(VaapiDriver::Ihd, true, false, false);
         let ffmpeg_info = ffmpeg_info_with_filters(&[KnownVideoFilter::TonemapVaapi]);
         let state = hdr_vaapi_state();
+        let filter_options = VideoFilterOptions::default();
 
         let input: VideoFilter = ToneMapFilter {
             algorithm: Some(String::from("hable")),
@@ -863,7 +879,7 @@ mod tests {
         }
         .into();
 
-        let result = vaapi.best_filter(&input, &ffmpeg_info, &state);
+        let result = vaapi.best_filter(&input, &ffmpeg_info, &state, &filter_options);
         assert!(
             matches!(result, VideoFilter::TonemapVaapi(_)),
             "expected TonemapVaapi on iHD when opencl is unavailable, got {:?}",
@@ -876,6 +892,7 @@ mod tests {
         let vaapi = vaapi_accel_with_tonemap(VaapiDriver::RadeonSI, true, true, false);
         let ffmpeg_info = ffmpeg_info_with_filters(&[]);
         let state = hdr_vaapi_state();
+        let filter_options = VideoFilterOptions::default();
 
         let input: VideoFilter = ToneMapFilter {
             algorithm: Some(String::from("hable")),
@@ -883,7 +900,7 @@ mod tests {
         }
         .into();
 
-        let result = vaapi.best_filter(&input, &ffmpeg_info, &state);
+        let result = vaapi.best_filter(&input, &ffmpeg_info, &state, &filter_options);
         assert!(
             matches!(result, VideoFilter::ToneMap(_)),
             "expected software ToneMap when ffmpeg has no hw tonemap filters, got {:?}",
@@ -895,6 +912,7 @@ mod tests {
     fn best_filter_falls_back_for_non_p010le_input() {
         let vaapi = vaapi_accel_with_tonemap(VaapiDriver::RadeonSI, true, true, false);
         let ffmpeg_info = ffmpeg_info_with_filters(&[KnownVideoFilter::TonemapVaapi]);
+        let filter_options = VideoFilterOptions::default();
 
         let mut state = hdr_vaapi_state();
         state.pixel_format = PixelFormat::Nv12;
@@ -905,7 +923,7 @@ mod tests {
         }
         .into();
 
-        let result = vaapi.best_filter(&input, &ffmpeg_info, &state);
+        let result = vaapi.best_filter(&input, &ffmpeg_info, &state, &filter_options);
         assert!(
             matches!(result, VideoFilter::ToneMap(_)),
             "expected software ToneMap for non-P010le input, got {:?}",
@@ -919,6 +937,7 @@ mod tests {
         let accel = HardwareAccel::Vaapi(vaapi);
         let ffmpeg_info = ffmpeg_info_with_filters(&[KnownVideoFilter::TonemapVaapi]);
         let initial_state = hdr_vaapi_state();
+        let filter_options = VideoFilterOptions::default();
 
         let tonemap: VideoFilter = ToneMapFilter {
             algorithm: Some(String::from("hable")),
@@ -930,6 +949,7 @@ mod tests {
         chain.resolve(
             &ffmpeg_info,
             &Some(accel),
+            &filter_options,
             &initial_state,
             &FrameSurface::Vaapi,
             &Some(PixelFormat::Nv12),
@@ -965,6 +985,7 @@ mod tests {
         let accel = HardwareAccel::Vaapi(vaapi);
         let ffmpeg_info = ffmpeg_info_with_filters(&[KnownVideoFilter::TonemapVaapi]);
         let initial_state = hdr_vaapi_state();
+        let filter_options = VideoFilterOptions::default();
 
         let tonemap: VideoFilter = ToneMapFilter {
             algorithm: Some(String::from("hable")),
@@ -976,6 +997,7 @@ mod tests {
         chain.resolve(
             &ffmpeg_info,
             &Some(accel),
+            &filter_options,
             &initial_state,
             &FrameSurface::Vaapi,
             &Some(PixelFormat::Nv12),
@@ -1040,6 +1062,7 @@ mod tests {
         let ffmpeg_info =
             ffmpeg_info_with_filters(&[KnownVideoFilter::PadVaapi, KnownVideoFilter::PadOpencl]);
         let state = sdr_vaapi_state();
+        let filter_options = VideoFilterOptions::default();
 
         let input: VideoFilter = PadFilter {
             size: Some(FrameSize {
@@ -1050,7 +1073,7 @@ mod tests {
         }
         .into();
 
-        let result = vaapi.best_filter(&input, &ffmpeg_info, &state);
+        let result = vaapi.best_filter(&input, &ffmpeg_info, &state, &filter_options);
         assert!(
             matches!(result, VideoFilter::PadVaapi(PadVaapi { .. })),
             "expected PadVaapi when both pad_vaapi and pad_opencl available, got {:?}",
@@ -1063,6 +1086,7 @@ mod tests {
         let vaapi = vaapi_accel_with_opencl(true);
         let ffmpeg_info = ffmpeg_info_with_filters(&[KnownVideoFilter::PadOpencl]);
         let state = sdr_vaapi_state();
+        let filter_options = VideoFilterOptions::default();
 
         let input: VideoFilter = PadFilter {
             size: Some(FrameSize {
@@ -1073,7 +1097,7 @@ mod tests {
         }
         .into();
 
-        let result = vaapi.best_filter(&input, &ffmpeg_info, &state);
+        let result = vaapi.best_filter(&input, &ffmpeg_info, &state, &filter_options);
         assert!(
             matches!(result, VideoFilter::PadOpencl(PadOpencl { .. })),
             "expected PadOpencl when pad_vaapi unavailable, got {:?}",
@@ -1086,6 +1110,7 @@ mod tests {
         let vaapi = vaapi_accel_with_opencl(false);
         let ffmpeg_info = ffmpeg_info_with_filters(&[]);
         let state = sdr_vaapi_state();
+        let filter_options = VideoFilterOptions::default();
 
         let input: VideoFilter = PadFilter {
             size: Some(FrameSize {
@@ -1096,7 +1121,7 @@ mod tests {
         }
         .into();
 
-        let result = vaapi.best_filter(&input, &ffmpeg_info, &state);
+        let result = vaapi.best_filter(&input, &ffmpeg_info, &state, &filter_options);
         assert!(
             matches!(result, VideoFilter::Pad(_)),
             "expected software Pad fallback, got {:?}",
@@ -1109,6 +1134,7 @@ mod tests {
         let vaapi = vaapi_accel_with_opencl(false);
         let ffmpeg_info = ffmpeg_info_with_filters(&[KnownVideoFilter::PadOpencl]);
         let state = sdr_vaapi_state();
+        let filter_options = VideoFilterOptions::default();
 
         let input: VideoFilter = PadFilter {
             size: Some(FrameSize {
@@ -1119,7 +1145,7 @@ mod tests {
         }
         .into();
 
-        let result = vaapi.best_filter(&input, &ffmpeg_info, &state);
+        let result = vaapi.best_filter(&input, &ffmpeg_info, &state, &filter_options);
         assert!(
             matches!(result, VideoFilter::Pad(_)),
             "expected software Pad when no OpenCL capabilities, got {:?}",
@@ -1133,6 +1159,7 @@ mod tests {
         let accel = HardwareAccel::Vaapi(vaapi);
         let ffmpeg_info = ffmpeg_info_with_filters(&[KnownVideoFilter::PadOpencl]);
         let initial_state = sdr_vaapi_state();
+        let filter_options = VideoFilterOptions::default();
 
         let pad: VideoFilter = PadFilter {
             size: Some(FrameSize {
@@ -1147,6 +1174,7 @@ mod tests {
         chain.resolve(
             &ffmpeg_info,
             &Some(accel),
+            &filter_options,
             &initial_state,
             &FrameSurface::Vaapi,
             &Some(PixelFormat::Nv12),
@@ -1204,6 +1232,7 @@ mod tests {
         let ffmpeg_info =
             ffmpeg_info_with_filters(&[KnownVideoFilter::PadVaapi, KnownVideoFilter::PadOpencl]);
         let initial_state = sdr_vaapi_state();
+        let filter_options = VideoFilterOptions::default();
 
         let pad: VideoFilter = PadFilter {
             size: Some(FrameSize {
@@ -1218,6 +1247,7 @@ mod tests {
         chain.resolve(
             &ffmpeg_info,
             &Some(accel),
+            &filter_options,
             &initial_state,
             &FrameSurface::Vaapi,
             &Some(PixelFormat::Nv12),
@@ -1253,6 +1283,7 @@ mod tests {
         let accel = HardwareAccel::Vaapi(vaapi);
         let ffmpeg_info = ffmpeg_info_with_filters(&[KnownVideoFilter::PadOpencl]);
         let initial_state = sdr_vaapi_state();
+        let filter_options = VideoFilterOptions::default();
 
         let pad: VideoFilter = PadFilter {
             size: Some(FrameSize {
@@ -1267,6 +1298,7 @@ mod tests {
         chain.resolve(
             &ffmpeg_info,
             &Some(accel),
+            &filter_options,
             &initial_state,
             &FrameSurface::Vaapi,
             &Some(PixelFormat::Nv12),

--- a/crates/ffpipeline/src/hw_accel.rs
+++ b/crates/ffpipeline/src/hw_accel.rs
@@ -3,6 +3,7 @@ use enum_dispatch::enum_dispatch;
 use crate::ffmpeg_info::{FfmpegInfo, KnownHardwareAccel};
 use crate::filter_chain::PipelineFilter;
 use crate::frame_size::FrameSize;
+use crate::output_settings::VideoFilterOptions;
 use crate::overlay_filter::OverlayFilter;
 use crate::pipeline::{
     FrameState, FrameSurface, HwPixelFormat, PixelFormat, SurfaceSet, VideoFormat,
@@ -19,6 +20,7 @@ pub trait HwAccel {
         video_filter: &VideoFilter,
         _ffmpeg_info: &FfmpegInfo,
         _current_state: &FrameState,
+        _filter_options: &VideoFilterOptions,
     ) -> VideoFilter {
         video_filter.clone()
     }

--- a/crates/ffpipeline/src/output_settings.rs
+++ b/crates/ffpipeline/src/output_settings.rs
@@ -13,7 +13,7 @@ pub struct OutputSettings {
     pub video_buffer: Option<Kbps>,
     pub video_size: Option<FrameSize>,
     pub scaling_mode: ScalingMode,
-    pub tonemap_algorithm: Option<String>,
+    pub filter_options: VideoFilterOptions,
     pub deinterlace: bool,
     pub accel: Option<HardwareAccel>,
     pub format: OutputFormat,
@@ -21,6 +21,28 @@ pub struct OutputSettings {
     pub realtime: bool,
     pub frame_rate: Option<FrameRate>,
     pub subtitle_mode: SubtitleMode,
+}
+
+#[derive(Debug, Default)]
+pub struct VideoFilterOptions {
+    pub libplacebo: LibplaceboOptions,
+    pub tonemap: TonemapOptions,
+    pub tonemap_opencl: TonemapOpenclOptions,
+}
+
+#[derive(Debug, Default)]
+pub struct LibplaceboOptions {
+    pub tonemapping: Option<String>,
+}
+
+#[derive(Debug, Default)]
+pub struct TonemapOptions {
+    pub tonemap: Option<String>,
+}
+
+#[derive(Debug, Default)]
+pub struct TonemapOpenclOptions {
+    pub tonemap: Option<String>,
 }
 
 #[derive(Debug)]

--- a/crates/ffpipeline/src/pipeline.rs
+++ b/crates/ffpipeline/src/pipeline.rs
@@ -16,7 +16,7 @@ use crate::global_option::{GlobalOption, LogLevel};
 use crate::hw_accel::{HardwareAccel, HwAccel};
 use crate::input::{FfmpegInputArgs, InputSettings, InputSource, WatermarkInput};
 use crate::output_option::OutputOption;
-use crate::output_settings::{OutputSettings, ScalingMode, SubtitleMode};
+use crate::output_settings::{OutputSettings, ScalingMode, SubtitleMode, VideoFilterOptions};
 use crate::overlay_filter::{OverlayFilter, OverlaySource, SoftwareOverlay};
 use crate::video_codec::VideoCodec;
 use crate::video_decoder::VideoDecoder;
@@ -233,6 +233,7 @@ impl PipelineInput {
 pub struct Pipeline {
     ffmpeg_info: FfmpegInfo,
     accel: Option<HardwareAccel>,
+    filter_options: VideoFilterOptions,
     initial_state: FrameState,
 
     global_options: Vec<GlobalOption>,
@@ -359,7 +360,7 @@ impl Pipeline {
             ),
             PipelineFilter::Video(
                 ToneMapFilter {
-                    algorithm: final_output_settings.tonemap_algorithm.clone(),
+                    algorithm: final_output_settings.filter_options.tonemap.tonemap.clone(),
                     output_format: match final_output_settings.bit_depth {
                         Some(10) => PixelFormat::Yuv420p10le,
                         _ => PixelFormat::Yuv420p,
@@ -578,6 +579,7 @@ impl Pipeline {
         Ok(Pipeline {
             ffmpeg_info: ffmpeg_info.clone(),
             accel: final_output_settings.accel.clone(),
+            filter_options: final_output_settings.filter_options,
             initial_state: initial_state.clone(),
             global_options: vec![
                 // hardware accel should use a single thread
@@ -658,6 +660,7 @@ impl Pipeline {
         self.filter_chain.resolve(
             &self.ffmpeg_info,
             &self.accel,
+            &self.filter_options,
             &self.initial_state,
             &self.output_context.preferred_surface,
             &self.output_context.preferred_pixel_format,

--- a/crates/ffpipeline/tests/common/mod.rs
+++ b/crates/ffpipeline/tests/common/mod.rs
@@ -10,6 +10,7 @@ use ffpipeline::input::{InputSettings, InputSource, LocalInputSource, ProbedInpu
 use ffpipeline::output_format::OutputFormat;
 use ffpipeline::output_settings::{
     AudioLoudnessSettings, AudioOutputSettings, OutputSettings, ScalingMode, SubtitleMode,
+    VideoFilterOptions,
 };
 use ffpipeline::pipeline::{AudioFormat, Hz, Kbps, Pipeline, VideoFormat, generate_pipeline};
 use ffpipeline::probe::{ProbeDeps, ProbeResult, ProbeResultStream, Probeable};
@@ -176,7 +177,7 @@ pub struct TestOutputParams {
     pub loudness: Option<AudioLoudnessSettings>,
     pub accel: Option<HardwareAccel>,
     pub frame_rate: Option<FrameRate>,
-    pub tonemap_algorithm: Option<String>,
+    pub filter_options: VideoFilterOptions,
 }
 
 impl Default for TestOutputParams {
@@ -194,7 +195,7 @@ impl Default for TestOutputParams {
             loudness: None,
             accel: None,
             frame_rate: None,
-            tonemap_algorithm: None,
+            filter_options: VideoFilterOptions::default(),
         }
     }
 }
@@ -215,7 +216,7 @@ pub fn build_output(dir: &Path, params: TestOutputParams) -> OutputSettings {
         video_buffer: params.video_buffer,
         video_size: params.video_size,
         scaling_mode: ScalingMode::ScaleAndPad,
-        tonemap_algorithm: params.tonemap_algorithm,
+        filter_options: VideoFilterOptions::default(),
         deinterlace: params.deinterlace,
         accel: params.accel,
         format: OutputFormat::Hls {

--- a/crates/ffpipeline/tests/common/mod.rs
+++ b/crates/ffpipeline/tests/common/mod.rs
@@ -216,7 +216,7 @@ pub fn build_output(dir: &Path, params: TestOutputParams) -> OutputSettings {
         video_buffer: params.video_buffer,
         video_size: params.video_size,
         scaling_mode: ScalingMode::ScaleAndPad,
-        filter_options: VideoFilterOptions::default(),
+        filter_options: params.filter_options,
         deinterlace: params.deinterlace,
         accel: params.accel,
         format: OutputFormat::Hls {

--- a/crates/ffpipeline/tests/cuda.rs
+++ b/crates/ffpipeline/tests/cuda.rs
@@ -12,6 +12,7 @@ use ffpipeline::capabilities::nvidia::NvidiaCapabilities;
 use ffpipeline::ffmpeg_info::KnownHardwareAccel;
 use ffpipeline::frame_size::FrameSize;
 use ffpipeline::hw_accel::HardwareAccel;
+use ffpipeline::output_settings::{LibplaceboOptions, VideoFilterOptions};
 use ffpipeline::pipeline::{AudioFormat, VideoFormat};
 use rstest::rstest;
 use tokio::sync::OnceCell;
@@ -82,7 +83,12 @@ async fn tonemap(
                 video_format: Some(vf),
                 video_size: Some(res),
                 bit_depth: Some(bpp),
-                tonemap_algorithm: Some("hable".to_string()),
+                filter_options: VideoFilterOptions {
+                    libplacebo: LibplaceboOptions {
+                        tonemapping: Some("hable".to_string()),
+                    },
+                    ..VideoFilterOptions::default()
+                },
                 ..TestOutputParams::default()
             },
             expected_video_codec: vf.to_string(),

--- a/crates/ffpipeline/tests/vaapi.rs
+++ b/crates/ffpipeline/tests/vaapi.rs
@@ -11,6 +11,7 @@ use ffpipeline::capabilities::vaapi::VaapiCapabilities;
 use ffpipeline::ffmpeg_info::KnownHardwareAccel;
 use ffpipeline::frame_size::FrameSize;
 use ffpipeline::hw_accel::HardwareAccel;
+use ffpipeline::output_settings::{TonemapOpenclOptions, VideoFilterOptions};
 use ffpipeline::pipeline::{AudioFormat, VideoFormat};
 use rstest::rstest;
 use tokio::sync::OnceCell;
@@ -128,7 +129,12 @@ async fn tonemap(
                 video_format: Some(vf),
                 video_size: Some(res),
                 bit_depth: Some(bpp),
-                tonemap_algorithm: Some("hable".to_string()),
+                filter_options: VideoFilterOptions {
+                    tonemap_opencl: TonemapOpenclOptions {
+                        tonemap: Some("hable".to_string()),
+                    },
+                    ..VideoFilterOptions::default()
+                },
                 ..TestOutputParams::default()
             },
             expected_video_codec: vf.to_string(),

--- a/schema/channel_config.json
+++ b/schema/channel_config.json
@@ -158,6 +158,18 @@
         "vulkan"
       ]
     },
+    "LibplaceboOptions": {
+      "type": "object",
+      "properties": {
+        "tonemapping": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
     "NormalizationConfig": {
       "type": "object",
       "properties": {
@@ -218,6 +230,30 @@
         }
       }
     },
+    "TonemapOpenclOptions": {
+      "type": "object",
+      "properties": {
+        "tonemap": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "TonemapOptions": {
+      "type": "object",
+      "properties": {
+        "tonemap": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
     "VaapiDriver": {
       "type": "string",
       "enum": [
@@ -225,6 +261,42 @@
         "i965",
         "radeonsi"
       ]
+    },
+    "VideoFilterOptionsConfig": {
+      "type": "object",
+      "properties": {
+        "libplacebo": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/LibplaceboOptions"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "tonemap": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/TonemapOptions"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "tonemap_opencl": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/TonemapOpenclOptions"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false
     },
     "VideoFormat": {
       "type": "string",
@@ -276,6 +348,9 @@
           "type": "boolean",
           "default": false
         },
+        "filters": {
+          "$ref": "#/$defs/VideoFilterOptionsConfig"
+        },
         "format": {
           "anyOf": [
             {
@@ -296,12 +371,6 @@
         },
         "scaling_mode": {
           "$ref": "#/$defs/ScalingMode"
-        },
-        "tonemap_algorithm": {
-          "type": [
-            "string",
-            "null"
-          ]
         },
         "vaapi_device": {
           "type": [


### PR DESCRIPTION
replaces `tonemap_algorithm` with filter-specific settings