### PR TITLE
fix: cuda optimizations

### DIFF
--- a/crates/ffpipeline/src/accel/cuda.rs
+++ b/crates/ffpipeline/src/accel/cuda.rs
@@ -45,6 +45,7 @@ impl HwAccel for Cuda {
                 && !current_state.pixel_format.has_alpha() =>
             {
                 ScaleCuda {
+                    format: None,
                     size: *size,
                     input_is_anamorphic: *input_is_anamorphic,
                     force_original_aspect_ratio: force_original_aspect_ratio.clone(),
@@ -230,8 +231,9 @@ impl HwAccel for Cuda {
     }
 }
 
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct ScaleCuda {
+    pub(crate) format: Option<PixelFormat>,
     pub(crate) size: Option<FrameSize>,
     pub(crate) input_is_anamorphic: bool,
     pub(crate) force_original_aspect_ratio: Option<ForceOriginalAspectRatio>,
@@ -250,6 +252,10 @@ impl VideoFilterOp for ScaleCuda {
             state.sample_aspect_ratio = Some(String::from("1:1"));
             state.display_aspect_ratio = None;
         }
+
+        if let Some(format) = &self.format {
+            state.pixel_format = *format;
+        }
     }
 
     fn required_surface(&self) -> Option<FrameSurface> {
@@ -263,15 +269,20 @@ impl VideoFilterOp for ScaleCuda {
                 .as_ref()
                 .map_or(String::new(), |f| f.as_arg());
 
+            let format = self
+                .format
+                .as_ref()
+                .map_or(String::new(), |f| format!(":format={}", f.as_arg()));
+
             if self.input_is_anamorphic {
                 Some(format!(
-                    "scale_cuda=iw*sar:ih,scale_cuda={}:{}{},setsar=1",
-                    size.width, size.height, aspect_ratio
+                    "scale_cuda=iw*sar:ih,scale_cuda={}:{}{}{},setsar=1",
+                    size.width, size.height, aspect_ratio, format
                 ))
             } else {
                 Some(format!(
-                    "scale_cuda={}:{}{},setsar=1",
-                    size.width, size.height, aspect_ratio
+                    "scale_cuda={}:{}{}{},setsar=1",
+                    size.width, size.height, aspect_ratio, format
                 ))
             }
         } else {
@@ -280,7 +291,7 @@ impl VideoFilterOp for ScaleCuda {
     }
 }
 
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct PadCuda {
     pub(crate) size: Option<FrameSize>,
 }
@@ -311,7 +322,7 @@ impl VideoFilterOp for PadCuda {
     }
 }
 
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct FormatCuda {
     pub(crate) format: PixelFormat,
 }
@@ -335,7 +346,7 @@ impl VideoFilterOp for FormatCuda {
     }
 }
 
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct HwUploadCudaWorkaround;
 
 impl VideoFilterOp for HwUploadCudaWorkaround {
@@ -358,7 +369,7 @@ impl VideoFilterOp for HwUploadCudaWorkaround {
     }
 }
 
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct LibplaceboCuda {
     /// algorithm to use for tonemapping
     pub(crate) algorithm: Option<String>,
@@ -400,12 +411,12 @@ impl VideoFilterOp for LibplaceboCuda {
     }
 }
 
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct DeinterlaceCuda {
     pub(crate) filter: CudaDeinterlaceFilter,
 }
 
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub enum CudaDeinterlaceFilter {
     Bwdif(BwdifCudaOptions),
     Yadif(YadifCudaOptions),
@@ -456,7 +467,7 @@ impl VideoFilterOp for DeinterlaceCuda {
     }
 }
 
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct CudaOverlay;
 
 impl OverlayKindOp for CudaOverlay {

--- a/crates/ffpipeline/src/accel/opencl.rs
+++ b/crates/ffpipeline/src/accel/opencl.rs
@@ -3,7 +3,7 @@ use crate::frame_size::FrameSize;
 use crate::pipeline::{FrameState, FrameSurface, HwPixelFormat};
 use crate::video_filter::{VideoFilter, VideoFilterOp};
 
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct TonemapOpencl {
     /// The algorithm to use for tonemapping.
     /// See: https://ffmpeg.org/ffmpeg-filters.html#tonemap
@@ -39,7 +39,7 @@ impl VideoFilterOp for TonemapOpencl {
     }
 }
 
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct PadOpencl {
     pub(crate) size: Option<FrameSize>,
 }

--- a/crates/ffpipeline/src/accel/qsv.rs
+++ b/crates/ffpipeline/src/accel/qsv.rs
@@ -141,7 +141,7 @@ impl HwAccel for Qsv {
     }
 }
 
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct ScaleQsv {
     pub(crate) size: Option<FrameSize>,
     pub(crate) input_is_anamorphic: bool,
@@ -185,7 +185,7 @@ impl VideoFilterOp for ScaleQsv {
     }
 }
 
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct FormatQsv {
     pub(crate) format: PixelFormat,
 }
@@ -209,7 +209,7 @@ impl VideoFilterOp for FormatQsv {
     }
 }
 
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct DeinterlaceQsv {
     pub mode: Option<String>,
 }

