### PR TITLE
fix: disable embedded text subtitles

### DIFF
--- a/crates/ersatztv-channel/src/channel_session.rs
+++ b/crates/ersatztv-channel/src/channel_session.rs
@@ -21,7 +21,7 @@ use ffpipeline::input::{
     LavfiInputSource, LocalInputSource, ProbedInput, RtspInputOptions, RtspInputSource,
     WatermarkInput,
 };
-use ffpipeline::output_settings::{AudioOutputSettings, OutputSettings};
+use ffpipeline::output_settings::{AudioOutputSettings, OutputSettings, SubtitleMode};
 use ffpipeline::pipeline::{AudioFormat, Hz, Kbps, PtsOffset, SEGMENT_SECONDS, VideoFormat};
 use ffpipeline::probe::{
     CodecType, ProbeResult, ProbeResultAudioStream, ProbeResultColorParams, ProbeResultStream,
@@ -529,6 +529,12 @@ impl ChannelSession {
                 None
             },
             subtitle_mode: self.channel_config.normalization.subtitle.mode.into(),
+            fonts_folder: self
+                .channel_config
+                .normalization
+                .subtitle
+                .fonts_folder
+                .clone(),
             reports_folder: self.channel_config.ffmpeg.reports_folder.clone(),
             report_id: Some(self.channel_config.number().to_owned()),
         };
@@ -589,7 +595,7 @@ impl ChannelSession {
             _ => None,
         };
 
-        let input_settings = InputSettings {
+        let mut input_settings = InputSettings {
             start: current_item.start,
             audio_input: ProbedInput {
                 input_source: audio_input_source,
@@ -614,7 +620,7 @@ impl ChannelSession {
         };
 
         let mut subtitle_source: Option<SubtitleSource> = None;
-        if output_settings.subtitle_mode == ffpipeline::output_settings::SubtitleMode::Convert
+        if output_settings.subtitle_mode == SubtitleMode::Convert
             && let Some(subtitle_stream) = input_settings.select_subtitle_stream()
             && !subtitle_stream.is_subtitle_image()
             && let Some(input) = input_settings.subtitle_input.as_ref()
@@ -631,6 +637,23 @@ impl ChannelSession {
                 cursor: 0,
                 next_segment_source_offset: input.in_point,
             });
+        }
+
+        let skip_embedded_text_subtitles = output_settings.subtitle_mode == SubtitleMode::Burn
+            && input_settings
+                .subtitle_input
+                .as_ref()
+                .is_some_and(|i| i.probe_result.streams.len() > 1)
+            && input_settings
+                .select_subtitle_stream()
+                .is_some_and(|s| !s.is_subtitle_image());
+
+        if skip_embedded_text_subtitles {
+            log::warn!(
+                "skipping embedded text subtitles for item {}; scheduler must extract to a sidecar file",
+                current_item.id
+            );
+            input_settings.subtitle_input = None;
         }
 
         let pts_offset = output_settings.pts_offset;

--- a/crates/ersatztv-channel/src/config.rs
+++ b/crates/ersatztv-channel/src/config.rs
@@ -14,6 +14,7 @@ pub const PATH_FIELDS: &[&str] = &[
     "/ffmpeg/ffmpeg_path",
     "/ffmpeg/ffprobe_path",
     "/ffmpeg/reports_folder",
+    "/normalization/subtitle/fonts_folder",
 ];
 
 #[derive(Deserialize, Serialize, Clone, Debug, JsonSchema)]
@@ -460,6 +461,8 @@ impl From<VideoFormat> for ffpipeline::pipeline::VideoFormat {
 pub struct SubtitleNormalizationConfig {
     #[serde(default)]
     pub mode: SubtitleMode,
+    #[serde(default)]
+    pub fonts_folder: Option<String>,
 }
 
 #[derive(Deserialize, Serialize, Clone, Debug, JsonSchema, Default, Copy)]

--- a/crates/ffpipeline/src/output_settings.rs
+++ b/crates/ffpipeline/src/output_settings.rs
@@ -22,6 +22,7 @@ pub struct OutputSettings {
     pub is_live: bool,
     pub frame_rate: Option<FrameRate>,
     pub subtitle_mode: SubtitleMode,
+    pub fonts_folder: Option<String>,
     pub reports_folder: Option<String>,
     pub report_id: Option<String>,
 }

--- a/crates/ffpipeline/src/pipeline.rs
+++ b/crates/ffpipeline/src/pipeline.rs
@@ -485,6 +485,7 @@ impl Pipeline {
                     SubtitlesFilter {
                         path: subtitle_input.probe_result.path.to_owned(),
                         seek: subtitle_input.in_point,
+                        fonts_folder: final_output_settings.fonts_folder.to_owned(),
                     }
                     .into(),
                 ))

--- a/crates/ffpipeline/src/video_filter.rs
+++ b/crates/ffpipeline/src/video_filter.rs
@@ -491,6 +491,7 @@ impl VideoFilterOp for HwMapFilter {
 pub struct SubtitlesFilter {
     pub path: String,
     pub seek: Duration,
+    pub fonts_folder: Option<String>,
 }
 
 impl VideoFilterOp for SubtitlesFilter {
@@ -511,16 +512,23 @@ impl VideoFilterOp for SubtitlesFilter {
     }
 
     fn as_arg(&self) -> Option<String> {
-        let escaped_path = FfmpegInfo::escape_path(&self.path);
+        let filter_args = match self.fonts_folder.as_ref() {
+            Some(fonts_folder) => format!(
+                "{}:fontsdir={}",
+                FfmpegInfo::escape_path(&self.path),
+                FfmpegInfo::escape_path(fonts_folder)
+            ),
+            None => FfmpegInfo::escape_path(&self.path),
+        };
 
         if self.seek > Duration::ZERO {
             Some(format!(
                 "setpts=PTS+{}/TB,subtitles={},setpts=PTS-STARTPTS",
                 self.seek.as_secs_f64(),
-                escaped_path,
+                filter_args,
             ))
         } else {
-            Some(format!("subtitles={}", escaped_path))
+            Some(format!("subtitles={}", filter_args))
         }
     }
 }

--- a/crates/ffpipeline/tests/common/mod.rs
+++ b/crates/ffpipeline/tests/common/mod.rs
@@ -230,6 +230,7 @@ pub fn build_output(dir: &Path, params: TestOutputParams) -> OutputSettings {
         is_live: false,
         frame_rate: params.frame_rate,
         subtitle_mode: SubtitleMode::Burn,
+        fonts_folder: None,
         reports_folder: None,
         report_id: None,
     }

--- a/schema/channel_config.json
+++ b/schema/channel_config.json
@@ -234,6 +234,7 @@
         "subtitle": {
           "$ref": "#/$defs/SubtitleNormalizationConfig",
           "default": {
+            "fonts_folder": null,
             "mode": "burn"
           }
         },
@@ -283,6 +284,13 @@
     "SubtitleNormalizationConfig": {
       "type": "object",
       "properties": {
+        "fonts_folder": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "default": null
+        },
         "mode": {
           "$ref": "#/$defs/SubtitleMode",
           "default": "burn"


### PR DESCRIPTION
Embedded text subtitles must first be extracted; playout items with embedded text subtitles will now ignore those subtitles.