### PR TITLE
feat: generate error dossier when transcoding fails

### DIFF
--- a/crates/ersatztv-channel/src/channel_session.rs
+++ b/crates/ersatztv-channel/src/channel_session.rs
@@ -659,8 +659,8 @@ impl ChannelSession {
         tokio::select! {
             status = ffmpeg_child.wait() => {
                 let status = status.map_err(|e| ChannelError::StreamFailure(e.to_string()))?;
+                let _ = reader_handle.await;
                 if !status.success() {
-                    let _ = reader_handle.await;
                     let stderr_tail = ring
                         .lock()
                         .map(|r| r.iter().cloned().collect())
@@ -676,22 +676,13 @@ impl ChannelSession {
                         "ffmpeg exited {status}"
                     )));
                 } else {
-                    if let Some(reports_folder) = &self.channel_config.ffmpeg.reports_folder {
-                        let report_file = PathBuf::from(reports_folder).join(format!(".in-flight-{}.log", self.channel_config.number()));
-                        if report_file.exists() {
-                            let _ = tokio::fs::remove_file(report_file).await;
-                        }
-                    }
+                    self.cleanup_old_report().await;
                 }
             }
             _ = self.timeout_notify.notified() => {
                 ffmpeg_child.kill().await.ok();
-                if let Some(reports_folder) = &self.channel_config.ffmpeg.reports_folder {
-                    let report_file = PathBuf::from(reports_folder).join(format!(".in-flight-{}.log", self.channel_config.number()));
-                    if report_file.exists() {
-                        let _ = tokio::fs::remove_file(report_file).await;
-                    }
-                }
+                let _ = reader_handle.await;
+                self.cleanup_old_report().await;
                 return Err(ChannelError::IdleTimeout(self.channel_config.number().to_owned()));
             }
         }
@@ -956,6 +947,16 @@ impl ChannelSession {
                     log::warn!("error converting subtitle to vtt: {err}");
                     None
                 }
+            }
+        }
+    }
+
+    async fn cleanup_old_report(&self) {
+        if let Some(reports_folder) = &self.channel_config.ffmpeg.reports_folder {
+            let report_file = PathBuf::from(reports_folder)
+                .join(format!(".in-flight-{}.log", self.channel_config.number()));
+            if report_file.exists() {
+                let _ = tokio::fs::remove_file(report_file).await;
             }
         }
     }

--- a/crates/ersatztv-channel/src/channel_session.rs
+++ b/crates/ersatztv-channel/src/channel_session.rs
@@ -1,4 +1,5 @@
 use std::borrow::Cow;
+use std::collections::VecDeque;
 use std::fmt::Formatter;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
@@ -25,12 +26,16 @@ use ffpipeline::probe::{ProbeResult, ProbeResultVideoStream, Probeable};
 use ffpipeline::web_vtt::Cue;
 use ffpipeline::{pipeline, probe};
 use time::OffsetDateTime;
+use tokio::io::AsyncBufReadExt;
 use tokio::sync::Mutex;
 
+use crate::dossier::Dossier;
 use crate::local_proxy::{LocalProxyServer, ScriptCommand};
 use crate::playlist_manager::{PlaylistManager, PlaylistManagerOutputFiles, SubtitleSource};
 use crate::playout_loader::PlayoutLoader;
 use crate::pts_scanner::{PtsScanner, PtsTime};
+
+const STDERR_RING_LINES: usize = 2_000;
 
 #[derive(Copy, Clone, PartialEq)]
 enum ChannelSessionState {
@@ -497,8 +502,8 @@ impl ChannelSession {
                 None
             },
             subtitle_mode: self.channel_config.normalization.subtitle.mode.into(),
-            save_reports: self.channel_config.ffmpeg.save_reports,
             reports_folder: self.channel_config.ffmpeg.reports_folder.clone(),
+            report_id: Some(self.channel_config.number().to_owned()),
         };
 
         let start_at_zero = matches!(
@@ -623,8 +628,31 @@ impl ChannelSession {
                     .map(|env| (env.key.as_str(), env.value.as_str())),
             )
             .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::piped())
             .spawn()
             .map_err(|_| ChannelError::StreamFailure(String::from("failed to spawn ffmpeg")))?;
