### PR TITLE
fix: resume a chunked item from the position its output actually reached

### DIFF
--- a/crates/ersatztv-channel/src/channel_session.rs
+++ b/crates/ersatztv-channel/src/channel_session.rs
@@ -42,6 +42,10 @@ use crate::pts_scanner::{PtsScanner, PtsTime};
 
 const STDERR_RING_LINES: usize = 2_000;
 
+/// How far a measured resume position may sit from the scheduled one before it
+/// is treated as unusable. Encoder drift over a single chunk is far below this.
+const MAX_RESUME_DRIFT: Duration = Duration::from_secs(SEGMENT_SECONDS as u64);
+
 #[derive(Copy, Clone, PartialEq)]
 enum ChannelSessionState {
     SeekAndWorkAhead,
@@ -93,6 +97,12 @@ pub struct ChannelSession {
 
     cached_subtitles: Option<(String, Arc<Vec<Cue>>)>,
     dynamic_http_client: reqwest::Client,
+
+    /// The output pts the current item started at, recorded when the item
+    /// begins. A pipeline resuming the item partway through uses the distance
+    /// from this to the current pts as its source read position, so the
+    /// content and the output timeline advance by the same amount.
+    item_base_pts: Option<Duration>,
 }
 
 impl ChannelSession {
@@ -187,6 +197,7 @@ impl ChannelSession {
             timeout_notify: Arc::new(tokio::sync::Notify::new()),
             cached_subtitles: None,
             dynamic_http_client,
+            item_base_pts: None,
         })
     }
 
@@ -544,12 +555,25 @@ impl ChannelSession {
             ChannelSessionState::ZeroAndWorkAhead | ChannelSessionState::ZeroAndRealtime
         );
 
+        // record where this item's output timeline began, so a pipeline that
+        // resumes the item partway through can measure how much content the
+        // previous one actually produced
+        if start_at_zero {
+            self.item_base_pts = pts_duration;
+        }
+
+        let measured_progress = match (pts_duration, self.item_base_pts) {
+            (Some(now), Some(base)) => Some(now.saturating_sub(base)),
+            _ => None,
+        };
+
         let audio_timing = self.input_timing(
             current_item,
             &audio_source,
             start_at_zero,
             realtime,
             is_live,
+            measured_progress,
         );
         let video_timing = self.input_timing(
             current_item,
@@ -557,10 +581,18 @@ impl ChannelSession {
             start_at_zero,
             realtime,
             is_live,
+            measured_progress,
         );
-        let subtitle_timing = subtitle_source
-            .as_ref()
-            .map(|s| self.input_timing(current_item, s, start_at_zero, realtime, is_live));
+        let subtitle_timing = subtitle_source.as_ref().map(|s| {
+            self.input_timing(
+                current_item,
+                s,
+                start_at_zero,
+                realtime,
+                is_live,
+                measured_progress,
+            )
+        });
 
         let video_index = current_item
             .tracks
@@ -894,6 +926,7 @@ impl ChannelSession {
         start_at_zero: bool,
         realtime: bool,
         is_live: bool,
+        measured_progress: Option<Duration>,
     ) -> TimingResult {
         let mut is_complete = true;
 
@@ -928,11 +961,8 @@ impl ChannelSession {
             self.transcoded_until
         };
 
-        let progress_ms = if start_at_zero {
-            0
-        } else {
-            (effective_now - item_start).whole_milliseconds().max(0) as u64
-        };
+        let progress_ms =
+            resume_progress_ms(start_at_zero, measured_progress, effective_now - item_start);
         let effective_in_point = Duration::from_millis(item_in_point_base_ms + progress_ms);
 
         let duration =
@@ -1262,6 +1292,50 @@ fn playout_timing_to_pipeline(
     })
 }
 