--- a/crates/ffpipeline/src/accel/vaapi.rs
+++ b/crates/ffpipeline/src/accel/vaapi.rs
@@ -342,7 +342,7 @@ impl HwAccel for Vaapi {
     }
 }
 
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct ScaleVaapi {
     pub(crate) size: Option<FrameSize>,
     pub(crate) input_is_anamorphic: bool,
@@ -392,7 +392,7 @@ impl VideoFilterOp for ScaleVaapi {
     }
 }
 
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct PadVaapi {
     pub(crate) size: Option<FrameSize>,
 }
@@ -420,7 +420,7 @@ impl VideoFilterOp for PadVaapi {
     }
 }
 
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct FormatVaapi {
     pub(crate) format: PixelFormat,
 }
@@ -443,7 +443,7 @@ impl VideoFilterOp for FormatVaapi {
     }
 }
 
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct TonemapVaapi {
     pub(crate) output_format: HwPixelFormat,
 }
@@ -472,7 +472,7 @@ impl VideoFilterOp for TonemapVaapi {
     }
 }
 
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct VaapiOverlay;
 
 impl OverlayKindOp for VaapiOverlay {
@@ -505,7 +505,7 @@ impl OverlayKindOp for VaapiOverlay {
     }
 }
 
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct DeinterlaceVaapi {
     pub mode: Option<String>,
 }

--- a/crates/ffpipeline/src/accel/video_toolbox.rs
+++ b/crates/ffpipeline/src/accel/video_toolbox.rs
@@ -118,7 +118,7 @@ impl HwAccel for VideoToolbox {
     }
 }
 
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct ScaleVt {
     pub(crate) size: Option<FrameSize>,
     pub(crate) input_is_anamorphic: bool,

--- a/crates/ffpipeline/src/accel/vulkan.rs
+++ b/crates/ffpipeline/src/accel/vulkan.rs
@@ -140,7 +140,7 @@ impl HwAccel for Vulkan {
     }
 }
 
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct FormatVulkan {
     pub(crate) format: PixelFormat,
 }