+
+        let stderr = ffmpeg_child
+            .stderr
+            .take()
+            .ok_or(ChannelError::CaptureFFmpegStderrFailure)?;
+        let ring = Arc::new(std::sync::Mutex::new(VecDeque::<String>::with_capacity(
+            STDERR_RING_LINES,
+        )));
+
+        let reader_ring = Arc::clone(&ring);
+        let reader_handle = tokio::spawn(async move {
+            let mut lines = tokio::io::BufReader::new(stderr).lines();
+            while let Ok(Some(line)) = lines.next_line().await {
+                eprintln!("{line}");
+                if let Ok(mut buf) = reader_ring.lock() {
+                    if buf.len() == STDERR_RING_LINES {
+                        buf.pop_front();
+                    }
+                    buf.push_back(line);
+                }
+            }
+        });
 
         log::debug!("waiting for ffmpeg to terminate...");
 
@@ -632,13 +660,38 @@ impl ChannelSession {
             status = ffmpeg_child.wait() => {
                 let status = status.map_err(|e| ChannelError::StreamFailure(e.to_string()))?;
                 if !status.success() {
+                    let _ = reader_handle.await;
+                    let stderr_tail = ring
+                        .lock()
+                        .map(|r| r.iter().cloned().collect())
+                        .unwrap_or_default();
+                    let report_source_file = self.channel_config.ffmpeg.reports_folder.as_ref().map(|folder| {
+                        PathBuf::from(folder).join(format!(".in-flight-{}.log", self.channel_config.number()))
+                    });
+                    let dossier = Dossier::new(&self.channel_config, current_item, stderr_tail, report_source_file);
+                    if let Err(err) = dossier.write().await {
+                        log::error!("failed to save dossier: {err}");
+                    }
                     return Err(ChannelError::StreamFailure(format!(
                         "ffmpeg exited {status}"
                     )));
+                } else {
+                    if let Some(reports_folder) = &self.channel_config.ffmpeg.reports_folder {
+                        let report_file = PathBuf::from(reports_folder).join(format!(".in-flight-{}.log", self.channel_config.number()));
+                        if report_file.exists() {
+                            let _ = tokio::fs::remove_file(report_file).await;
+                        }
+                    }
                 }
             }
             _ = self.timeout_notify.notified() => {
                 ffmpeg_child.kill().await.ok();
+                if let Some(reports_folder) = &self.channel_config.ffmpeg.reports_folder {
+                    let report_file = PathBuf::from(reports_folder).join(format!(".in-flight-{}.log", self.channel_config.number()));
+                    if report_file.exists() {
+                        let _ = tokio::fs::remove_file(report_file).await;
+                    }
+                }
                 return Err(ChannelError::IdleTimeout(self.channel_config.number().to_owned()));
             }
         }

--- a/crates/ersatztv-channel/src/config.rs
+++ b/crates/ersatztv-channel/src/config.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
 
 use schemars::JsonSchema;
-use serde::{Deserialize, Deserializer};
+use serde::{Deserialize, Deserializer, Serialize};
 use serde_json::Value;
 use simple_expand_tilde::expand_tilde;
 use time::OffsetDateTime;
@@ -16,7 +16,7 @@ pub const PATH_FIELDS: &[&str] = &[
     "/ffmpeg/reports_folder",
 ];
 
