### PR TITLE
feat: vaapi vpp, rate control, surface transfer improvements

### DIFF
--- a/crates/ffpipeline/src/accel/amf.rs
+++ b/crates/ffpipeline/src/accel/amf.rs
@@ -13,19 +13,20 @@ impl HwAccel for Amf {
     fn codec_for_format(
         &self,
         format: &VideoFormat,
+        _bit_depth: u8,
         _video_size: Option<FrameSize>,
     ) -> Option<VideoCodec> {
         match format {
             VideoFormat::H264 => Some(VideoCodec {
                 codec_name: "h264_amf",
-                options: &[],
+                options: Vec::new(),
                 preferred_pixel_format_8bit: Some(PixelFormat::Nv12),
                 preferred_pixel_format_10bit: Some(PixelFormat::P010le),
                 preferred_surface: FrameSurface::Amf,
             }),
             VideoFormat::Hevc => Some(VideoCodec {
                 codec_name: "hevc_amf",
-                options: &["-tag:v", "hvc1"],
+                options: args!["-tag:v", "hvc1"],
                 preferred_pixel_format_8bit: Some(PixelFormat::Nv12),
                 preferred_pixel_format_10bit: Some(PixelFormat::P010le),
                 preferred_surface: FrameSurface::Amf,

--- a/crates/ffpipeline/src/accel/cuda.rs
+++ b/crates/ffpipeline/src/accel/cuda.rs
@@ -126,21 +126,22 @@ impl HwAccel for Cuda {
     fn codec_for_format(
         &self,
         format: &VideoFormat,
+        _bit_depth: u8,
         _video_size: Option<FrameSize>,
     ) -> Option<VideoCodec> {
         match format {
             VideoFormat::H264 => Some(VideoCodec {
                 codec_name: "h264_nvenc",
-                options: &[],
+                options: Vec::new(),
                 preferred_pixel_format_8bit: Some(PixelFormat::Nv12),
                 preferred_pixel_format_10bit: Some(PixelFormat::P010le),
                 preferred_surface: FrameSurface::Cuda,
             }),
             VideoFormat::Hevc => {
                 let options = if self.capabilities.b_frame_ref_mode(format) {
-                    &["-tag:v", "hvc1", "-b_ref_mode", "1"]
+                    args!["-tag:v", "hvc1", "-b_ref_mode", "1"]
                 } else {
-                    &["-tag:v", "hvc1", "-b_ref_mode", "0"]
+                    args!["-tag:v", "hvc1", "-b_ref_mode", "0"]
                 };
 
                 Some(VideoCodec {

--- a/crates/ffpipeline/src/accel/qsv.rs
+++ b/crates/ffpipeline/src/accel/qsv.rs
@@ -66,19 +66,20 @@ impl HwAccel for Qsv {
     fn codec_for_format(
         &self,
         format: &VideoFormat,
+        _bit_depth: u8,
         _video_size: Option<FrameSize>,
     ) -> Option<VideoCodec> {
         match format {
             VideoFormat::H264 => Some(VideoCodec {
                 codec_name: "h264_qsv",
-                options: &["-low_power", "0", "-look_ahead", "0", "-forced_idr", "1"],
+                options: args!["-low_power", "0", "-look_ahead", "0", "-forced_idr", "1"],
                 preferred_pixel_format_8bit: Some(PixelFormat::Nv12),
                 preferred_pixel_format_10bit: Some(PixelFormat::P010le),
                 preferred_surface: FrameSurface::Qsv,
             }),
             VideoFormat::Hevc => Some(VideoCodec {
                 codec_name: "hevc_qsv",
-                options: &[
+                options: args![
                     "-low_power",
                     "0",
                     "-look_ahead",

--- a/crates/ffpipeline/src/accel/qsv.rs
+++ b/crates/ffpipeline/src/accel/qsv.rs
@@ -134,7 +134,7 @@ impl HwAccel for Qsv {
         }
     }
 
-    fn supports_upload_format(&self, pixel_format: &PixelFormat) -> bool {
+    fn accepts_upload_format(&self, pixel_format: &PixelFormat) -> bool {
         self.capabilities.vpp_supports_format(pixel_format)
     }
 }

--- a/crates/ffpipeline/src/accel/qsv.rs
+++ b/crates/ffpipeline/src/accel/qsv.rs
@@ -133,7 +133,7 @@ impl HwAccel for Qsv {
         }
     }
 
-    fn supports_pixel_format(&self, pixel_format: &PixelFormat) -> bool {
+    fn supports_upload_format(&self, pixel_format: &PixelFormat) -> bool {
         self.capabilities.vpp_supports_format(pixel_format)
     }
 }

--- a/crates/ffpipeline/src/accel/rkmpp.rs
+++ b/crates/ffpipeline/src/accel/rkmpp.rs
@@ -31,19 +31,20 @@ impl HwAccel for Rkmpp {
     fn codec_for_format(
         &self,
         format: &VideoFormat,
+        _bit_depth: u8,
         _video_size: Option<FrameSize>,
     ) -> Option<VideoCodec> {
         match format {
             VideoFormat::H264 if self.capabilities.can_encode(format, 8) => Some(VideoCodec {
                 codec_name: "h264_rkmpp",
-                options: &[],
+                options: Vec::new(),
                 preferred_pixel_format_8bit: Some(PixelFormat::Nv12),
                 preferred_pixel_format_10bit: None,
                 preferred_surface: FrameSurface::Rkmpp,
             }),
             VideoFormat::Hevc if self.capabilities.can_encode(format, 8) => Some(VideoCodec {
                 codec_name: "hevc_rkmpp",
-                options: &[],
+                options: Vec::new(),
                 preferred_pixel_format_8bit: Some(PixelFormat::Nv12),
                 preferred_pixel_format_10bit: None,
                 preferred_surface: FrameSurface::Rkmpp,

--- a/crates/ffpipeline/src/accel/vaapi.rs
+++ b/crates/ffpipeline/src/accel/vaapi.rs
@@ -1,7 +1,7 @@
 use crate::ArgVec;
 use crate::accel::opencl::{PadOpencl, TonemapOpencl};
 use crate::capabilities::opencl::OpenCLCapabilities;
-use crate::capabilities::vaapi::VaapiCapabilities;
+use crate::capabilities::vaapi::{RateControlMode, VaapiCapabilities};
 use crate::ffmpeg_info::{FfmpegInfo, KnownHardwareAccel, KnownVideoFilter};
 use crate::frame_size::FrameSize;
 use crate::hw_accel::{HwAccel, HwDecoder};
@@ -194,25 +194,40 @@ impl HwAccel for Vaapi {
     fn codec_for_format(
         &self,
         format: &VideoFormat,
+        bit_depth: u8,
         video_size: Option<FrameSize>,
     ) -> Option<VideoCodec> {
+        let force_cqp = self.capabilities.rate_control_mode_for(format, bit_depth)
+            == Some(RateControlMode::Cqp);
+
         match format {
-            VideoFormat::H264 => Some(VideoCodec {
-                codec_name: "h264_vaapi",
-                options: &[],
-                preferred_pixel_format_8bit: Some(PixelFormat::Nv12),
-                preferred_pixel_format_10bit: Some(PixelFormat::P010le),
-                preferred_surface: FrameSurface::Vaapi,
-            }),
+            VideoFormat::H264 => {
+                let options = if force_cqp {
+                    args!["-rc_mode", "1"]
+                } else {
+                    Vec::new()
+                };
+
+                Some(VideoCodec {
+                    codec_name: "h264_vaapi",
+                    options,
+                    preferred_pixel_format_8bit: Some(PixelFormat::Nv12),
+                    preferred_pixel_format_10bit: Some(PixelFormat::P010le),
+                    preferred_surface: FrameSurface::Vaapi,
+                })
+            }
             VideoFormat::Hevc => {
-                let mut options: &'static [&'static str] = &[];
+                let mut options = Vec::new();
+                if force_cqp {
+                    options.extend(args!["-rc_mode", "1"]);
+                }
 
                 // WORKAROUND: RadeonSI doesn't always output appropriate crop
                 // metadata with HEVC encoder; it doesn't hurt anything to always specify
                 if self.driver == VaapiDriver::RadeonSI
                     && video_size.map(|s| s.height) == Some(1080)
                 {
-                    options = &["-bsf:v", "hevc_metadata=crop_bottom=8"];
+                    options.extend(args!["-bsf:v", "hevc_metadata=crop_bottom=8"]);
                 }
 
                 Some(VideoCodec {
@@ -544,6 +559,7 @@ mod tests {
                 can_hdr_to_sdr_tonemap: HashSet::new(),
                 can_hdr_to_hdr_tonemap: HashSet::new(),
                 can_overlay: false,
+                rate_control: HashMap::new(),
             },
             opencl_capabilities: OpenCLCapabilities {
                 platform_count: 0,

--- a/crates/ffpipeline/src/accel/vaapi.rs
+++ b/crates/ffpipeline/src/accel/vaapi.rs
@@ -51,7 +51,10 @@ impl HwAccel for Vaapi {
                 force_original_aspect_ratio,
                 ..
             }) if ffmpeg_info.has_video_filter(&KnownVideoFilter::ScaleVaapi)
-                && !current_state.pixel_format.has_alpha() =>
+                && !current_state.pixel_format.has_alpha()
+                && self
+                    .capabilities
+                    .vpp_supports_format(&current_state.pixel_format) =>
             {
                 ScaleVaapi {
                     size: *size,
@@ -67,7 +70,13 @@ impl HwAccel for Vaapi {
                 }
                 if let Some(hw_filter) = ffmpeg_info.find_best_fit(pad_options.as_slice()) {
                     match hw_filter {
-                        KnownVideoFilter::PadVaapi => PadVaapi { size: *size }.into(),
+                        KnownVideoFilter::PadVaapi
+                            if self
+                                .capabilities
+                                .vpp_supports_format(&current_state.pixel_format) =>
+                        {
+                            PadVaapi { size: *size }.into()
+                        }
                         KnownVideoFilter::PadOpencl => PadOpencl { size: *size }.into(),
                         _ => video_filter.clone(),
                     }
@@ -80,7 +89,10 @@ impl HwAccel for Vaapi {
                 input_is_interlaced,
                 ..
             }) if *input_is_interlaced
-                && ffmpeg_info.has_video_filter(&KnownVideoFilter::DeinterlaceVaapi) =>
+                && ffmpeg_info.has_video_filter(&KnownVideoFilter::DeinterlaceVaapi)
+                && self
+                    .capabilities
+                    .vpp_supports_format(&current_state.pixel_format) =>
             {
                 DeinterlaceVaapi {
                     mode: filter_options.deinterlace_vaapi.mode.clone(),
@@ -299,8 +311,13 @@ impl HwAccel for Vaapi {
         }
     }
 
-    fn supports_pixel_format(&self, pixel_format: &PixelFormat) -> bool {
-        self.capabilities.vpp_supports_format(pixel_format)
+    fn supports_upload_format(&self, pixel_format: &PixelFormat) -> bool {
+        // upload works even when vpp is unsupported for a format, so match
+        // the canonical VA surface formats first.
+        // it is safe to allow 10 bit here because encoder is already checked,
+        // e.g. 10-bit software encoder will never try to upload
+        matches!(pixel_format, PixelFormat::Nv12 | PixelFormat::P010le)
+            || self.capabilities.vpp_supports_format(pixel_format)
     }
 }
 
@@ -523,7 +540,7 @@ mod tests {
             capabilities: VaapiCapabilities {
                 vendor: String::from("test"),
                 supported: HashSet::new(),
-                vpp_pixel_formats: HashSet::new(),
+                vpp_pixel_formats: HashSet::from([libva_sys::VA_FOURCC_NV12]),
                 can_hdr_to_sdr_tonemap: HashSet::new(),
                 can_hdr_to_hdr_tonemap: HashSet::new(),
                 can_overlay: false,

--- a/crates/ffpipeline/src/accel/vaapi.rs
+++ b/crates/ffpipeline/src/accel/vaapi.rs
@@ -326,13 +326,17 @@ impl HwAccel for Vaapi {
         }
     }
 
-    fn supports_upload_format(&self, pixel_format: &PixelFormat) -> bool {
+    fn accepts_upload_format(&self, pixel_format: &PixelFormat) -> bool {
         // upload works even when vpp is unsupported for a format, so match
         // the canonical VA surface formats first.
         // it is safe to allow 10 bit here because encoder is already checked,
         // e.g. 10-bit software encoder will never try to upload
         matches!(pixel_format, PixelFormat::Nv12 | PixelFormat::P010le)
             || self.capabilities.vpp_supports_format(pixel_format)
+    }
+
+    fn can_convert_pixel_format(&self, pixel_format: &PixelFormat) -> bool {
+        self.capabilities.vpp_supports_format(pixel_format)
     }
 }
 

--- a/crates/ffpipeline/src/accel/video_toolbox.rs
+++ b/crates/ffpipeline/src/accel/video_toolbox.rs
@@ -60,19 +60,20 @@ impl HwAccel for VideoToolbox {
     fn codec_for_format(
         &self,
         format: &VideoFormat,
+        _bit_depth: u8,
         _video_size: Option<FrameSize>,
     ) -> Option<VideoCodec> {
         match format {
             VideoFormat::H264 if self.capabilities.can_encode(format, 8) => Some(VideoCodec {
                 codec_name: "h264_videotoolbox",
-                options: &[],
+                options: Vec::new(),
                 preferred_pixel_format_8bit: Some(PixelFormat::Nv12),
                 preferred_pixel_format_10bit: Some(PixelFormat::P010le),
                 preferred_surface: FrameSurface::VideoToolbox,
             }),
             VideoFormat::Hevc if self.capabilities.can_encode(format, 8) => Some(VideoCodec {
                 codec_name: "hevc_videotoolbox",
-                options: &[],
+                options: Vec::new(),
                 preferred_pixel_format_8bit: Some(PixelFormat::Nv12),
                 preferred_pixel_format_10bit: Some(PixelFormat::P010le),
                 preferred_surface: FrameSurface::VideoToolbox,

--- a/crates/ffpipeline/src/accel/vulkan.rs
+++ b/crates/ffpipeline/src/accel/vulkan.rs
@@ -68,26 +68,27 @@ impl HwAccel for Vulkan {
     fn codec_for_format(
         &self,
         format: &VideoFormat,
+        _bit_depth: u8,
         _video_size: Option<FrameSize>,
     ) -> Option<VideoCodec> {
         match format {
             VideoFormat::H264 => Some(VideoCodec {
                 codec_name: "h264_vulkan",
-                options: &[],
+                options: Vec::new(),
                 preferred_pixel_format_8bit: Some(PixelFormat::Nv12),
                 preferred_pixel_format_10bit: Some(PixelFormat::P010le),
                 preferred_surface: FrameSurface::Vulkan,
             }),
             VideoFormat::Hevc => Some(VideoCodec {
                 codec_name: "hevc_vulkan",
-                options: &["-tag:v", "hvc1"],
+                options: args!["-tag:v", "hvc1"],
                 preferred_pixel_format_8bit: Some(PixelFormat::Nv12),
                 preferred_pixel_format_10bit: Some(PixelFormat::P010le),
                 preferred_surface: FrameSurface::Vulkan,
             }),
             VideoFormat::Av1 => Some(VideoCodec {
                 codec_name: "av1_vulkan",
-                options: &[],
+                options: Vec::new(),
                 preferred_pixel_format_8bit: Some(PixelFormat::Nv12),
                 preferred_pixel_format_10bit: Some(PixelFormat::P010le),
                 preferred_surface: FrameSurface::Vulkan,

--- a/crates/ffpipeline/src/bin/probe_capabilities.rs
+++ b/crates/ffpipeline/src/bin/probe_capabilities.rs
@@ -3,7 +3,7 @@ use ffpipeline::capabilities::nvidia::NvidiaCapabilities;
 use ffpipeline::capabilities::opencl::OpenCLCapabilities;
 use ffpipeline::capabilities::qsv::QsvCapabilities;
 use ffpipeline::capabilities::rkmpp::RkmppCapabilities;
-use ffpipeline::capabilities::vaapi::VaapiCapabilities;
+use ffpipeline::capabilities::vaapi::{RateControlMode, VaapiCapabilities};
 use ffpipeline::capabilities::videotoolbox::VideoToolboxCapabilities;
 use ffpipeline::capabilities::vulkan::VulkanCapabilities;
 use ffpipeline::pipeline::{PixelFormat, VideoFormat};
@@ -224,6 +224,23 @@ fn print_vaapi(device: &str, driver: Option<&str>) -> Result<(), String> {
         }
     }
     println!("  Overlay:     {}", yn(caps.can_overlay()));
+
+    println!();
+    println!("Rate Control:");
+    println!("  {:<12} {:<8} {:<14}", "Codec", "Bits", "Forced Mode");
+    println!("  {:<12} {:<8} {:<14}", "-----", "----", "-----------");
+    for f in ALL_FORMATS {
+        for bd in [8u8, 10] {
+            let forced = caps.rate_control_mode_for(f, bd);
+            if caps.can_encode(f, bd) || caps.can_encode_low_power(f, bd) {
+                let label = match forced {
+                    Some(RateControlMode::Cqp) => "CQP (forced)",
+                    None => "(default)",
+                };
+                println!("  {:<12} {:<8} {:<14}", format_name(f), bd, label);
+            }
+        }
+    }
 
     Ok(())
 }

--- a/crates/ffpipeline/src/capabilities/vaapi/linux.rs
+++ b/crates/ffpipeline/src/capabilities/vaapi/linux.rs
@@ -1,4 +1,4 @@
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::ffi::{CStr, c_uint};
 use std::fs::File;
 use std::os::unix::io::AsRawFd;
@@ -92,6 +92,7 @@ impl VaapiCapabilities {
 
         let max_entrypoints = unsafe { (va.vaMaxNumEntrypoints)(display) } as usize;
         let mut supported = HashSet::new();
+        let mut rate_control = HashMap::new();
 
         for &profile in &profiles {
             let mut entrypoints = vec![0i32; max_entrypoints];
@@ -107,6 +108,16 @@ impl VaapiCapabilities {
             if status == VA_STATUS_SUCCESS {
                 for &ep in &entrypoints[..num_entrypoints as usize] {
                     supported.insert((profile, ep));
+
+                    let mut attr = VAConfigAttrib {
+                        type_: VA_CONFIG_ATTRIB_RATE_CONTROL,
+                        value: 0,
+                    };
+                    let status =
+                        unsafe { (va.vaGetConfigAttributes)(display, profile, ep, &mut attr, 1) };
+                    if status == VA_STATUS_SUCCESS && attr.value != VA_ATTRIB_NOT_SUPPORTED {
+                        rate_control.insert((profile, ep), attr.value);
+                    }
                 }
             }
         }
@@ -318,6 +329,7 @@ impl VaapiCapabilities {
             can_hdr_to_hdr_tonemap,
             can_hdr_to_sdr_tonemap,
             can_overlay: can_overlay.unwrap_or_default(),
+            rate_control,
         })
     }
 

--- a/crates/ffpipeline/src/capabilities/vaapi/mod.rs
+++ b/crates/ffpipeline/src/capabilities/vaapi/mod.rs
@@ -1,4 +1,4 @@
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 
 use libva_sys::*;
 
@@ -22,6 +22,13 @@ pub struct VaapiCapabilities {
     /// FourCC of supported HDR->HDR tonemap formats.   
     pub(crate) can_hdr_to_hdr_tonemap: HashSet<FourCC>,
     pub(crate) can_overlay: bool,
+    /// Bitmask of VA_RC_* per (profile, entrypoint). Absent = unknown / not queried.
+    pub(crate) rate_control: HashMap<(i32, i32), u32>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RateControlMode {
+    Cqp,
 }
 
 impl VaapiCapabilities {
@@ -109,5 +116,28 @@ impl VaapiCapabilities {
 
     pub fn can_overlay(&self) -> bool {
         self.can_overlay
+    }
+
+    /// Returns Some(Cqp) when the only available RC mode is CQP and we must force it.
+    /// Returns None when VBR/CBR is available (driver default is fine) or nothing is known.
+    pub fn rate_control_mode_for(
+        &self,
+        format: &VideoFormat,
+        bit_depth: u8,
+    ) -> Option<RateControlMode> {
+        let profile = Self::encode_profile_for(format, bit_depth)?;
+        // try ENC_SLICE then ENC_SLICE_LP
+        for ep in [VA_ENTRYPOINT_ENC_SLICE, VA_ENTRYPOINT_ENC_SLICE_LP] {
+            if let Some(&mask) = self.rate_control.get(&(profile, ep)) {
+                if mask & (VA_RC_VBR | VA_RC_CBR) != 0 {
+                    return None; // default RC is fine
+                }
+                if mask & VA_RC_CQP != 0 {
+                    return Some(RateControlMode::Cqp);
+                }
+            }
+        }
+
+        None
     }
 }

--- a/crates/ffpipeline/src/filter_chain.rs
+++ b/crates/ffpipeline/src/filter_chain.rs
@@ -279,7 +279,7 @@ impl FilterChain {
         // we will need explicit converesion
         if current_state.surface == FrameSurface::System {
             let accel_supports =
-                |pf: &PixelFormat| accel.as_ref().is_none_or(|a| a.supports_pixel_format(pf));
+                |pf: &PixelFormat| accel.as_ref().is_none_or(|a| a.supports_upload_format(pf));
 
             // current format isn't supported, so pick a conversion target
             if !accel_supports(&current_state.pixel_format) {
@@ -1026,7 +1026,7 @@ mod tests {
             capabilities: VaapiCapabilities {
                 vendor: String::from("test"),
                 supported: HashSet::new(),
-                vpp_pixel_formats: HashSet::new(),
+                vpp_pixel_formats: HashSet::from([libva_sys::VA_FOURCC_NV12]),
                 can_hdr_to_sdr_tonemap: HashSet::new(),
                 can_hdr_to_hdr_tonemap: HashSet::new(),
                 can_overlay: false,

--- a/crates/ffpipeline/src/filter_chain.rs
+++ b/crates/ffpipeline/src/filter_chain.rs
@@ -303,17 +303,21 @@ impl FilterChain {
                     && !encoder_pixel_format.as_ref().is_some_and(hw_can_convert));
 
             if convert_in_sw {
-                let target = if let Some(pf) = encoder_pixel_format
+                let canonical = match current_state.pixel_format.bit_depth() {
+                    10 => PixelFormat::P010le,
+                    _ => PixelFormat::Nv12,
+                };
+
+                let target = encoder_pixel_format
                     .as_ref()
                     .copied()
                     .filter(|pf| accepts_upload(pf))
-                {
-                    pf
-                } else if current_state.pixel_format.bit_depth() == 10 {
-                    // eager 10-bit to 8-bit conversion when encoder wants 8-bit
-                    PixelFormat::Nv12
-                } else {
-                    return false;
+                    .or_else(|| accepts_upload(&canonical).then_some(canonical))
+                    .ok_or(());
+
+                let target = match target {
+                    Ok(pf) => pf,
+                    Err(()) => return false,
                 };
 
                 let format: VideoFilter = FormatFilter { format: target }.into();
@@ -1527,5 +1531,192 @@ mod tests {
                 source_format: PixelFormat::Nv12,
             })
         ),);
+    }
+
+    #[test]
+    fn resolve_falls_back_to_nv12_when_yuv420p_not_accepted_for_upload() {
+        // System/Yuv420p with no encoder hint and an accel that doesn't
+        // accept Yuv420p directly on upload (free-driver VAAPI). Previously the
+        // ladder gave up and returned false. Should now pick the canonical 8-bit
+        // surface format (NV12) and succeed.
+        let accel = vaapi_accel();
+        let ffmpeg_info = FfmpegInfo::default();
+        let filter_options = VideoFilterOptions::default();
+
+        let initial_state = FrameState {
+            size: FrameSize {
+                width: 1920,
+                height: 1080,
+            },
+            is_anamorphic: false,
+            is_interlaced: false,
+            sample_aspect_ratio: None,
+            display_aspect_ratio: None,
+            surface: FrameSurface::System,
+            pixel_format: PixelFormat::Yuv420p,
+            is_hdr: false,
+        };
+
+        let mut chain = FilterChain::new(Vec::new());
+        chain.resolve(
+            &ffmpeg_info,
+            &Some(accel),
+            &filter_options,
+            &initial_state,
+            &FrameSurface::Vaapi,
+            &None, // no encoder pixel format hint
+        );
+
+        let video_filters: Vec<&VideoFilter> = chain
+            .filters
+            .iter()
+            .filter_map(|f| match f {
+                PipelineFilter::Video(vf) => Some(vf),
+                _ => None,
+            })
+            .collect();
+
+        assert_eq!(video_filters.len(), 2, "expected [format=nv12, hwupload]",);
+
+        assert!(
+            matches!(
+                video_filters[0],
+                VideoFilter::Format(FormatFilter {
+                    format: PixelFormat::Nv12
+                })
+            ),
+            "first filter should be software format=nv12",
+        );
+
+        assert!(
+            matches!(
+                video_filters[1],
+                VideoFilter::HwUpload(HwUploadFilter {
+                    target_surface: FrameSurface::Vaapi,
+                    source_format: PixelFormat::Nv12,
+                })
+            ),
+            "second filter should be hwupload to Vaapi with NV12 source",
+        );
+    }
+
+    #[test]
+    fn resolve_preserves_bit_depth_when_10bit_input_has_no_encoder_hint() {
+        // System/Yuv420p10le with no encoder hint. Previously this fell
+        // into the eager 10 -> 8 branch and converted to NV12, throwing away two
+        // bits per channel. Should now convert to P010le instead - the canonical
+        // 10-bit surface format, which is accepted on upload.
+        let accel = vaapi_accel();
+        let ffmpeg_info = FfmpegInfo::default();
+        let filter_options = VideoFilterOptions::default();
+
+        let initial_state = FrameState {
+            size: FrameSize {
+                width: 1920,
+                height: 1080,
+            },
+            is_anamorphic: false,
+            is_interlaced: false,
+            sample_aspect_ratio: None,
+            display_aspect_ratio: None,
+            surface: FrameSurface::System,
+            pixel_format: PixelFormat::Yuv420p10le,
+            is_hdr: false,
+        };
+
+        let mut chain = FilterChain::new(Vec::new());
+        chain.resolve(
+            &ffmpeg_info,
+            &Some(accel),
+            &filter_options,
+            &initial_state,
+            &FrameSurface::Vaapi,
+            &None, // no encoder pixel format hint
+        );
+
+        let video_filters: Vec<&VideoFilter> = chain
+            .filters
+            .iter()
+            .filter_map(|f| match f {
+                PipelineFilter::Video(vf) => Some(vf),
+                _ => None,
+            })
+            .collect();
+
+        assert_eq!(video_filters.len(), 2, "expected [format=p010le, hwupload]",);
+
+        assert!(
+            matches!(
+                video_filters[0],
+                VideoFilter::Format(FormatFilter {
+                    format: PixelFormat::P010le
+                })
+            ),
+            "first filter should be software format=p010le (no bit-depth loss)",
+        );
+
+        assert!(
+            matches!(
+                video_filters[1],
+                VideoFilter::HwUpload(HwUploadFilter {
+                    target_surface: FrameSurface::Vaapi,
+                    source_format: PixelFormat::P010le,
+                })
+            ),
+            "second filter should be hwupload to Vaapi with P010le source",
+        );
+    }
+
+    #[test]
+    fn resolve_uses_encoder_format_when_present_over_bit_depth_canonical() {
+        // 10-bit input but encoder explicitly wants 8-bit NV12: the encoder
+        // hint must take precedence over the bit-depth-preserving fallback,
+        // because the encoder is what actually defines what's downstream.
+        let accel = vaapi_accel();
+        let ffmpeg_info = FfmpegInfo::default();
+        let filter_options = VideoFilterOptions::default();
+
+        let initial_state = FrameState {
+            size: FrameSize {
+                width: 1920,
+                height: 1080,
+            },
+            is_anamorphic: false,
+            is_interlaced: false,
+            sample_aspect_ratio: None,
+            display_aspect_ratio: None,
+            surface: FrameSurface::System,
+            pixel_format: PixelFormat::Yuv420p10le,
+            is_hdr: false,
+        };
+
+        let mut chain = FilterChain::new(Vec::new());
+        chain.resolve(
+            &ffmpeg_info,
+            &Some(accel),
+            &filter_options,
+            &initial_state,
+            &FrameSurface::Vaapi,
+            &Some(PixelFormat::Nv12),
+        );
+
+        let video_filters: Vec<&VideoFilter> = chain
+            .filters
+            .iter()
+            .filter_map(|f| match f {
+                PipelineFilter::Video(vf) => Some(vf),
+                _ => None,
+            })
+            .collect();
+
+        assert!(
+            matches!(
+                video_filters[0],
+                VideoFilter::Format(FormatFilter {
+                    format: PixelFormat::Nv12
+                })
+            ),
+            "encoder format hint (NV12) should win over bit-depth canonical (P010le)",
+        );
     }
 }

--- a/crates/ffpipeline/src/filter_chain.rs
+++ b/crates/ffpipeline/src/filter_chain.rs
@@ -547,6 +547,7 @@ mod tests {
                 can_hdr_to_sdr_tonemap: HashSet::new(),
                 can_hdr_to_hdr_tonemap: HashSet::new(),
                 can_overlay: false,
+                rate_control: HashMap::new(),
             },
             opencl_capabilities: OpenCLCapabilities::default(),
         })
@@ -576,6 +577,7 @@ mod tests {
                 can_hdr_to_sdr_tonemap,
                 can_hdr_to_hdr_tonemap,
                 can_overlay: false,
+                rate_control: HashMap::new(),
             },
             opencl_capabilities: OpenCLCapabilities {
                 platform_count: if opencl { 1 } else { 0 },
@@ -1030,6 +1032,7 @@ mod tests {
                 can_hdr_to_sdr_tonemap: HashSet::new(),
                 can_hdr_to_hdr_tonemap: HashSet::new(),
                 can_overlay: false,
+                rate_control: HashMap::new(),
             },
             opencl_capabilities: OpenCLCapabilities {
                 platform_count: if opencl { 1 } else { 0 },

--- a/crates/ffpipeline/src/filter_chain.rs
+++ b/crates/ffpipeline/src/filter_chain.rs
@@ -162,6 +162,7 @@ impl FilterChain {
                             &mut current_state,
                             &main_req.pixel_format,
                             accel,
+                            &mut surfaces,
                         );
                     }
 
@@ -232,7 +233,13 @@ impl FilterChain {
         if let Some(pixel_format) = encoder_pixel_format
             && current_state.pixel_format != *pixel_format
         {
-            Self::convert_pixel_format(&mut resolved, &mut current_state, pixel_format, accel);
+            Self::convert_pixel_format(
+                &mut resolved,
+                &mut current_state,
+                pixel_format,
+                accel,
+                &mut surfaces,
+            );
         }
 
         self.filters = resolved;
@@ -278,25 +285,35 @@ impl FilterChain {
         // first check if the current pixel formats are compatiable, otherwise
         // we will need explicit converesion
         if current_state.surface == FrameSurface::System {
-            let accel_supports =
-                |pf: &PixelFormat| accel.as_ref().is_none_or(|a| a.supports_upload_format(pf));
+            let accepts_upload =
+                |pf: &PixelFormat| accel.as_ref().is_none_or(|a| a.accepts_upload_format(pf));
 
-            // current format isn't supported, so pick a conversion target
-            if !accel_supports(&current_state.pixel_format) {
-                let target = if current_state.pixel_format.bit_depth() == 10
-                    && encoder_pixel_format
+            let hw_can_convert = |pf: &PixelFormat| {
+                accel
+                    .as_ref()
+                    .is_none_or(|a| a.can_convert_pixel_format(pf))
+            };
+
+            let needs_format_change = encoder_pixel_format
+                .as_ref()
+                .is_some_and(|pf| *pf != current_state.pixel_format);
+
+            let convert_in_sw = !accepts_upload(&current_state.pixel_format)
+                || (needs_format_change
+                    && !encoder_pixel_format
                         .as_ref()
-                        .is_some_and(|pf| pf.bit_depth() == 8)
-                {
-                    // eager 10-bit to 8-bit conversion when encoder wants 8-bit
-                    PixelFormat::Nv12
-                } else if let Some(target) = encoder_pixel_format
+                        .is_some_and(|pf| hw_can_convert(pf)));
+
+            if convert_in_sw {
+                let target = if let Some(pf) = encoder_pixel_format
                     .as_ref()
                     .copied()
-                    .filter(|pf| accel_supports(pf))
+                    .filter(|pf| accepts_upload(pf))
                 {
-                    // accel supports the encoder's desired format, so convert to that
-                    target
+                    pf
+                } else if current_state.pixel_format.bit_depth() == 10 {
+                    // eager 10-bit to 8-bit conversion when encoder wants 8-bit
+                    PixelFormat::Nv12
                 } else {
                     return false;
                 };
@@ -337,6 +354,7 @@ impl FilterChain {
         current_state: &mut FrameState,
         pixel_format: &PixelFormat,
         accel: &Option<HardwareAccel>,
+        surfaces: &mut SurfaceSet,
     ) {
         log::debug!(
             "current pixel format {:?} doesn't match required {:?}",
@@ -353,11 +371,39 @@ impl FilterChain {
                 format.apply_to(current_state);
                 resolved.push(PipelineFilter::Video(format))
             }
-            (_, Some(a)) => {
+            (_, Some(a)) if a.can_convert_pixel_format(pixel_format) => {
                 if let Some(f) = a.format_filter(pixel_format) {
                     f.apply_to(current_state);
                     resolved.push(PipelineFilter::Video(f));
                 }
+            }
+            (_, Some(_)) => {
+                let original_surface = current_state.surface;
+
+                // hw can't do the format change, so use sw
+                // hwdownload -> format -> hwupload
+                Self::transfer_surface(
+                    accel,
+                    resolved,
+                    current_state,
+                    FrameSurface::System,
+                    &Some(*pixel_format),
+                    surfaces,
+                );
+                let format: VideoFilter = FormatFilter {
+                    format: *pixel_format,
+                }
+                .into();
+                format.apply_to(current_state);
+                resolved.push(PipelineFilter::Video(format));
+                Self::transfer_surface(
+                    accel,
+                    resolved,
+                    current_state,
+                    original_surface,
+                    &Some(*pixel_format),
+                    surfaces,
+                );
             }
             _ => {}
         }
@@ -534,7 +580,9 @@ mod tests {
     use crate::hw_accel::HardwareAccel;
     use crate::output_settings::ScalingMode;
     use crate::pipeline::HwPixelFormat;
-    use crate::video_filter::{HwMapFilter, PadFilter, ScaleFilter, ToneMapFilter};
+    use crate::video_filter::{
+        FormatFilter, HwMapFilter, HwUploadFilter, PadFilter, ScaleFilter, ToneMapFilter,
+    };
 
     fn vaapi_accel() -> HardwareAccel {
         HardwareAccel::Vaapi(Vaapi {
@@ -1352,5 +1400,134 @@ mod tests {
             args.is_empty(),
             "no filter_complex should be emitted: {args:?}"
         );
+    }
+
+    #[test]
+    fn resolve_converts_in_software_before_upload_when_vpp_unavailable() {
+        // 10-bit source lands us at System/p010le, encoder wants Vaapi/nv12,
+        // but the driver has no VPP so scale_vaapi=format=nv12 would fail.
+        // The chain must convert in software before hwupload and not emit any VPP filter.
+        let accel = vaapi_accel(); // vpp_pixel_formats is empty
+        let ffmpeg_info = FfmpegInfo::default();
+        let filter_options = VideoFilterOptions::default();
+
+        let initial_state = FrameState {
+            size: FrameSize {
+                width: 1280,
+                height: 720,
+            },
+            is_anamorphic: false,
+            is_interlaced: false,
+            sample_aspect_ratio: None,
+            display_aspect_ratio: None,
+            surface: FrameSurface::System,
+            pixel_format: PixelFormat::P010le,
+            is_hdr: false,
+        };
+
+        let mut chain = FilterChain::new(Vec::new());
+
+        chain.resolve(
+            &ffmpeg_info,
+            &Some(accel),
+            &filter_options,
+            &initial_state,
+            &FrameSurface::Vaapi,
+            &Some(PixelFormat::Nv12),
+        );
+
+        let video_filters: Vec<&VideoFilter> = chain
+            .filters
+            .iter()
+            .filter_map(|f| match f {
+                PipelineFilter::Video(vf) => Some(vf),
+                _ => None,
+            })
+            .collect();
+
+        assert_eq!(
+            video_filters.len(),
+            2,
+            "expected exactly [format, hwupload]",
+        );
+
+        assert!(
+            matches!(
+                video_filters[0],
+                VideoFilter::Format(FormatFilter {
+                    format: PixelFormat::Nv12
+                })
+            ),
+            "first filter should be a software format=nv12",
+        );
+
+        assert!(
+            matches!(
+                video_filters[1],
+                VideoFilter::HwUpload(HwUploadFilter {
+                    target_surface: FrameSurface::Vaapi,
+                    source_format: PixelFormat::Nv12,
+                })
+            ),
+            "second filter should be hwupload to Vaapi with NV12 source",
+        );
+
+        assert!(
+            !video_filters
+                .iter()
+                .any(|f| matches!(f, VideoFilter::FormatVaapi(_) | VideoFilter::ScaleVaapi(_))),
+            "must not emit any VPP filter when vpp_pixel_formats is empty",
+        );
+    }
+
+    #[test]
+    fn resolve_uploads_without_format_change_when_encoder_format_matches() {
+        // sw already at NV12 — upload should be a single hwupload
+        // with no format= prefix and no VPP filter inserted.
+        let accel = vaapi_accel();
+        let ffmpeg_info = FfmpegInfo::default();
+        let filter_options = VideoFilterOptions::default();
+
+        let initial_state = FrameState {
+            size: FrameSize {
+                width: 1280,
+                height: 720,
+            },
+            is_anamorphic: false,
+            is_interlaced: false,
+            sample_aspect_ratio: None,
+            display_aspect_ratio: None,
+            surface: FrameSurface::System,
+            pixel_format: PixelFormat::Nv12,
+            is_hdr: false,
+        };
+
+        let mut chain = FilterChain::new(Vec::new());
+        chain.resolve(
+            &ffmpeg_info,
+            &Some(accel),
+            &filter_options,
+            &initial_state,
+            &FrameSurface::Vaapi,
+            &Some(PixelFormat::Nv12),
+        );
+
+        let video_filters: Vec<&VideoFilter> = chain
+            .filters
+            .iter()
+            .filter_map(|f| match f {
+                PipelineFilter::Video(vf) => Some(vf),
+                _ => None,
+            })
+            .collect();
+
+        assert_eq!(video_filters.len(), 1, "expected exactly [hwupload]");
+        assert!(matches!(
+            video_filters[0],
+            VideoFilter::HwUpload(HwUploadFilter {
+                target_surface: FrameSurface::Vaapi,
+                source_format: PixelFormat::Nv12,
+            })
+        ),);
     }
 }

--- a/crates/ffpipeline/src/filter_chain.rs
+++ b/crates/ffpipeline/src/filter_chain.rs
@@ -300,9 +300,7 @@ impl FilterChain {
 
             let convert_in_sw = !accepts_upload(&current_state.pixel_format)
                 || (needs_format_change
-                    && !encoder_pixel_format
-                        .as_ref()
-                        .is_some_and(|pf| hw_can_convert(pf)));
+                    && !encoder_pixel_format.as_ref().is_some_and(hw_can_convert));
 
             if convert_in_sw {
                 let target = if let Some(pf) = encoder_pixel_format

--- a/crates/ffpipeline/src/hw_accel.rs
+++ b/crates/ffpipeline/src/hw_accel.rs
@@ -74,7 +74,7 @@ pub trait HwAccel {
             _ => HwPixelFormat::Nv12,
         }
     }
-    fn supports_pixel_format(&self, _pixel_format: &PixelFormat) -> bool {
+    fn supports_upload_format(&self, _pixel_format: &PixelFormat) -> bool {
         true
     }
 }

--- a/crates/ffpipeline/src/hw_accel.rs
+++ b/crates/ffpipeline/src/hw_accel.rs
@@ -50,6 +50,7 @@ pub trait HwAccel {
     fn codec_for_format(
         &self,
         format: &VideoFormat,
+        bit_depth: u8,
         video_size: Option<FrameSize>,
     ) -> Option<VideoCodec>;
     fn envs(&self) -> Vec<EnvironmentVariable> {

--- a/crates/ffpipeline/src/hw_accel.rs
+++ b/crates/ffpipeline/src/hw_accel.rs
@@ -75,7 +75,14 @@ pub trait HwAccel {
             _ => HwPixelFormat::Nv12,
         }
     }
-    fn supports_upload_format(&self, _pixel_format: &PixelFormat) -> bool {
+
+    /// Can hwupload be used for this pixel format on the accel's surface
+    fn accepts_upload_format(&self, _pixel_format: &PixelFormat) -> bool {
+        true
+    }
+
+    /// Can the accel's format filter (scale_vaapi, vpp_qsv, etc.) use this pixel format
+    fn can_convert_pixel_format(&self, _pixel_format: &PixelFormat) -> bool {
         true
     }
 }

--- a/crates/ffpipeline/src/output_format.rs
+++ b/crates/ffpipeline/src/output_format.rs
@@ -32,7 +32,7 @@ impl OutputFormat {
                 playlist,
                 segment_template,
             } => {
-                if output_context.video_codec != VideoCodec::COPY {
+                if output_context.video_codec.codec_name != VideoCodec::COPY {
                     args.extend(args![
                         "-g",
                         gop,

--- a/crates/ffpipeline/src/pipeline.rs
+++ b/crates/ffpipeline/src/pipeline.rs
@@ -295,16 +295,20 @@ impl Pipeline {
             final_output_settings.video_format,
         ) {
             (Some(a), Some(format)) => a
-                .codec_for_format(&format, final_output_settings.video_size)
+                .codec_for_format(
+                    &format,
+                    final_output_settings.bit_depth.unwrap_or(8),
+                    final_output_settings.video_size,
+                )
                 .filter(|_| a.can_encode(&format, final_output_settings.bit_depth.unwrap_or(8)))
                 .unwrap_or(match format {
-                    VideoFormat::Hevc => VideoCodec::LIBX265,
-                    VideoFormat::H264 => VideoCodec::LIBX264,
-                    _ => VideoCodec::COPY,
+                    VideoFormat::Hevc => VideoCodec::libx265(),
+                    VideoFormat::H264 => VideoCodec::libx264(),
+                    _ => VideoCodec::copy(),
                 }),
-            (_, Some(VideoFormat::H264)) => VideoCodec::LIBX264,
-            (_, Some(VideoFormat::Hevc)) => VideoCodec::LIBX265,
-            _ => VideoCodec::COPY,
+            (_, Some(VideoFormat::H264)) => VideoCodec::libx264(),
+            (_, Some(VideoFormat::Hevc)) => VideoCodec::libx265(),
+            _ => VideoCodec::copy(),
         };
 
         let is_still_image = input_settings.video_input.probe_result.is_still_image();
@@ -698,7 +702,7 @@ impl Pipeline {
         }
 
         // video copy shouldn't have bitrate, etc
-        if self.output_context.video_codec == VideoCodec::COPY {
+        if self.output_context.video_codec.codec_name == VideoCodec::COPY {
             self.output_options.retain(|o| {
                 !matches!(
                     o,

--- a/crates/ffpipeline/src/video_codec.rs
+++ b/crates/ffpipeline/src/video_codec.rs
@@ -1,45 +1,51 @@
-use std::borrow::Cow;
-
 use crate::ArgVec;
 use crate::pipeline::{FrameSurface, PixelFormat};
 
 #[derive(Clone, PartialEq)]
 pub struct VideoCodec {
     pub(crate) codec_name: &'static str,
-    pub(crate) options: &'static [&'static str],
+    pub(crate) options: ArgVec,
     pub(crate) preferred_pixel_format_8bit: Option<PixelFormat>,
     pub(crate) preferred_pixel_format_10bit: Option<PixelFormat>,
     pub(crate) preferred_surface: FrameSurface,
 }
 
 impl VideoCodec {
-    pub const COPY: VideoCodec = VideoCodec {
-        codec_name: "copy",
-        options: &[],
-        preferred_pixel_format_8bit: None,
-        preferred_pixel_format_10bit: None,
-        preferred_surface: FrameSurface::System,
-    };
+    pub const COPY: &'static str = "copy";
 
-    pub const LIBX264: VideoCodec = VideoCodec {
-        codec_name: "libx264",
-        options: &[],
-        preferred_pixel_format_8bit: Some(PixelFormat::Yuv420p),
-        preferred_pixel_format_10bit: Some(PixelFormat::Yuv420p10le),
-        preferred_surface: FrameSurface::System,
-    };
+    pub fn copy() -> Self {
+        Self {
+            codec_name: Self::COPY,
+            options: Vec::new(),
+            preferred_pixel_format_8bit: None,
+            preferred_pixel_format_10bit: None,
+            preferred_surface: FrameSurface::System,
+        }
+    }
 
-    pub const LIBX265: VideoCodec = VideoCodec {
-        codec_name: "libx265",
-        options: &["-tag:v", "hvc1", "-x265-params", "log-level=error"],
-        preferred_pixel_format_8bit: Some(PixelFormat::Yuv420p),
-        preferred_pixel_format_10bit: Some(PixelFormat::Yuv420p10le),
-        preferred_surface: FrameSurface::System,
-    };
+    pub fn libx264() -> Self {
+        Self {
+            codec_name: "libx264",
+            options: Vec::new(),
+            preferred_pixel_format_8bit: Some(PixelFormat::Yuv420p),
+            preferred_pixel_format_10bit: Some(PixelFormat::Yuv420p10le),
+            preferred_surface: FrameSurface::System,
+        }
+    }
+
+    pub fn libx265() -> Self {
+        Self {
+            codec_name: "libx265",
+            options: args!["-tag:v", "hvc1", "-x265-params", "log-level=error"],
+            preferred_pixel_format_8bit: Some(PixelFormat::Yuv420p),
+            preferred_pixel_format_10bit: Some(PixelFormat::Yuv420p10le),
+            preferred_surface: FrameSurface::System,
+        }
+    }
 
     pub(crate) fn as_arg(&self) -> ArgVec {
         let mut args = args!["-vcodec", self.codec_name];
-        args.extend(self.options.iter().copied().map(Cow::Borrowed));
+        args.extend(self.options.iter().cloned());
         args
     }
 }

--- a/crates/libva-sys/src/ffi.rs
+++ b/crates/libva-sys/src/ffi.rs
@@ -5,8 +5,9 @@ use std::ffi::{c_char, c_int, c_uint, c_void};
 use libloading::Library;
 
 use crate::{
-    VAConfigID, VAContextID, VADisplay, VAEntrypoint, VAProcFilterCapHighDynamicRange,
-    VAProcFilterType, VAProcPipelineCaps, VAProfile, VAStatus, VASurfaceAttrib, VASurfaceID,
+    VAConfigAttrib, VAConfigID, VAContextID, VADisplay, VAEntrypoint,
+    VAProcFilterCapHighDynamicRange, VAProcFilterType, VAProcPipelineCaps, VAProfile, VAStatus,
+    VASurfaceAttrib, VASurfaceID,
 };
 
 pub struct VaLib {
@@ -74,6 +75,13 @@ pub struct VaLib {
         num_surfaces: c_uint,
     ) -> VAStatus,
     pub vaErrorStr: unsafe extern "C" fn(VAStatus) -> *const c_char,
+    pub vaGetConfigAttributes: unsafe extern "C" fn(
+        VADisplay,
+        VAProfile,
+        VAEntrypoint,
+        *mut VAConfigAttrib,
+        c_int,
+    ) -> VAStatus,
 }
 
 impl VaLib {
@@ -99,6 +107,7 @@ impl VaLib {
             let vaDestroySurfaces = *lib.get(b"vaDestroySurfaces\0")?;
             let vaErrorStr = *lib.get(b"vaErrorStr\0")?;
             let vaGetDisplayDRM = *lib_drm.get(b"vaGetDisplayDRM\0")?;
+            let vaGetConfigAttributes = *lib.get(b"vaGetConfigAttributes\0")?;
             Ok(Self {
                 _libva: lib,
                 _libva_drm: lib_drm,
@@ -120,6 +129,7 @@ impl VaLib {
                 vaCreateSurfaces,
                 vaDestroySurfaces,
                 vaErrorStr,
+                vaGetConfigAttributes,
             })
         }
     }

--- a/crates/libva-sys/src/lib.rs
+++ b/crates/libva-sys/src/lib.rs
@@ -6,6 +6,7 @@ pub type VADisplay = *mut c_void;
 pub type VAStatus = c_int;
 pub type VAProfile = c_int;
 pub type VAEntrypoint = c_int;
+pub type VAConfigAttribType = c_int;
 pub type VAConfigID = c_uint;
 pub type VAGenericValueType = c_int;
 pub type VASurfaceID = c_uint;
@@ -13,6 +14,22 @@ pub type VAContextID = c_uint;
 // https://intel.github.io/libva/group__api__vpp.html#ga3614dbee76b8ac89dd5a3dc8b1a12bb7
 pub type VAProcFilterType = c_int;
 pub type VAProcColorStandardType = c_int;
+
+pub const VA_CONFIG_ATTRIB_RATE_CONTROL: VAConfigAttribType = 5;
+
+pub const VA_RC_NONE: c_uint = 0x00000000;
+pub const VA_RC_CBR: c_uint = 0x00000002;
+pub const VA_RC_VBR: c_uint = 0x00000004;
+pub const VA_RC_CQP: c_uint = 0x00000010;
+
+pub const VA_ATTRIB_NOT_SUPPORTED: c_uint = 0x80000000;
+
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct VAConfigAttrib {
+    pub type_: VAConfigAttribType,
+    pub value: c_uint,
+}
 
 pub const VA_PROFILE_NONE: VAProfile = -1;
 pub const VA_PROFILE_MPEG2_SIMPLE: VAProfile = 0;


### PR DESCRIPTION
Many fixes for free `intel-media-va-driver`, which may not have VPP support (no hardware filters), may require RC mode CQP, and may require software format conversions before uploading for encoding.