+/// How far into an item the next pipeline resumes reading, in milliseconds of
+/// content.
+///
+/// A pipeline that stops partway through an item is followed by one that seeks
+/// back in and continues, and the output pts that second pipeline is stamped
+/// with comes from measuring what the first one actually left on disk. The
+/// source read position has to come from that same measurement. Deriving the
+/// read position from the schedule instead lets the two disagree by however
+/// much the encoder over- or under-ran, which leaves a gap in one of the
+/// output streams at the restart while the other stays continuous.
+///
+/// Falls back to the scheduled position when there is no measurement to use,
+/// which is the case for the first item a channel joins partway through, or
+/// when the measurement is too far from the schedule to be describing this
+/// item at all.
+fn resume_progress_ms(
+    start_at_zero: bool,
+    measured_progress: Option<Duration>,
+    scheduled_progress: time::Duration,
+) -> u64 {
+    if start_at_zero {
+        return 0;
+    }
+
+    let scheduled_ms = scheduled_progress.whole_milliseconds().max(0) as u64;
+
+    let Some(measured) = measured_progress else {
+        return scheduled_ms;
+    };
+
+    // the two should differ only by encoder drift over one chunk. Anything
+    // larger means the measured pts is not describing this item, and seeking
+    // to it would land outside the source, so prefer the schedule
+    let measured_ms = measured.as_millis() as u64;
+    if measured_ms.abs_diff(scheduled_ms) > MAX_RESUME_DRIFT.as_millis() as u64 {
+        log::warn!(
+            "measured resume position {measured_ms}ms is too far from the scheduled {scheduled_ms}ms; using the schedule"
+        );
+        return scheduled_ms;
+    }
+
+    measured_ms
+}
+
 fn source_is_live(source: &PlayoutItemSource) -> bool {
     matches!(
         source,
@@ -1329,5 +1403,73 @@ fn probe_hint_to_result(hint: &ProbeHint, path: String) -> ProbeResult {
         streams: video.chain(audio).chain(subtitle).collect(),
         duration: hint.duration_ms.map(Duration::from_millis),
         format_name: hint.format_name.clone().or(Some(String::from("mpegts"))),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn an_item_starting_fresh_reads_from_its_in_point() {
+        let progress = resume_progress_ms(
+            true,
+            Some(Duration::from_secs(90)),
+            time::Duration::seconds(30),
+        );
+
+        assert_eq!(progress, 0);
+    }
+
+    #[test]
+    fn a_resumed_item_reads_from_the_measured_output_position() {
+        // the previous pipeline was stamped from 60s and left output ending at
+        // 103.5s, so it produced 43.5s of content, half a second short of the
+        // 44s the schedule asked for
+        let progress = resume_progress_ms(
+            false,
+            Some(Duration::from_millis(43_500)),
+            time::Duration::seconds(44),
+        );
+
+        assert_eq!(progress, 43_500);
+    }
+
+    #[test]
+    fn a_resumed_item_falls_back_to_the_schedule_without_a_measurement() {
+        let progress = resume_progress_ms(false, None, time::Duration::seconds(44));
+
+        assert_eq!(progress, 44_000);
+    }
+
+    #[test]
+    fn a_measurement_far_from_the_schedule_is_rejected() {
+        // a pts that does not describe this item at all, e.g. carried over
+        // from somewhere else; seeking there would land outside the source
+        let progress = resume_progress_ms(
+            false,
+            Some(Duration::from_secs(4_000)),
+            time::Duration::seconds(44),
+        );
+
+        assert_eq!(progress, 44_000);
+    }
+
+    #[test]
+    fn a_measurement_within_the_drift_allowance_is_used() {
+        let progress = resume_progress_ms(
+            false,
+            Some(Duration::from_millis(46_000)),
+            time::Duration::seconds(44),
+        );
+
+        assert_eq!(progress, 46_000);
+    }
+
+    #[test]
+    fn a_negative_scheduled_position_is_clamped_to_the_in_point() {
+        let progress = resume_progress_ms(false, None, time::Duration::seconds(-5));
+
+        assert_eq!(progress, 0);
     }
 }


### PR DESCRIPTION

#### The problem

While the channel works ahead, a pipeline does not cover a whole playout item. `input_timing` clamps the chunk to `SEGMENT_SECONDS * 11`, which is 44 seconds, and marks the item incomplete. The state machine moves to `SeekAndRealtime`. A second pipeline then seeks back into the same item and continues it.

The two pipelines take their positions from two different clocks.

The source read position comes from the schedule. `effective_in_point` is the item's in point plus `transcoded_until - item_start`. That advances by exactly the 44 seconds the chunk was asked for.

The output timestamp comes from a measurement. `PtsScanner::get_last_pts` runs ffprobe on the newest segment on disk and returns the largest `pts_time + duration_time` it finds. That value becomes the next pipeline's `-output_ts_offset`.

The two positions agree only when the encoder produced exactly the requested duration. Two things make that unlikely:

1. The encoder emits whole frames and the segmenter closes segments on keyframes. The real end lands near the requested boundary, not on it.
2. The scan has no `-select_streams`, so it takes the maximum across audio and video packets together. The two streams do not end at the same timestamp. The anchor therefore lands on whichever stream extends further.

At the restart, one output stream continues from where it really ended. The other is stamped from a different point. The difference is a splice partway through a program, with the two streams displaced from each other.

#### The fix

Record the output timestamp at which each item starts. Position a resumed pipeline by the distance from that mark to the current timestamp. The source read position and the output timeline then advance by the same amount, by construction.

The schedule is still used in two cases:

- No measurement is available. This happens for the first item a channel joins partway through, where there is no earlier output to measure.
- The measurement sits further from the schedule than encoder drift can explain, currently one segment duration. A measurement that far out does not describe this item, and a seek to it could land outside the source. The code logs a warning and uses the schedule.

The comparison logic is a free function, so tests can call it directly. Six unit tests cover the fresh start, the resumed case, both fallbacks, and the drift boundary.

#### Standards context

The worker marks every pipeline restart with `EXT-X-DISCONTINUITY`, and rfc8216bis-22 section 3 permits a signaled discontinuity:

> "Each Media Segment MUST carry the continuation of the encoded bitstream from the end of the segment with the previous Media Sequence Number, where values in a series such as timestamps and Continuity Counters MUST continue uninterrupted. The only exceptions are the first Media Segment ever to appear in a Media Playlist and Media Segments that are explicitly signaled as discontinuities (Section 4.4.4.3)."

The old behavior depended on that exception. The fix satisfies the rule. Timestamps now continue uninterrupted through a chunk restart, and the tag becomes a safety margin.

The same section of the spec names the practical failure mode: "Unmarked media discontinuities can trigger playback errors." Many IPTV clients are ffmpeg based and ignore discontinuity tags. For those clients, a tagged discontinuity is functionally an unmarked one. The fix removes the discontinuity itself, so those clients no longer depend on a tag they do not read.

The old splice was also outside what the tag can describe. Section 4.4.4.3 defines the tag at segment granularity: "The EXT-X-DISCONTINUITY tag indicates a discontinuity between the Media Segment that follows it and the one that preceded it." HLS has no per-stream discontinuity signal. The old code moved one elementary stream and not the other, which no playlist tag can express. Even a client that honors the tag received an incomplete description of the seam. After the fix, both streams move together, and the segment-level model describes the stream accurately again.

#### Scope

The change applies to one path: a pipeline that resumes an item that an earlier pipeline started. Every other pipeline, including one that starts an item from zero, keeps its current behavior.

If the read position was meant to follow the schedule for a reason I have not seen, I would rather hear it than have you take this on my reading of the code alone.

I am new to Rust and collaborated with Claude Code on this PR. The AI did most of the code reading and testing described above, so extra scrutiny in review is welcome.