@@ -163,7 +163,7 @@ impl VideoFilterOp for FormatVulkan {
     }
 }
 
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct LibplaceboVulkan {
     pub(crate) algorithm: Option<String>,
     pub(crate) format: PixelFormat,
@@ -192,7 +192,7 @@ impl VideoFilterOp for LibplaceboVulkan {
     }
 }
 
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct ScaleVulkan {
     pub(crate) size: Option<FrameSize>,
     pub(crate) input_is_anamorphic: bool,

--- a/crates/ffpipeline/src/audio_filter.rs
+++ b/crates/ffpipeline/src/audio_filter.rs
@@ -1,7 +1,7 @@
 use crate::output_settings::AudioLoudnessSettings;
 use crate::pipeline::{FrameState, Hz};
 
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub enum AudioFilter {
     Resample,
     Pad,

--- a/crates/ffpipeline/src/filter_chain.rs
+++ b/crates/ffpipeline/src/filter_chain.rs
@@ -3,7 +3,7 @@ use crate::audio_filter::AudioFilter;
 use crate::ffmpeg_info::FfmpegInfo;
 use crate::hw_accel::{HardwareAccel, HwAccel};
 use crate::output_settings::VideoFilterOptions;
-use crate::overlay_filter::{OverlayFilter, OverlayKindOp, OverlaySource};
+use crate::overlay_filter::{OverlayFilter, OverlayKind, OverlayKindOp, OverlaySource};
 use crate::pipeline::{FrameState, FrameSurface, PixelFormat, SurfaceSet};
 use crate::video_filter::{
     FormatFilter, HwDownloadFilter, HwUploadFilter, VideoFilter, VideoFilterOp,
@@ -101,6 +101,42 @@ impl FilterChain {
         let mut resolved = Vec::new();
         let mut current_state = initial_state.clone();
         let mut surfaces = SurfaceSet::new();
+
+        // eagerly convert to 8-bit if it allows us to use a hardware overlay
+        if let Some(a) = accel.as_ref()
+            && let Some(pf) = encoder_pixel_format
+            && pf.bit_depth() == 8
+        {
+            let initial_state_8bit = FrameState {
+                pixel_format: *pf,
+                ..initial_state.clone()
+            };
+
+            let eager_unlocks_hw_overlay = self.filters.iter().any(|f| {
+                let PipelineFilter::Overlay(o) = f else {
+                    return false;
+                };
+                let at_input = a.best_overlay(o, ffmpeg_info, initial_state);
+                let at_8bit = a.best_overlay(o, ffmpeg_info, &initial_state_8bit);
+                matches!(at_input.kind, OverlayKind::Software(_))
+                    && !matches!(at_8bit.kind, OverlayKind::Software(_))
+            });
+
+            if eager_unlocks_hw_overlay {
+                let fmt: Option<VideoFilter> = if initial_state.surface == FrameSurface::System {
+                    Some(FormatFilter { format: *pf }.into())
+                } else if a.can_convert_pixel_format(pf) {
+                    a.format_filter(pf)
+                } else {
+                    None
+                };
+
+                if let Some(fmt) = fmt {
+                    fmt.apply_to(&mut current_state);
+                    resolved.push(PipelineFilter::Video(fmt));
+                }
+            }
+        }
 
         for filter in &self.filters {
             match filter {
@@ -248,6 +284,12 @@ impl FilterChain {
 
     pub(crate) fn surfaces(&self) -> &SurfaceSet {
         &self.surfaces
+    }
+
+    pub(crate) fn prepend(&mut self, filters: Vec<PipelineFilter>) {
+        let mut new_filters = filters;
+        new_filters.append(&mut self.filters);
+        self.filters = new_filters;
     }
 
     fn transfer_surface(

--- a/crates/ffpipeline/src/filter_chain.rs
+++ b/crates/ffpipeline/src/filter_chain.rs
@@ -9,14 +9,14 @@ use crate::video_filter::{
     FormatFilter, HwDownloadFilter, HwUploadFilter, VideoFilter, VideoFilterOp,
 };
 
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub enum PipelineFilter {
     Audio(AudioFilter),
     Video(VideoFilter),
     Overlay(OverlayFilter),
 }
 
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub(crate) struct FilterChain {
     pub(crate) filters: Vec<PipelineFilter>,
     surfaces: SurfaceSet,
@@ -106,6 +106,7 @@ impl FilterChain {
         if let Some(a) = accel.as_ref()
             && let Some(pf) = encoder_pixel_format
             && pf.bit_depth() == 8
+            && initial_state.pixel_format.bit_depth() > 8
         {
             let initial_state_8bit = FrameState {
                 pixel_format: *pf,
@@ -465,6 +466,66 @@ impl FilterChain {
         {
             log::debug!("swapping software scale filter before software tonemap filter");
             self.filters.swap(tonemap_index, tonemap_index + 1);
+        }
+
+        loop {
+            let mut changed = false;
+
+            let mut i = 0;
+            while i + 1 < self.filters.len() {
+                // skip non-video filters
+                if !matches!(self.filters[i], PipelineFilter::Video(_)) {
+                    i += 1;
+                    continue;
+                }
+
+                // find the next video filter (before overlay)
+                let mut j = i + 1;
+                while j < self.filters.len() && matches!(self.filters[j], PipelineFilter::Audio(_))
+                {
+                    j += 1;
+                }
+                if j >= self.filters.len() || !matches!(self.filters[j], PipelineFilter::Video(_)) {
+                    i += 1;
+                    continue;
+                }
+
+                if let Some(fused) = Self::try_fuse_cuda(&self.filters[i], &self.filters[j]) {
+                    self.filters[i] = fused;
+                    self.filters.remove(j);
+                    changed = true;
+                } else {
+                    i += 1;
+                }
+            }
+
+            if !changed {
+                break;
+            }
+        }
+    }
+
+    /// try to fuse consecutive scale_cuda (format, resize) into a single scale_cuda kernel
+    fn try_fuse_cuda(a: &PipelineFilter, b: &PipelineFilter) -> Option<PipelineFilter> {
+        use VideoFilter::{FormatCuda, ScaleCuda};
+        let (PipelineFilter::Video(va), PipelineFilter::Video(vb)) = (a, b) else {
+            return None;
+        };
+        match (va, vb) {
+            (FormatCuda(_), FormatCuda(f)) => Some(PipelineFilter::Video(FormatCuda(f.clone()))),
+            (FormatCuda(f), ScaleCuda(s)) if s.size.is_some() => Some(PipelineFilter::Video(
+                ScaleCuda(crate::accel::cuda::ScaleCuda {
+                    format: Some(s.format.unwrap_or(f.format)),
+                    ..s.clone()
+                }),
+            )),
+            (ScaleCuda(s), FormatCuda(f)) if s.size.is_some() => Some(PipelineFilter::Video(
+                ScaleCuda(crate::accel::cuda::ScaleCuda {
+                    format: Some(f.format),
+                    ..s.clone()
+                }),
+            )),
+            _ => None,
         }
     }
 

--- a/crates/ffpipeline/src/overlay_filter.rs
+++ b/crates/ffpipeline/src/overlay_filter.rs
@@ -5,7 +5,7 @@ use crate::accel::vaapi::VaapiOverlay;
 use crate::pipeline::{FrameState, FrameSurface, PixelFormat};
 use crate::video_filter::VideoFilter;
 
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct OverlayFilter {
     pub kind: OverlayKind,
     pub secondary: Vec<VideoFilter>,
@@ -23,19 +23,19 @@ impl OverlayFilter {
     }
 }
 
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct FramePoint {
     pub x: u32,
     pub y: u32,
 }
 
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub enum OverlaySource {
     Subtitle,
     Watermark,
 }
 
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 #[enum_dispatch(OverlayKindOp)]
 pub enum OverlayKind {
     Software(SoftwareOverlay),
@@ -43,7 +43,7 @@ pub enum OverlayKind {
     Vaapi(VaapiOverlay),
 }
 
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct SoftwareOverlay {
     pub bit_depth: u8,
 }

--- a/crates/ffpipeline/src/pipeline.rs
+++ b/crates/ffpipeline/src/pipeline.rs
@@ -365,8 +365,6 @@ impl Pipeline {
             PipelineFilter::Audio(AudioFilter::Pad),
         ];
 
-        filters.extend(video_decoder.filters());
-
         filters.extend([
             PipelineFilter::Video(LoopFilter { is_still_image }.into()),
             PipelineFilter::Video(
@@ -734,6 +732,16 @@ impl Pipeline {
             &self.output_context.preferred_surface,
             &self.output_context.preferred_pixel_format,
         );
+
+        // prepend decoder filters;
+        // this is a special case that's only really needed for CUDA's hwupload workaround
+        if let Some(video_decoder) = self.inputs.iter().find_map(|s| match s {
+            PipelineInput::Video { decoder, .. } => Some(decoder),
+            _ => None,
+        }) {
+            self.filter_chain.prepend(video_decoder.filters());
+        }
+
         self.filter_chain.optimize();
 
         if let Some(accel) = &self.accel {

--- a/crates/ffpipeline/src/video_filter.rs
+++ b/crates/ffpipeline/src/video_filter.rs
@@ -10,7 +10,7 @@ use crate::input::{PeriodicClock, PeriodicTiming, WatermarkTiming};
 use crate::output_settings::{BwdifOptions, ScalingMode, W3fdifOptions, YadifOptions};
 use crate::pipeline::{FrameState, FrameSurface, PixelFormat};
 
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub enum ForceOriginalAspectRatio {
     Increase,
     Decrease,
@@ -29,14 +29,14 @@ impl ForceOriginalAspectRatio {
     }
 }
 
-#[derive(Clone, Default)]
+#[derive(Debug, Clone, Default)]
 pub struct SoftwareDeinterlaceOptions {
     pub bwdif: BwdifOptions,
     pub w3fdif: W3fdifOptions,
     pub yadif: YadifOptions,
 }
 
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub enum SoftwareDeinterlaceFilter {
     Bwdif(BwdifOptions),
     Yadif(YadifOptions),
@@ -51,7 +51,7 @@ pub trait VideoFilterOp {
     fn as_arg(&self) -> Option<String>;
 }
 
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 #[enum_dispatch(VideoFilterOp)]
 pub enum VideoFilter {
     HwUpload(HwUploadFilter),
@@ -97,7 +97,7 @@ pub enum VideoFilter {
 
 // --- Software filter structs ---
 
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct HwUploadFilter {
     pub target_surface: FrameSurface,
     pub source_format: PixelFormat,
@@ -151,7 +151,7 @@ impl VideoFilterOp for HwUploadFilter {
     }
 }
 
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct HwDownloadFilter {
     pub target_pixel_format: PixelFormat,
 }
@@ -178,7 +178,7 @@ impl VideoFilterOp for HwDownloadFilter {
     }
 }
 
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct ScaleFilter {
     pub size: Option<FrameSize>,
     pub scaling_mode: ScalingMode,
@@ -259,7 +259,7 @@ impl VideoFilterOp for ScaleFilter {
     }
 }
 
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct PadFilter {
     pub size: Option<FrameSize>,
     pub scaling_mode: ScalingMode,
@@ -295,7 +295,7 @@ impl VideoFilterOp for PadFilter {
     }
 }
 
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct LoopFilter {
     pub is_still_image: bool,
 }
@@ -320,7 +320,7 @@ impl VideoFilterOp for LoopFilter {
     }
 }
 
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct FormatFilter {
     pub format: PixelFormat,
 }
@@ -347,7 +347,7 @@ impl VideoFilterOp for FormatFilter {
     }
 }
 
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct ToneMapFilter {
     pub algorithm: Option<String>,
     pub output_format: PixelFormat,
@@ -380,7 +380,7 @@ impl VideoFilterOp for ToneMapFilter {
     }
 }
 
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct DeinterlaceFilter {
     pub filter: SoftwareDeinterlaceFilter,
     pub options: SoftwareDeinterlaceOptions,
@@ -454,7 +454,7 @@ impl VideoFilterOp for DeinterlaceFilter {
     }
 }
 
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct HwMapFilter {
     pub from_surface: FrameSurface,
     pub to_surface: FrameSurface,
@@ -482,7 +482,7 @@ impl VideoFilterOp for HwMapFilter {
     }
 }
 
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct SubtitlesFilter {
     pub path: String,
     pub seek: Duration,
@@ -520,7 +520,7 @@ impl VideoFilterOp for SubtitlesFilter {
     }
 }
 
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct ColorChannelMixerFilter {
     pub alpha: f32,
 }
@@ -547,7 +547,7 @@ impl VideoFilterOp for ColorChannelMixerFilter {
     }
 }
 
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct FadeFilter {
     point: FadePoint,
     duration: Duration,
@@ -605,13 +605,13 @@ impl VideoFilterOp for FadeFilter {
     }
 }
 
-#[derive(Clone, Copy)]
+#[derive(Debug, Clone, Copy)]
 enum FadeMode {
     In,
     Out,
 }
 
-#[derive(Clone, Copy)]
+#[derive(Debug, Clone, Copy)]
 struct FadePoint {
     mode: FadeMode,
     time: Duration,
@@ -731,7 +731,7 @@ impl FadePoint {
     }
 }
 
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct CropFilter {
     pub size: Option<FrameSize>,
     pub scaling_mode: ScalingMode,


### PR DESCRIPTION
optimizes cuda pipeline to convert to 8-bit early when encoder is 8-bit and hardware overlay can be used with 8-bit, instead of downloading and using software overlay with 10-bit content that will later be converted to 8-bit anyway.