### PR TITLE
feat: add playout item source script

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -355,13 +355,14 @@ dependencies = [
 name = "ersatztv-channel"
 version = "0.1.0"
 dependencies = [
+ "axum",
  "clap",
  "env_logger",
  "ersatztv-core",
  "ersatztv-playout",
  "ffpipeline",
+ "futures-core",
  "log",
- "rstest",
  "schemars",
  "serde",
  "serde_json",
@@ -370,6 +371,7 @@ dependencies = [
  "thiserror",
  "time",
  "tokio",
+ "tokio-util",
  "uuid",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ ersatztv-core = { path = "crates/ersatztv-core" }
 ersatztv-playout = { path = "crates/ersatztv-playout" }
 ffpipeline = { path = "crates/ffpipeline" }
 filetime = "0.2"
+futures-core = "0.3.32"
 libloading = "0.9"
 libcl-sys = { path = "crates/libcl-sys" }
 libmpp-sys = { path = "crates/libmpp-sys" }
@@ -49,6 +50,7 @@ tempfile = "3"
 thiserror = "2.0"
 time = { version = "0.3", features = ["formatting", "local-offset", "macros", "parsing", "serde"] }
 tokio = { version = "1.50", features = ["fs", "io-std", "io-util", "macros", "process", "rt-multi-thread", "signal", "sync", "time"] }
+tokio-util = {  version = "0.7.18", features = ["io-util"] }
 tower = "0.5"
 tower-http = { version = "0.6", features = ["cors", "fs"] }
 uuid = { version = "1.23", features = ["v4"] }

--- a/crates/ersatztv-channel/Cargo.toml
+++ b/crates/ersatztv-channel/Cargo.toml
@@ -4,13 +4,14 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
+axum = { workspace = true }
 clap = { workspace = true }
 env_logger = { workspace = true }
 ersatztv-core = { workspace = true }
 ersatztv-playout = { workspace = true }
 ffpipeline = { workspace = true }
+futures-core = { workspace = true }
 log = { workspace = true }
-rstest = { workspace = true }
 schemars = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
@@ -19,6 +20,7 @@ tempfile = { workspace = true }
 thiserror = { workspace = true }
 time = { workspace = true }
 tokio = { workspace = true }
+tokio-util = { workspace = true }
 uuid = { workspace = true }
 
 [[bin]]

--- a/crates/ersatztv-channel/src/channel_session.rs
+++ b/crates/ersatztv-channel/src/channel_session.rs
@@ -27,6 +27,7 @@ use ffpipeline::{pipeline, probe};
 use time::OffsetDateTime;
 use tokio::sync::Mutex;
 
+use crate::local_proxy::{LocalProxyServer, ScriptCommand};
 use crate::playlist_manager::{PlaylistManager, PlaylistManagerOutputFiles, SubtitleSource};
 use crate::playout_loader::PlayoutLoader;
 use crate::pts_scanner::{PtsScanner, PtsTime};
@@ -62,6 +63,7 @@ pub struct ChannelSession {
     playout_loader: PlayoutLoader,
     pts_scanner: PtsScanner,
     playlist_manager: Arc<Mutex<PlaylistManager>>,
+    local_proxy_server: LocalProxyServer,
 
     ffmpeg_path: PathBuf,
     ffprobe_path: PathBuf,
@@ -83,7 +85,7 @@ pub struct ChannelSession {
 }
 
 impl ChannelSession {
-    pub fn new(channel_config: ChannelConfig) -> Result<ChannelSession, ChannelError> {
+    pub async fn new(channel_config: ChannelConfig) -> Result<ChannelSession, ChannelError> {
         let now = OffsetDateTime::now_local()?;
 
         let start_time_offset = if let Some(virtual_start) = channel_config.playout.virtual_start {
@@ -149,11 +151,14 @@ impl ChannelSession {
             .clone()
             .unwrap_or(default_ffmpeg_path);
 
+        let local_proxy_server = LocalProxyServer::start().await?;
+
         Ok(ChannelSession {
             channel_config,
             playout_loader,
             pts_scanner,
             playlist_manager,
+            local_proxy_server,
             ffmpeg_path: ffmpeg_path.to_owned(),
             ffprobe_path: ffprobe_path.to_owned(),
             ffmpeg_info: FfmpegInfo::default(),
@@ -372,18 +377,18 @@ impl ChannelSession {
         let subtitle_source_is_video_source =
             subtitle_source.as_ref().is_some_and(|s| s == &video_source);
 
-        let audio_input_source = Self::playout_source_to_input_source(audio_source.clone())?;
+        let audio_input_source = self.playout_source_to_input_source(audio_source.clone())?;
         let video_input_source = if audio_source_is_video_source {
             audio_input_source.clone()
         } else {
-            Self::playout_source_to_input_source(video_source.clone())?
+            self.playout_source_to_input_source(video_source.clone())?
         };
         let subtitle_input_source = if subtitle_source_is_video_source {
             Some(video_input_source.clone())
         } else {
             subtitle_source
                 .clone()
-                .and_then(|s| Self::playout_source_to_input_source(s.clone()).ok())
+                .and_then(|s| self.playout_source_to_input_source(s.clone()).ok())
         };
 
         let audio_fut = self.probe_source(&audio_input_source);
@@ -406,7 +411,7 @@ impl ChannelSession {
 
         let watermark_fut = async {
             if let Some(w) = current_item.watermark.as_ref() {
-                let input_source = Self::playout_source_to_input_source(w.source.clone())?;
+                let input_source = self.playout_source_to_input_source(w.source.clone())?;
                 let location = playout_location_to_pipeline(&w.location);
                 let timing = playout_timing_to_pipeline(w.timing.as_ref());
 
@@ -446,6 +451,10 @@ impl ChannelSession {
             _ => None,
         };
 
+        // consider an item to be live if any of its sources are live;
+        // live sources can never seek or work ahead
+        let is_live = source_is_live(&video_source) || source_is_live(&audio_source);
+
         // generate pipeline
         let output_settings = OutputSettings {
             audio: AudioOutputSettings {
@@ -481,6 +490,7 @@ impl ChannelSession {
             },
             pts_offset: pts_duration.map(|duration| PtsOffset { duration }),
             realtime,
+            is_live,
             frame_rate: if video_probe_result.is_still_image() {
                 Some(FrameRate::default())
             } else {
@@ -494,11 +504,23 @@ impl ChannelSession {
             ChannelSessionState::ZeroAndWorkAhead | ChannelSessionState::ZeroAndRealtime
         );
 
-        let audio_timing = self.input_timing(current_item, &audio_source, start_at_zero, realtime);
-        let video_timing = self.input_timing(current_item, &video_source, start_at_zero, realtime);
+        let audio_timing = self.input_timing(
+            current_item,
+            &audio_source,
+            start_at_zero,
+            realtime,
+            is_live,
+        );
+        let video_timing = self.input_timing(
+            current_item,
+            &video_source,
+            start_at_zero,
+            realtime,
+            is_live,
+        );
         let subtitle_timing = subtitle_source
             .as_ref()
-            .map(|s| self.input_timing(current_item, s, start_at_zero, realtime));
+            .map(|s| self.input_timing(current_item, s, start_at_zero, realtime, is_live));
 
         let video_index = current_item
             .tracks
@@ -617,7 +639,7 @@ impl ChannelSession {
         }
 
         let finish = std::cmp::min(audio_timing.finish, video_timing.finish);
-        let is_complete = audio_timing.is_complete && video_timing.is_complete;
+        let is_complete = is_live || (audio_timing.is_complete && video_timing.is_complete);
 
         Ok((finish, is_complete))
     }
@@ -662,6 +684,7 @@ impl ChannelSession {
     }
 
     fn playout_source_to_input_source(
+        &self,
         source: PlayoutItemSource,
     ) -> Result<InputSource, ChannelError> {
         match source {
@@ -701,6 +724,22 @@ impl ChannelSession {
                     },
                 }))
             }
+            PlayoutItemSource::Script { command, args, .. } => {
+                let url = self.local_proxy_server.register_script(ScriptCommand {
+                    command: expand_template(&command)?,
+                    args: args
+                        .iter()
+                        .map(|a| expand_template(a))
+                        .collect::<Result<_, _>>()?,
+                })?;
+                Ok(InputSource::Http(HttpInputSource {
+                    uri: url,
+                    options: HttpInputOptions {
+                        reconnect: false,
+                        ..Default::default()
+                    },
+                }))
+            }
         }
     }
 
@@ -710,6 +749,7 @@ impl ChannelSession {
         source: &PlayoutItemSource,
         start_at_zero: bool,
         realtime: bool,
+        is_live: bool,
     ) -> TimingResult {
         let mut is_complete = true;
 
@@ -727,6 +767,16 @@ impl ChannelSession {
                 .unwrap_or(item_in_point_base_ms + item_duration.whole_milliseconds() as u64),
             _ => item_in_point_base_ms + item_duration.whole_milliseconds() as u64,
         };
+
+        // live content never seeks and is always a complete transcode
+        if is_live {
+            return TimingResult {
+                in_point: Duration::ZERO,
+                out_point: Duration::from_millis(item_duration.whole_milliseconds() as u64),
+                finish: item_finish,
+                is_complete: true,
+            };
+        }
 
         let effective_now = if start_at_zero {
             item_start
@@ -888,4 +938,14 @@ fn playout_timing_to_pipeline(
 
         ffpipeline::input::WatermarkTiming::Periodic(periodic_timing)
     })
+}
+
+fn source_is_live(source: &PlayoutItemSource) -> bool {
+    matches!(
+        source,
+        PlayoutItemSource::Script {
+            is_live: Some(true),
+            ..
+        }
+    )
 }

--- a/crates/ersatztv-channel/src/local_proxy.rs
+++ b/crates/ersatztv-channel/src/local_proxy.rs
@@ -87,16 +87,20 @@ impl Stream for ProcStream {
 }
 
 async fn handle(State(st): State<ServerState>, Path(token): Path<String>) -> Response {
-    let registry = match st.registry.lock() {
-        Ok(r) => r,
-        Err(e) => {
-            log::error!("script registry lock is poisoned: {e}");
-            return StatusCode::INTERNAL_SERVER_ERROR.into_response();
-        }
-    };
+    let cmd = {
+        let registry = match st.registry.lock() {
+            Ok(r) => r,
+            Err(e) => {
+                log::error!("script registry lock is poisoned: {e}");
+                return StatusCode::INTERNAL_SERVER_ERROR.into_response();
+            }
+        };
 
-    let Some(cmd) = registry.get(&token).cloned() else {
-        return StatusCode::NOT_FOUND.into_response();
+        let Some(cmd) = registry.get(&token).cloned() else {
+            return StatusCode::NOT_FOUND.into_response();
+        };
+
+        cmd
     };
 
     let mut child = match Command::new(&cmd.command)

--- a/crates/ersatztv-channel/src/local_proxy.rs
+++ b/crates/ersatztv-channel/src/local_proxy.rs
@@ -1,0 +1,127 @@
+use std::collections::HashMap;
+use std::hash::{DefaultHasher, Hash, Hasher};
+use std::pin::Pin;
+use std::process::Stdio;
+use std::sync::{Arc, Mutex};
+use std::task::{Context, Poll};
+
+use axum::Router;
+use axum::body::{Body, Bytes};
+use axum::extract::{Path, State};
+use axum::http::StatusCode;
+use axum::http::header::CONTENT_TYPE;
+use axum::response::{IntoResponse, Response};
+use axum::routing::get;
+use ersatztv_channel::error::ChannelError;
+use futures_core::Stream;
+use tokio::net::TcpListener;
+use tokio::process::Command;
+
+#[derive(Clone, Hash)]
+pub struct ScriptCommand {
+    pub command: String,
+    pub args: Vec<String>,
+}
+
+#[derive(Clone)]
+struct ServerState {
+    registry: Arc<Mutex<HashMap<String, ScriptCommand>>>,
+}
+
+pub struct LocalProxyServer {
+    base: String,
+    state: ServerState,
+    task: tokio::task::JoinHandle<()>,
+}
+
+impl Drop for LocalProxyServer {
+    fn drop(&mut self) {
+        self.task.abort();
+    }
+}
+
+impl LocalProxyServer {
+    pub async fn start() -> Result<Self, ChannelError> {
+        let listener = TcpListener::bind("127.0.0.1:0").await?;
+        let port = listener.local_addr()?.port();
+        let state = ServerState {
+            registry: Default::default(),
+        };
+        let app = Router::new()
+            .route("/{token}", get(handle))
+            .with_state(state.clone());
+        let task = tokio::spawn(async move {
+            let _ = axum::serve(listener, app).await;
+        });
+        Ok(Self {
+            base: format!("http://127.0.0.1:{port}"),
+            state,
+            task,
+        })
+    }
+
+    pub fn register_script(&self, cmd: ScriptCommand) -> Result<String, ChannelError> {
+        let mut hasher = DefaultHasher::new();
+        cmd.hash(&mut hasher);
+        let token = format!("{:x}", hasher.finish());
+
+        let mut registry = self.state.registry.lock().map_err(|e| {
+            ChannelError::StreamFailure(format!("script registry lock is poisoned: {e}"))
+        })?;
+
+        registry.entry(token.clone()).or_insert(cmd);
+        Ok(format!("{}/{token}", self.base))
+    }
+}
+
+struct ProcStream {
+    inner: tokio_util::io::ReaderStream<tokio::process::ChildStdout>,
+    _child: tokio::process::Child,
+}
+
+impl Stream for ProcStream {
+    type Item = std::io::Result<Bytes>;
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        Pin::new(&mut self.inner).poll_next(cx)
+    }
+}
+
+async fn handle(State(st): State<ServerState>, Path(token): Path<String>) -> Response {
+    let registry = match st.registry.lock() {
+        Ok(r) => r,
+        Err(e) => {
+            log::error!("script registry lock is poisoned: {e}");
+            return StatusCode::INTERNAL_SERVER_ERROR.into_response();
+        }
+    };
+
+    let Some(cmd) = registry.get(&token).cloned() else {
+        return StatusCode::NOT_FOUND.into_response();
+    };
+
+    let mut child = match Command::new(&cmd.command)
+        .args(&cmd.args)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .kill_on_drop(true)
+        .spawn()
+    {
+        Ok(c) => c,
+        Err(e) => {
+            log::error!("script spawn failed: {e}");
+            return StatusCode::BAD_GATEWAY.into_response();
+        }
+    };
+
+    let Some(stdout) = child.stdout.take() else {
+        log::error!("failed to capture stdout from script command");
+        return StatusCode::INTERNAL_SERVER_ERROR.into_response();
+    };
+
+    let body = Body::from_stream(ProcStream {
+        inner: tokio_util::io::ReaderStream::new(stdout),
+        _child: child,
+    });
+    ([(CONTENT_TYPE, "video/mp2t")], body).into_response()
+}

--- a/crates/ersatztv-channel/src/main.rs
+++ b/crates/ersatztv-channel/src/main.rs
@@ -1,4 +1,5 @@
 mod channel_session;
+mod local_proxy;
 mod playlist_manager;
 mod playout_loader;
 mod pts_scanner;
@@ -64,7 +65,7 @@ async fn run() -> Result<(), ChannelError> {
                 ChannelConfig::from_sources(&config_paths, &output_folder, &number).await?;
 
             // start channel session
-            let mut channel_session = ChannelSession::new(channel_config)?;
+            let mut channel_session = ChannelSession::new(channel_config).await?;
             channel_session.run().await
         }
         Commands::Debug { config_paths } => {

--- a/crates/ersatztv-playout/src/playout.rs
+++ b/crates/ersatztv-playout/src/playout.rs
@@ -208,7 +208,7 @@ pub enum PlayoutItemSource {
         /// Command that writes an MPEG-TS stream to its stdout
         command: String,
         /// Optional arguments for the command
-        #[serde(skip_serializing_if = "Vec::is_empty")]
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
         args: Vec<String>,
         /// Whether the content is live and therefore cannot work ahead (default: false)
         #[serde(skip_serializing_if = "Option::is_none")]

--- a/crates/ersatztv-playout/src/playout.rs
+++ b/crates/ersatztv-playout/src/playout.rs
@@ -204,6 +204,16 @@ pub enum PlayoutItemSource {
         #[serde(skip_serializing_if = "Option::is_none")]
         keep_alive: Option<bool>,
     },
+    Script {
+        /// Command that writes an MPEG-TS stream to its stdout
+        command: String,
+        /// Optional arguments for the command
+        #[serde(skip_serializing_if = "Vec::is_empty")]
+        args: Vec<String>,
+        /// Whether the content is live and therefore cannot work ahead (default: false)
+        #[serde(skip_serializing_if = "Option::is_none")]
+        is_live: Option<bool>,
+    },
 }
 
 pub struct PlayoutLoadResult {

--- a/crates/ffpipeline/src/input.rs
+++ b/crates/ffpipeline/src/input.rs
@@ -209,7 +209,7 @@ impl InputSettings {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct HttpInputOptions {
     pub headers: Vec<String>,
     pub user_agent: Option<String>,

--- a/crates/ffpipeline/src/output_settings.rs
+++ b/crates/ffpipeline/src/output_settings.rs
@@ -19,6 +19,7 @@ pub struct OutputSettings {
     pub format: OutputFormat,
     pub pts_offset: Option<PtsOffset>,
     pub realtime: bool,
+    pub is_live: bool,
     pub frame_rate: Option<FrameRate>,
     pub subtitle_mode: SubtitleMode,
 }

--- a/crates/ffpipeline/src/pipeline.rs
+++ b/crates/ffpipeline/src/pipeline.rs
@@ -422,7 +422,7 @@ impl Pipeline {
                 index: video_stream.stream_index,
                 path: input_settings.video_input.probe_result.path.to_owned(),
                 seek: input_settings.video_input.in_point,
-                realtime: final_output_settings.realtime,
+                realtime: final_output_settings.realtime && !final_output_settings.is_live,
                 decoder: video_decoder,
             },
         ];

--- a/crates/ffpipeline/tests/common/mod.rs
+++ b/crates/ffpipeline/tests/common/mod.rs
@@ -225,6 +225,7 @@ pub fn build_output(dir: &Path, params: TestOutputParams) -> OutputSettings {
         },
         pts_offset: None,
         realtime: false,
+        is_live: false,
         frame_rate: params.frame_rate,
         subtitle_mode: SubtitleMode::Burn,
     }

--- a/schema/playout.json
+++ b/schema/playout.json
@@ -326,6 +326,9 @@
         },
         {
           "$ref": "#/definitions/HttpSource"
+        },
+        {
+          "$ref": "#/definitions/ScriptSource"
         }
       ]
     },
@@ -459,6 +462,38 @@
             "null"
           ],
           "description": "Enable persistent connections in ffmpeg. Default: false."
+        }
+      }
+    },
+    "ScriptSource": {
+      "type": "object",
+      "description": "An external command whose stdout is an MPEG-TS stream, proxied to ffmpeg over loopback HTTP.",
+      "required": [
+        "source_type",
+        "command"
+      ],
+      "properties": {
+        "source_type": {
+          "type": "string",
+          "const": "script"
+        },
+        "command": {
+          "type": "string",
+          "description": "Command that writes an MPEG-TS stream to its stdout. Supports {{TEMPLATE}} expansion."
+        },
+        "args": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Optional arguments for the command. Supports {{TEMPLATE}} expansion. Defaults to []."
+        },
+        "is_live": {
+          "type": [
+            "boolean",
+            "null"
+          ],
+          "description": "Whether the content is live and therefore cannot work ahead. Default: false."
         }
       }
     }


### PR DESCRIPTION
Adds a script playout item source, to support scripted mpeg-ts input. Also adds a local proxy service in the channel crate which will manage invoking any scripts. Script sources are transformed into http sources to be used in the pipeline, so minimal changes were needed there.