### PR TITLE
add channel number to `display-name` in xmltv channel listings

### DIFF
--- a/crates/ersatztv/src/xmltv.rs
+++ b/crates/ersatztv/src/xmltv.rs
@@ -174,4 +174,21 @@ mod tests {
             "child element dropped: {output}"
         );
     }
+
+    #[test]
+    fn generate_blocking_includes_display_names() {
+        let channels = vec![ChannelMeta {
+            number: "1.1".to_string(),
+            name: "Test Channel".to_string(),
+            tvg_id: "test.1".to_string(),
+            logo: None,
+        }];
+
+        let result = generate_blocking(None, &channels).unwrap();
+        let output = String::from_utf8(result).unwrap();
+
+        assert!(output.contains("<display-name>1.1 Test Channel</display-name>"));
+        assert!(output.contains("<display-name>1.1</display-name>"));
+        assert!(output.contains("<display-name>Test Channel</display-name>"));
+    }
 }

--- a/crates/ersatztv/src/xmltv.rs
+++ b/crates/ersatztv/src/xmltv.rs
@@ -58,6 +58,10 @@ fn generate_blocking(
 
                         inner_writer
                             .create_element("display-name")
+                            .write_text_content(BytesText::new(&channel_num))?;
+
+                        inner_writer
+                            .create_element("display-name")
                             .write_text_content(BytesText::new(&channel_name))?;
 
                         if let Some(logo) = &channel.logo {

--- a/crates/ersatztv/src/xmltv.rs
+++ b/crates/ersatztv/src/xmltv.rs
@@ -51,18 +51,18 @@ fn generate_blocking(
                         let channel_num = channel.number.as_str();
                         let channel_name = channel.name.as_str();
                         let display_name = format!("{channel_num} {channel_name}");
-                        
+
                         inner_writer
                             .create_element("display-name")
                             .write_text_content(BytesText::new(&display_name))?;
 
                         inner_writer
                             .create_element("display-name")
-                            .write_text_content(BytesText::new(&channel_num))?;
+                            .write_text_content(BytesText::new(channel_num))?;
 
                         inner_writer
                             .create_element("display-name")
-                            .write_text_content(BytesText::new(&channel_name))?;
+                            .write_text_content(BytesText::new(channel_name))?;
 
                         if let Some(logo) = &channel.logo {
                             inner_writer

--- a/crates/ersatztv/src/xmltv.rs
+++ b/crates/ersatztv/src/xmltv.rs
@@ -10,6 +10,7 @@ use crate::LineupState;
 use crate::channel_model::ChannelModel;
 
 struct ChannelMeta {
+    pub number: String,
     pub name: String,
     pub tvg_id: String,
     pub logo: Option<String>,
@@ -18,6 +19,7 @@ struct ChannelMeta {
 impl From<&ChannelModel> for ChannelMeta {
     fn from(model: &ChannelModel) -> Self {
         Self {
+            number: model.number().to_string(),
             name: model.name().to_string(),
             tvg_id: model.tvg_id().to_string(),
             logo: model.logo().map(|s| s.to_string()),
@@ -46,9 +48,17 @@ fn generate_blocking(
                 w.create_element("channel")
                     .with_attribute(("id", channel.tvg_id.as_str()))
                     .write_inner_content(|inner_writer| {
+                        let channel_num = channel.number.as_str();
+                        let channel_name = channel.name.as_str();
+                        let display_name = format!("{channel_num} {channel_name}");
+                        
                         inner_writer
                             .create_element("display-name")
-                            .write_text_content(BytesText::new(channel.name.as_str()))?;
+                            .write_text_content(BytesText::new(&display_name))?;
+
+                        inner_writer
+                            .create_element("display-name")
+                            .write_text_content(BytesText::new(&channel_name))?;
 
                         if let Some(logo) = &channel.logo {
                             inner_writer


### PR DESCRIPTION
Adds another `display-name` entry for the channels to match the legacy xmltv output (some clients seem to do a lexical sort on this field)