### PR TITLE
fix: leave empty paths (e.g. ffmpeg) alone

### DIFF
--- a/crates/ersatztv-core/src/path_resolve.rs
+++ b/crates/ersatztv-core/src/path_resolve.rs
@@ -5,7 +5,9 @@ use simple_expand_tilde::expand_tilde;
 
 pub fn resolve_relative_paths(value: &mut Value, base_dir: &Path, pointers: &[&str]) {
     for pointer in pointers {
-        if let Some(Value::String(s)) = value.pointer_mut(pointer) {
+        if let Some(Value::String(s)) = value.pointer_mut(pointer)
+            && !s.is_empty()
+        {
             let expanded = expand_tilde(&s).unwrap_or(Path::new(s).to_path_buf());
 
             *s = if expanded.is_relative() {


### PR DESCRIPTION
fixes playback using example channel config which has empty ffmpeg and ffprobe paths (which are supposed to deserialize to none).