-#[derive(Deserialize, Clone, Debug, JsonSchema)]
+#[derive(Deserialize, Serialize, Clone, Debug, JsonSchema)]
 pub struct ChannelConfig {
     pub playout: PlayoutConfig,
     pub ffmpeg: FfmpegConfig,
@@ -32,7 +32,7 @@ pub struct ChannelConfig {
     number: String,
 }
 
-#[derive(Deserialize, Clone, Debug, JsonSchema)]
+#[derive(Deserialize, Serialize, Clone, Debug, JsonSchema)]
 pub struct PlayoutConfig {
     pub folder: String,
     /// RFC3339 formatted date/time, e.g. 2026-04-13T00:24:21.527-05:00
@@ -41,7 +41,7 @@ pub struct PlayoutConfig {
     pub virtual_start: Option<OffsetDateTime>,
 }
 
-#[derive(Deserialize, Clone, Debug, JsonSchema)]
+#[derive(Deserialize, Serialize, Clone, Debug, JsonSchema)]
 pub struct FfmpegConfig {
     #[serde(default, deserialize_with = "deserialize_optional_path")]
     pub ffmpeg_path: Option<PathBuf>,
@@ -52,12 +52,10 @@ pub struct FfmpegConfig {
     #[serde(default)]
     pub preferred_filters: Vec<String>,
     #[serde(default)]
-    pub save_reports: bool,
-    #[serde(default)]
     pub reports_folder: Option<String>,
 }
 
-#[derive(Deserialize, Clone, Debug, JsonSchema)]
+#[derive(Deserialize, Serialize, Clone, Debug, JsonSchema)]
 pub struct NormalizationConfig {
     pub audio: AudioNormalizationConfig,
     pub video: VideoNormalizationConfig,
@@ -65,7 +63,7 @@ pub struct NormalizationConfig {
     pub subtitle: SubtitleNormalizationConfig,
 }
 
-#[derive(Deserialize, Clone, Debug, JsonSchema)]
+#[derive(Deserialize, Serialize, Clone, Debug, JsonSchema)]
 pub struct AudioNormalizationConfig {
     pub format: Option<AudioFormat>,
     pub bitrate_kbps: Option<u32>,
@@ -77,7 +75,7 @@ pub struct AudioNormalizationConfig {
     pub loudness: Option<AudioLoudnessConfig>,
 }
 
-#[derive(Deserialize, Clone, Debug, JsonSchema)]
+#[derive(Deserialize, Serialize, Clone, Debug, JsonSchema)]
 #[serde(rename_all = "lowercase")]
 pub enum AudioFormat {
     Aac,
@@ -93,7 +91,7 @@ impl From<AudioFormat> for ffpipeline::pipeline::AudioFormat {
     }
 }
 
-#[derive(Deserialize, Clone, Debug, JsonSchema)]
+#[derive(Deserialize, Serialize, Clone, Debug, JsonSchema)]
 pub struct AudioLoudnessConfig {
     pub integrated_target: Option<f64>,
     pub range_target: Option<f64>,
@@ -114,7 +112,7 @@ impl From<&AudioLoudnessConfig> for ffpipeline::output_settings::AudioLoudnessSe
     }
 }
 
-#[derive(Deserialize, Clone, Debug, JsonSchema)]
+#[derive(Deserialize, Serialize, Clone, Debug, JsonSchema)]
 pub struct VideoNormalizationConfig {
     pub format: Option<VideoFormat>,
     #[serde(default, deserialize_with = "deserialize_bit_depth")]
@@ -135,7 +133,7 @@ pub struct VideoNormalizationConfig {
     pub filters: VideoFilterOptionsConfig,
 }
 
-#[derive(Deserialize, Clone, Debug, Default, JsonSchema)]
+#[derive(Deserialize, Serialize, Clone, Debug, Default, JsonSchema)]
 #[serde(default, deny_unknown_fields)]
 pub struct VideoFilterOptionsConfig {
     pub bwdif: Option<BwdifOptions>,
@@ -150,61 +148,61 @@ pub struct VideoFilterOptionsConfig {
     pub yadif_cuda: Option<YadifCudaOptions>,
 }
 
-#[derive(Deserialize, Clone, Debug, JsonSchema)]
+#[derive(Deserialize, Serialize, Clone, Debug, JsonSchema)]
 #[serde(deny_unknown_fields)]
 pub struct BwdifOptions {
     pub mode: Option<String>,
 }
 
-#[derive(Deserialize, Clone, Debug, JsonSchema)]
+#[derive(Deserialize, Serialize, Clone, Debug, JsonSchema)]
 #[serde(deny_unknown_fields)]
 pub struct BwdifCudaOptions {
     pub mode: Option<String>,
 }
 
-#[derive(Deserialize, Clone, Debug, JsonSchema)]
+#[derive(Deserialize, Serialize, Clone, Debug, JsonSchema)]
 #[serde(deny_unknown_fields)]
 pub struct DeinterlaceQsvOptions {
     pub mode: Option<String>,
 }
 
-#[derive(Deserialize, Clone, Debug, JsonSchema)]
+#[derive(Deserialize, Serialize, Clone, Debug, JsonSchema)]
 #[serde(deny_unknown_fields)]
 pub struct DeinterlaceVaapiOptions {
     pub mode: Option<String>,
 }
 
-#[derive(Deserialize, Clone, Debug, JsonSchema)]
+#[derive(Deserialize, Serialize, Clone, Debug, JsonSchema)]
 #[serde(deny_unknown_fields)]
 pub struct LibplaceboOptions {
     pub tonemapping: Option<String>,
 }
 
-#[derive(Deserialize, Clone, Debug, JsonSchema)]
+#[derive(Deserialize, Serialize, Clone, Debug, JsonSchema)]
 #[serde(deny_unknown_fields)]
 pub struct TonemapOptions {
     pub tonemap: Option<String>,
 }
 
-#[derive(Deserialize, Clone, Debug, JsonSchema)]
+#[derive(Deserialize, Serialize, Clone, Debug, JsonSchema)]
 #[serde(deny_unknown_fields)]
 pub struct TonemapOpenclOptions {
     pub tonemap: Option<String>,
 }
 
-#[derive(Deserialize, Clone, Debug, JsonSchema)]
+#[derive(Deserialize, Serialize, Clone, Debug, JsonSchema)]
 #[serde(deny_unknown_fields)]
 pub struct W3fdifOptions {
     pub mode: Option<String>,
 }
 
-#[derive(Deserialize, Clone, Debug, JsonSchema)]
+#[derive(Deserialize, Serialize, Clone, Debug, JsonSchema)]
 #[serde(deny_unknown_fields)]
 pub struct YadifOptions {
     pub mode: Option<String>,
 }
 
-#[derive(Deserialize, Clone, Debug, JsonSchema)]
+#[derive(Deserialize, Serialize, Clone, Debug, JsonSchema)]
 #[serde(deny_unknown_fields)]
 pub struct YadifCudaOptions {
     pub mode: Option<String>,
@@ -247,7 +245,7 @@ impl From<VideoFilterOptionsConfig> for ffpipeline::output_settings::VideoFilter
     }
 }
 
-#[derive(Deserialize, Clone, Copy, Debug, JsonSchema, Default)]
+#[derive(Deserialize, Serialize, Clone, Copy, Debug, JsonSchema, Default)]
 #[serde(rename_all = "snake_case")]
 pub enum ScalingMode {
     #[default]
@@ -269,7 +267,7 @@ impl From<ScalingMode> for ffpipeline::output_settings::ScalingMode {
     }
 }
 
-#[derive(Deserialize, Clone, Debug, JsonSchema)]
+#[derive(Deserialize, Serialize, Clone, Debug, JsonSchema)]
 #[serde(rename_all = "lowercase")]
 pub enum VaapiDriver {
     #[serde(alias = "ihd", alias = "iHD")]
@@ -290,14 +288,14 @@ impl From<VaapiDriver> for ffpipeline::accel::vaapi::VaapiDriver {
     }
 }
 
-#[derive(Deserialize, Clone, Debug, JsonSchema)]
+#[derive(Deserialize, Serialize, Clone, Debug, JsonSchema)]
 #[serde(rename_all = "lowercase")]
 pub enum VideoFormat {
     H264,
     Hevc,
 }
 
-#[derive(Deserialize, Clone, Debug, JsonSchema)]
+#[derive(Deserialize, Serialize, Clone, Debug, JsonSchema)]
 #[serde(rename_all = "lowercase")]
 pub enum HardwareAccel {
     Amf,
@@ -458,13 +456,13 @@ impl From<VideoFormat> for ffpipeline::pipeline::VideoFormat {
     }
 }
 
-#[derive(Deserialize, Clone, Debug, JsonSchema, Default)]
+#[derive(Deserialize, Serialize, Clone, Debug, JsonSchema, Default)]
 pub struct SubtitleNormalizationConfig {
     #[serde(default)]
     pub mode: SubtitleMode,
 }
 
-#[derive(Deserialize, Clone, Debug, JsonSchema, Default, Copy)]
+#[derive(Deserialize, Serialize, Clone, Debug, JsonSchema, Default, Copy)]
 #[serde(rename_all = "lowercase")]
 pub enum SubtitleMode {
     #[default]

--- a/crates/ersatztv-channel/src/dossier.rs
+++ b/crates/ersatztv-channel/src/dossier.rs
@@ -1,0 +1,75 @@
+use std::path::PathBuf;
+
+use ersatztv_channel::config::ChannelConfig;
+use ersatztv_channel::error::ChannelError;
+use ersatztv_playout::playout::PlayoutItem;
+use time::OffsetDateTime;
+
+pub struct Dossier {
+    channel_config: ChannelConfig,
+    item_id: String,
+    item_json: String,
+    stderr_tail: Vec<String>,
+    report_source_file: Option<PathBuf>,
+}
+
+impl Dossier {
+    pub fn new(
+        channel_config: &ChannelConfig,
+        item: &PlayoutItem,
+        stderr_tail: Vec<String>,
+        report_source_file: Option<PathBuf>,
+    ) -> Self {
+        Self {
+            channel_config: channel_config.clone(),
+            item_id: item.id.clone(),
+            item_json: serde_json::to_string_pretty(item).unwrap_or_else(|_| String::from("{}")),
+            stderr_tail,
+            report_source_file,
+        }
+    }
+
+    pub async fn write(&self) -> Result<(), ChannelError> {
+        if let Some(reports_folder) = self.channel_config.ffmpeg.reports_folder.as_ref() {
+            let timestamp = OffsetDateTime::now_utc().unix_timestamp_nanos();
+
+            let reports_folder = PathBuf::from(reports_folder);
+            let dossier_folder = reports_folder.join(format!(
+                "{}_{}_{}",
+                self.channel_config.number(),
+                timestamp,
+                self.item_id
+            ));
+
+            tokio::fs::create_dir_all(&dossier_folder).await?;
+
+            let mut report_saved = false;
+            if let Some(ref report_source_file) = self.report_source_file
+                && report_source_file.exists()
+            {
+                let report_dest_file = dossier_folder.join("ffreport.log");
+                if tokio::fs::rename(report_source_file, &report_dest_file)
+                    .await
+                    .is_ok()
+                {
+                    report_saved = true;
+                }
+            }
+
+            if !report_saved {
+                let ffmpeg_stderr_file = dossier_folder.join("ffmpeg_stderr.log");
+                tokio::fs::write(&ffmpeg_stderr_file, self.stderr_tail.join("\n")).await?;
+            }
+
+            let playout_item_file = dossier_folder.join("playout_item.json");
+            tokio::fs::write(&playout_item_file, &self.item_json).await?;
+
+            let channel_config_json = serde_json::to_string_pretty(&self.channel_config)
+                .unwrap_or_else(|_| String::from("{}"));
+            let channel_config_file = dossier_folder.join("channel_config.json");
+            tokio::fs::write(&channel_config_file, &channel_config_json).await?;
+        }
+
+        Ok(())
+    }
+}

--- a/crates/ersatztv-channel/src/error.rs
+++ b/crates/ersatztv-channel/src/error.rs
@@ -56,4 +56,7 @@ pub enum ChannelError {
 
     #[error("channel {0} terminated after idle timeout")]
     IdleTimeout(String),
+
+    #[error("failed to capture ffmpeg stderr")]
+    CaptureFFmpegStderrFailure,
 }

--- a/crates/ersatztv-channel/src/main.rs
+++ b/crates/ersatztv-channel/src/main.rs
@@ -1,4 +1,5 @@
 mod channel_session;
+mod dossier;
 mod local_proxy;
 mod playlist_manager;
 mod playout_loader;

--- a/crates/ffpipeline/src/output_settings.rs
+++ b/crates/ffpipeline/src/output_settings.rs
@@ -22,8 +22,8 @@ pub struct OutputSettings {
     pub is_live: bool,
     pub frame_rate: Option<FrameRate>,
     pub subtitle_mode: SubtitleMode,
-    pub save_reports: bool,
     pub reports_folder: Option<String>,
+    pub report_id: Option<String>,
 }
 
 #[derive(Debug, Default)]

--- a/crates/ffpipeline/src/pipeline.rs
+++ b/crates/ffpipeline/src/pipeline.rs
@@ -598,38 +598,36 @@ impl Pipeline {
 
         let mut env_vars = Vec::new();
 
-        if final_output_settings.save_reports {
-            if let Some(reports_folder) = final_output_settings
-                .reports_folder
+        if let Some(reports_folder) = final_output_settings
+            .reports_folder
+            .as_deref()
+            .filter(|s| !s.is_empty())
+            && let Some(report_id) = final_output_settings
+                .report_id
                 .as_deref()
                 .filter(|s| !s.is_empty())
-            {
-                let folder = PathBuf::from(reports_folder.replace(r"%", r"%%"));
-                if let Err(err) = std::fs::create_dir_all(&folder) {
-                    log::warn!(
-                        "failed to create ffmpeg reports folder: {err}; will not save report"
-                    );
-                } else {
-                    let file = folder
-                        .join("ffmpeg-%t-transcode.log")
-                        .to_string_lossy()
-                        .to_string();
-
-                    #[cfg(target_os = "windows")]
-                    let mut file = file;
-
-                    #[cfg(target_os = "windows")]
-                    {
-                        file = file.replace(r"\", r"/").replace(r":/", r"\:/");
-                    }
-
-                    env_vars = vec![EnvironmentVariable {
-                        key: String::from("FFREPORT"),
-                        value: format!("file={file}:level=32"),
-                    }]
-                }
+        {
+            let folder = PathBuf::from(reports_folder.replace(r"%", r"%%"));
+            if let Err(err) = std::fs::create_dir_all(&folder) {
+                log::warn!("failed to create ffmpeg reports folder: {err}; will not save report");
             } else {
-                log::warn!("unable to save ffmpeg reports without reports folder")
+                let file = folder
+                    .join(format!(".in-flight-{}.log", report_id))
+                    .to_string_lossy()
+                    .to_string();
+
+                #[cfg(target_os = "windows")]
+                let mut file = file;
+
+                #[cfg(target_os = "windows")]
+                {
+                    file = file.replace(r"\", r"/").replace(r":/", r"\:/");
+                }
+
+                env_vars = vec![EnvironmentVariable {
+                    key: String::from("FFREPORT"),
+                    value: format!("file={file}:level=32"),
+                }]
             }
         }
 

--- a/crates/ffpipeline/src/pipeline.rs
+++ b/crates/ffpipeline/src/pipeline.rs
@@ -607,14 +607,15 @@ impl Pipeline {
                 .as_deref()
                 .filter(|s| !s.is_empty())
         {
-            let folder = PathBuf::from(reports_folder.replace(r"%", r"%%"));
+            let folder = PathBuf::from(reports_folder);
             if let Err(err) = std::fs::create_dir_all(&folder) {
                 log::warn!("failed to create ffmpeg reports folder: {err}; will not save report");
             } else {
                 let file = folder
                     .join(format!(".in-flight-{}.log", report_id))
                     .to_string_lossy()
-                    .to_string();
+                    .to_string()
+                    .replace(r"%", r"%%");
 
                 #[cfg(target_os = "windows")]
                 let mut file = file;

--- a/crates/ffpipeline/tests/common/mod.rs
+++ b/crates/ffpipeline/tests/common/mod.rs
@@ -228,8 +228,8 @@ pub fn build_output(dir: &Path, params: TestOutputParams) -> OutputSettings {
         is_live: false,
         frame_rate: params.frame_rate,
         subtitle_mode: SubtitleMode::Burn,
-        save_reports: false,
         reports_folder: None,
+        report_id: None,
     }
 }
 

--- a/schema/channel_config.json
+++ b/schema/channel_config.json
@@ -198,10 +198,6 @@
             "null"
           ],
           "default": null
-        },
-        "save_reports": {
-          "type": "boolean",
-          "default": false
         }
       }
     },
@@ -236,7 +232,10 @@
           "$ref": "#/$defs/AudioNormalizationConfig"
         },
         "subtitle": {
-          "$ref": "#/$defs/SubtitleNormalizationConfig"
+          "$ref": "#/$defs/SubtitleNormalizationConfig",
+          "default": {
+            "mode": "burn"
+          }
         },
         "video": {
           "$ref": "#/$defs/VideoNormalizationConfig"
@@ -285,7 +284,8 @@
       "type": "object",
       "properties": {
         "mode": {
-          "$ref": "#/$defs/SubtitleMode"
+          "$ref": "#/$defs/SubtitleMode",
+          "default": "burn"
         }
       }
     },
@@ -332,7 +332,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "default": null
         },
         "bwdif_cuda": {
           "anyOf": [
@@ -342,7 +343,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "default": null
         },
         "deinterlace_qsv": {
           "anyOf": [
@@ -352,7 +354,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "default": null
         },
         "deinterlace_vaapi": {
           "anyOf": [
@@ -362,7 +365,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "default": null
         },
         "libplacebo": {
           "anyOf": [
@@ -372,7 +376,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "default": null
         },
         "tonemap": {
           "anyOf": [
@@ -382,7 +387,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "default": null
         },
         "tonemap_opencl": {
           "anyOf": [
@@ -392,7 +398,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "default": null
         },
         "w3fdif": {
           "anyOf": [
@@ -402,7 +409,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "default": null
         },
         "yadif": {
           "anyOf": [
@@ -412,7 +420,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "default": null
         },
         "yadif_cuda": {
           "anyOf": [
@@ -422,7 +431,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "default": null
         }
       },
       "additionalProperties": false
@@ -445,7 +455,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "default": null
         },
         "bit_depth": {
           "type": [
@@ -478,7 +489,19 @@
           "default": false
         },
         "filters": {
-          "$ref": "#/$defs/VideoFilterOptionsConfig"
+          "$ref": "#/$defs/VideoFilterOptionsConfig",
+          "default": {
+            "bwdif": null,
+            "bwdif_cuda": null,
+            "deinterlace_qsv": null,
+            "deinterlace_vaapi": null,
+            "libplacebo": null,
+            "tonemap": null,
+            "tonemap_opencl": null,
+            "w3fdif": null,
+            "yadif": null,
+            "yadif_cuda": null
+          }
         },
         "format": {
           "anyOf": [
@@ -499,7 +522,8 @@
           "minimum": 0
         },
         "scaling_mode": {
-          "$ref": "#/$defs/ScalingMode"
+          "$ref": "#/$defs/ScalingMode",
+          "default": "scale_and_pad"
         },
         "vaapi_device": {
           "type": [


### PR DESCRIPTION
This removes the `save_reports` channel config option; reports will now only save when `reports_folder` is set *and* transcoding fails (meaning ffmpeg exits with a non-zero exit code).