### PR TITLE
fix: pad every item to its slot and hand the stamp clock error back

### DIFF
--- a/crates/ersatztv-channel/src/channel_session.rs
+++ b/crates/ersatztv-channel/src/channel_session.rs
@@ -71,6 +71,42 @@ struct TimingResult {
     is_complete: bool,
 }
 
+/// Plain-data inputs for [`ChannelSession::build_output_settings`].
+/// `transcode_item` launches a real ffmpeg, so every decision that lives
+/// inline in it is invisible to the test suite; this seam lets tests reach
+/// the output settings a pipeline is actually built with.
+struct OutputSettingsPlan<'a> {
+    channel_config: &'a ChannelConfig,
+    accel: Option<ffpipeline::hw_accel::HardwareAccel>,
+    output_file: String,
+    output_segment_template: String,
+    troubleshoot: bool,
+    pts_duration: Option<Duration>,
+    realtime: bool,
+    is_live: bool,
+    video_is_still_image: bool,
+}
+
+/// Plain-data inputs for [`ChannelSession::plan_timings`].
+struct TimingPlan<'a> {
+    current_item: &'a PlayoutItem,
+    audio_source: &'a PlayoutItemSource,
+    video_source: &'a PlayoutItemSource,
+    subtitle_source: Option<&'a PlayoutItemSource>,
+    start_at_zero: bool,
+    realtime: bool,
+    is_live: bool,
+    transcoded_until: OffsetDateTime,
+}
+
+/// What [`ChannelSession::plan_timings`] decided: the per-stream input
+/// timings for one pipeline invocation.
+struct PlannedTimings {
+    audio: TimingResult,
+    video: TimingResult,
+    subtitle: Option<TimingResult>,
+}
+
 pub struct ChannelSession {
     channel_config: ChannelConfig,
     playout_loader: PlayoutLoader,
@@ -512,99 +548,42 @@ impl ChannelSession {
             subtitle_probe_opt
         };
 
-        let audio_norm = &self.channel_config.normalization.audio;
-        let video_norm = &self.channel_config.normalization.video;
-
-        let video_size = match (video_norm.width, video_norm.height) {
-            (Some(width), Some(height)) => Some(FrameSize { width, height }),
-            _ => None,
-        };
-
         // consider an item to be live if any of its sources are live;
         // live sources can never seek or work ahead
         let is_live = source_is_live(&video_source) || source_is_live(&audio_source);
 
         // generate pipeline
-        let output_settings = OutputSettings {
-            audio: AudioOutputSettings {
-                format: audio_norm.format.clone().map(AudioFormat::from),
-                bitrate: audio_norm.bitrate_kbps.map(Kbps),
-                buffer: audio_norm.buffer_kbps.map(Kbps),
-                channels: audio_norm.channels,
-                sample_rate: audio_norm.sample_rate_hz.map(Hz),
-                loudness: if audio_norm.normalize_loudness {
-                    Some(
-                        audio_norm
-                            .loudness
-                            .as_ref()
-                            .map(|l| l.into())
-                            .unwrap_or_default(),
-                    )
-                } else {
-                    None
-                },
-            },
-            video_format: video_norm.format.clone().map(VideoFormat::from),
-            bit_depth: video_norm.bit_depth,
-            video_bitrate: video_norm.bitrate_kbps.map(Kbps),
-            video_buffer: video_norm.buffer_kbps.map(Kbps),
-            video_size,
-            scaling_mode: video_norm.scaling_mode.into(),
-            filter_options: video_norm.filters.clone().into(),
-            deinterlace: video_norm.deinterlace,
+        let output_settings = Self::build_output_settings(OutputSettingsPlan {
+            channel_config: &self.channel_config,
             accel: self.hw_accel.clone(),
-            format: ffpipeline::output_format::OutputFormat::Hls {
-                playlist: self.output_file.clone(),
-                segment_template: self.output_segment_template.clone(),
-                troubleshoot,
-            },
-            pts_offset: pts_duration.map(|duration| PtsOffset { duration }),
+            output_file: self.output_file.clone(),
+            output_segment_template: self.output_segment_template.clone(),
+            troubleshoot,
+            pts_duration,
             realtime,
             is_live,
-            frame_rate: if video_probe_result.is_still_image() {
-                Some(FrameRate::default())
-            } else {
-                None
-            },
-            subtitle_mode: self.channel_config.normalization.subtitle.mode.into(),
-            fonts_folder: self
-                .channel_config
-                .normalization
-                .subtitle
-                .fonts_folder
-                .clone(),
-            subtitle_force_style: self
-                .channel_config
-                .normalization
-                .subtitle
-                .force_style
-                .clone(),
-            reports_folder: self.channel_config.ffmpeg.reports_folder.clone(),
-            report_id: Some(self.channel_config.number().to_owned()),
-        };
+            video_is_still_image: video_probe_result.is_still_image(),
+        });
 
         let start_at_zero = matches!(
             self.state,
             ChannelSessionState::ZeroAndWorkAhead | ChannelSessionState::ZeroAndRealtime
         );
 
-        let audio_timing = self.input_timing(
+        let PlannedTimings {
+            audio: audio_timing,
+            video: video_timing,
+            subtitle: subtitle_timing,
+        } = Self::plan_timings(TimingPlan {
             current_item,
-            &audio_source,
+            audio_source: &audio_source,
+            video_source: &video_source,
+            subtitle_source: subtitle_source.as_ref(),
             start_at_zero,
             realtime,
             is_live,
-        );
-        let video_timing = self.input_timing(
-            current_item,
-            &video_source,
-            start_at_zero,
-            realtime,
-            is_live,
-        );
-        let subtitle_timing = subtitle_source
-            .as_ref()
-            .map(|s| self.input_timing(current_item, s, start_at_zero, realtime, is_live));
+            transcoded_until: self.transcoded_until,
+        });
 
         let video_index = current_item
             .tracks
@@ -939,13 +918,13 @@ impl ChannelSession {
         }
     }
 
-    fn input_timing(
-        &self,
+    fn input_timing_at(
         current_item: &PlayoutItem,
         source: &PlayoutItemSource,
         start_at_zero: bool,
         realtime: bool,
         is_live: bool,
+        transcoded_until: OffsetDateTime,
     ) -> TimingResult {
         let mut is_complete = true;
 
@@ -967,7 +946,7 @@ impl ChannelSession {
         let effective_now = if start_at_zero {
             item_start
         } else {
-            self.transcoded_until
+            transcoded_until
         };
 
         // live content never seeks. limit it to the remaining schedule interval
@@ -1013,6 +992,115 @@ impl ChannelSession {
             out_point,
             finish,
             is_complete,
+        }
+    }
+
+    /// The output settings for one pipeline, as a pure function of plain
+    /// inputs, so a test can observe what a pipeline is actually built with.
+    fn build_output_settings(plan: OutputSettingsPlan) -> OutputSettings {
+        let audio_norm = &plan.channel_config.normalization.audio;
+        let video_norm = &plan.channel_config.normalization.video;
+
+        let video_size = match (video_norm.width, video_norm.height) {
+            (Some(width), Some(height)) => Some(FrameSize { width, height }),
+            _ => None,
+        };
+
+        OutputSettings {
+            audio: AudioOutputSettings {
+                format: audio_norm.format.clone().map(AudioFormat::from),
+                bitrate: audio_norm.bitrate_kbps.map(Kbps),
+                buffer: audio_norm.buffer_kbps.map(Kbps),
+                channels: audio_norm.channels,
+                sample_rate: audio_norm.sample_rate_hz.map(Hz),
+                loudness: if audio_norm.normalize_loudness {
+                    Some(
+                        audio_norm
+                            .loudness
+                            .as_ref()
+                            .map(|l| l.into())
+                            .unwrap_or_default(),
+                    )
+                } else {
+                    None
+                },
+            },
+            video_format: video_norm.format.clone().map(VideoFormat::from),
+            bit_depth: video_norm.bit_depth,
+            video_bitrate: video_norm.bitrate_kbps.map(Kbps),
+            video_buffer: video_norm.buffer_kbps.map(Kbps),
+            video_size,
+            scaling_mode: video_norm.scaling_mode.into(),
+            filter_options: video_norm.filters.clone().into(),
+            deinterlace: video_norm.deinterlace,
+            accel: plan.accel,
+            format: ffpipeline::output_format::OutputFormat::Hls {
+                playlist: plan.output_file,
+                segment_template: plan.output_segment_template,
+                troubleshoot: plan.troubleshoot,
+            },
+            pts_offset: plan.pts_duration.map(|duration| PtsOffset { duration }),
+            realtime: plan.realtime,
+            is_live: plan.is_live,
+            frame_rate: if plan.video_is_still_image {
+                Some(FrameRate::default())
+            } else {
+                None
+            },
+            subtitle_mode: plan.channel_config.normalization.subtitle.mode.into(),
+            fonts_folder: plan
+                .channel_config
+                .normalization
+                .subtitle
+                .fonts_folder
+                .clone(),
+            subtitle_force_style: plan
+                .channel_config
+                .normalization
+                .subtitle
+                .force_style
+                .clone(),
+            reports_folder: plan.channel_config.ffmpeg.reports_folder.clone(),
+            report_id: Some(plan.channel_config.number().to_owned()),
+        }
+    }
+
+    /// The input timings for one pipeline, as a pure function of plain
+    /// inputs. Same seam and same reason as
+    /// [`Self::build_output_settings`]: what the pipeline's -ss and -t are
+    /// derived from should be observable by a test.
+    fn plan_timings(plan: TimingPlan) -> PlannedTimings {
+        let audio = Self::input_timing_at(
+            plan.current_item,
+            plan.audio_source,
+            plan.start_at_zero,
+            plan.realtime,
+            plan.is_live,
+            plan.transcoded_until,
+        );
+        let video = Self::input_timing_at(
+            plan.current_item,
+            plan.video_source,
+            plan.start_at_zero,
+            plan.realtime,
+            plan.is_live,
+            plan.transcoded_until,
+        );
+        let subtitle = plan.subtitle_source.map(|s| {
+            Self::input_timing_at(
+                plan.current_item,
+                s,
+                plan.start_at_zero,
+                plan.realtime,
+                plan.is_live,
+                plan.transcoded_until,
+            )
+        });
+
+        PlannedTimings {
+            audio,
+            video,
+            subtitle,
         }
     }
 
@@ -1446,5 +1534,174 @@ fn probe_hint_to_result(hint: &ProbeHint, path: String) -> ProbeResult {
         streams: video.chain(audio).chain(subtitle).collect(),
         duration: hint.duration_ms.map(Duration::from_millis),
         format_name: hint.format_name.clone().or(Some(String::from("mpegts"))),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The channel configuration exactly as the scaffolder writes it, which
+    /// is the shape every deployment starts from.
+    fn test_channel_config() -> ChannelConfig {
+        serde_json::from_value(serde_json::json!({
+            "playout": { "folder": "/tmp/playout" },
+            "ffmpeg": {},
+            "normalization": {
+                "audio": {
+                    "format": "aac", "bitrate_kbps": 192, "buffer_kbps": 384,
+                    "channels": 2, "sample_rate_hz": 48000,
+                    "normalize_loudness": false
+                },
+                "video": {
+                    "format": "h264", "bit_depth": 8,
+                    "width": 1920, "height": 1080,
+                    "bitrate_kbps": 2000, "buffer_kbps": 4000
+                },
+                "subtitle": { "mode": "burn" }
+            }
+        }))
+        .expect("the scaffolded channel config shape deserializes")
+    }
+
+    fn output_settings(realtime: bool, is_live: bool, still: bool) -> OutputSettings {
+        ChannelSession::build_output_settings(OutputSettingsPlan {
+            channel_config: &test_channel_config(),
+            accel: None,
+            output_file: String::from("/tmp/out/live.m3u8"),
+            output_segment_template: String::from("/tmp/out/live%06d.ts"),
+            troubleshoot: false,
+            pts_duration: Some(Duration::from_millis(1234)),
+            realtime,
+            is_live,
+            video_is_still_image: still,
+        })
+    }
+
+    /// A still image decodes as a single frame, so the encoder must be told
+    /// a rate to emit it at.
+    #[test]
+    fn a_still_image_forces_an_output_frame_rate() {
+        assert!(output_settings(true, false, true).frame_rate.is_some());
+        assert!(output_settings(true, false, false).frame_rate.is_none());
+    }
+
+    /// The scanned pts offset must reach the encoder unchanged; it is the
+    /// only thing keeping output timestamps monotonic across items.
+    #[test]
+    fn the_pts_offset_reaches_the_encoder() {
+        let settings = output_settings(true, false, false);
+        assert_eq!(
+            settings.pts_offset.expect("offset is declared").duration,
+            Duration::from_millis(1234)
+        );
+    }
+
+    /// Output pacing follows the caller alone.
+    #[test]
+    fn pacing_follows_the_caller() {
+        assert!(output_settings(true, false, false).realtime);
+        assert!(!output_settings(false, false, false).realtime);
+    }
+
+    /// A plain file item occupying an 11.021 second slot.
+    fn file_item() -> PlayoutItem {
+        serde_json::from_value(serde_json::json!({
+            "id": "file-item",
+            "start": "2026-08-15T12:00:00.000-04:00",
+            "finish": "2026-08-15T12:00:11.021-04:00",
+            "source": { "source_type": "local", "path": "/media/item.mp4" }
+        }))
+        .expect("a local file item deserializes")
+    }
+
+    fn plan_for(item: &PlayoutItem, start_at_zero: bool, realtime: bool) -> PlannedTimings {
+        let audio_source =
+            ChannelSession::resolve_source(item, |t| t.audio.as_ref()).expect("audio source");
+        let video_source =
+            ChannelSession::resolve_source(item, |t| t.video.as_ref()).expect("video source");
+        let is_live = source_is_live(&video_source) || source_is_live(&audio_source);
+        ChannelSession::plan_timings(TimingPlan {
+            current_item: item,
+            audio_source: &audio_source,
+            video_source: &video_source,
+            subtitle_source: None,
+            start_at_zero,
+            realtime,
+            is_live,
+            transcoded_until: item.start,
+        })
+    }
+
+    /// A realtime pipeline covers its whole remaining slot in one
+    /// invocation, and both streams agree on the range.
+    #[test]
+    fn a_realtime_item_fills_its_slot_in_one_pipeline() {
+        let item = file_item();
+        let planned = plan_for(&item, true, true);
+        assert_eq!(planned.audio.in_point, Duration::ZERO);
+        assert_eq!(planned.audio.out_point, Duration::from_millis(11_021));
+        assert_eq!(planned.video.out_point, Duration::from_millis(11_021));
+        assert!(planned.video.is_complete);
+        assert_eq!(planned.video.finish, item.finish);
+    }
+
+    /// While working ahead, a long item is transcoded in chunks so the
+    /// buffer builds up quickly; the chunk boundary advances the schedule
+    /// by exactly the chunk.
+    #[test]
+    fn work_ahead_chunks_a_long_item() {
+        let item: PlayoutItem = serde_json::from_value(serde_json::json!({
+            "id": "long-item",
+            "start": "2026-08-15T12:00:00.000-04:00",
+            "finish": "2026-08-15T12:05:00.000-04:00",
+            "source": { "source_type": "local", "path": "/media/episode.mp4" }
+        }))
+        .expect("a local file item deserializes");
+
+        let limit = Duration::from_secs(SEGMENT_SECONDS as u64 * 11);
+        let planned = plan_for(&item, true, false);
+        assert_eq!(planned.video.in_point, Duration::ZERO);
+        assert_eq!(planned.video.out_point, limit);
+        assert!(!planned.video.is_complete);
+        assert_eq!(planned.video.finish, item.start + limit);
+    }
+
+    /// A live source never seeks, wherever the session is in the item: the
+    /// read position is the live edge, and only the remaining schedule
+    /// interval bounds the output.
+    #[test]
+    fn a_live_source_never_seeks() {
+        let item: PlayoutItem = serde_json::from_value(serde_json::json!({
+            "id": "live-item",
+            "start": "2026-08-15T12:00:00.000-04:00",
+            "finish": "2026-08-15T12:02:30.000-04:00",
+            "source": {
+                "source_type": "http",
+                "uri": "http://host:8000/live.ts",
+                "is_live": true
+            }
+        }))
+        .expect("a live http item deserializes");
+
+        let audio_source =
+            ChannelSession::resolve_source(&item, |t| t.audio.as_ref()).expect("audio source");
+        let video_source =
+            ChannelSession::resolve_source(&item, |t| t.video.as_ref()).expect("video source");
+        let planned = ChannelSession::plan_timings(TimingPlan {
+            current_item: &item,
+            audio_source: &audio_source,
+            video_source: &video_source,
+            subtitle_source: None,
+            start_at_zero: false,
+            realtime: true,
+            is_live: true,
+            // ninety seconds into the item
+            transcoded_until: item.start + Duration::from_secs(90),
+        });
+        assert_eq!(planned.video.in_point, Duration::ZERO);
+        assert_eq!(planned.video.out_point, Duration::from_secs(60));
+        assert!(planned.video.is_complete);
+        assert_eq!(planned.video.finish, item.finish);
     }
 }

--- a/crates/ersatztv-channel/src/channel_session.rs
+++ b/crates/ersatztv-channel/src/channel_session.rs
@@ -97,14 +97,19 @@ struct TimingPlan<'a> {
     realtime: bool,
     is_live: bool,
     transcoded_until: OffsetDateTime,
+    /// `last_segment_end - transcoded_until`: how far the stamp clock has
+    /// run past the schedule clock.
+    stamp_error_ms: i64,
 }
 
 /// What [`ChannelSession::plan_timings`] decided: the per-stream input
-/// timings for one pipeline invocation.
+/// timings for one pipeline invocation, with the emission trim already
+/// applied.
 struct PlannedTimings {
     audio: TimingResult,
     video: TimingResult,
     subtitle: Option<TimingResult>,
+    trim_ms: i64,
 }
 
 pub struct ChannelSession {
@@ -570,10 +575,25 @@ impl ChannelSession {
             ChannelSessionState::ZeroAndWorkAhead | ChannelSessionState::ZeroAndRealtime
         );
 
+        // measure how far the stamp clock has run past the schedule clock;
+        // plan_timings hands it back on this pipeline's output duration.
+        // update() first: the previous pipeline's final segments may not have
+        // been scanned yet, and an unscanned segment would hide exactly the
+        // error this is measuring
+        let stamp_error_ms = {
+            let mut playlist_manager = self.playlist_manager.lock().await;
+            playlist_manager.update().await?;
+            Self::stamp_error_ms(
+                playlist_manager.last_segment_end(),
+                self.transcoded_until,
+                self.start_time_offset,
+            )
+        };
         let PlannedTimings {
             audio: audio_timing,
             video: video_timing,
             subtitle: subtitle_timing,
+            trim_ms,
         } = Self::plan_timings(TimingPlan {
             current_item,
             audio_source: &audio_source,
@@ -583,7 +603,14 @@ impl ChannelSession {
             realtime,
             is_live,
             transcoded_until: self.transcoded_until,
+            stamp_error_ms,
         });
+        if trim_ms != 0 {
+            log::debug!(
+                "emission trim {trim_ms}ms for item {} (stamp clock is {stamp_error_ms}ms past the schedule)",
+                current_item.id
+            );
+        }
 
         let video_index = current_item
             .tracks
@@ -1040,6 +1067,24 @@ impl ChannelSession {
                 troubleshoot: plan.troubleshoot,
             },
             pts_offset: plan.pts_duration.map(|duration| PtsOffset { duration }),
+            // A file whose video stream ends before its container does books
+            // more slot than its video can fill, and the shortfall is lost
+            // permanently because last_segment_end only advances by emitted
+            // EXTINF; the schedule then runs ahead of the stamps forever.
+            // Padding every pipeline to its -t clamp closes that hole.
+            //
+            // Padding alone is not safe: with tpad in the chain the video
+            // stream never reaches EOF, so the output -t cut decides the
+            // emitted duration, and that cut is frame-quantized upward (the
+            // frame straddling it is emitted whole). Every item whose slot is
+            // not frame-aligned then emits up to one frame long, and that
+            // error accumulates instead. The emission trim (emission_trim_ms,
+            // applied by plan_timings) hands the measured error back on the
+            // next pipeline's output duration, which bounds the drift at
+            // about one frame. The flag and the trim only work as a pair: the
+            // trim assumes every pipeline is padded, because only a padded
+            // pipeline can extend to cover a negative error.
+            pad_to_duration: true,
             realtime: plan.realtime,
             is_live: plan.is_live,
             frame_rate: if plan.video_is_still_image {
@@ -1097,10 +1142,82 @@ impl ChannelSession {
             )
         });
 
+        let pipeline_ms = std::cmp::min(
+            audio.out_point.saturating_sub(audio.in_point),
+            video.out_point.saturating_sub(video.in_point),
+        )
+        .as_millis() as u64;
+        let trim_ms = Self::emission_trim_ms(plan.stamp_error_ms, pipeline_ms);
+        let audio = Self::apply_emission_trim(audio, trim_ms);
+        let video = Self::apply_emission_trim(video, trim_ms);
+
         PlannedTimings {
             audio,
             video,
             subtitle,
+            trim_ms,
+        }
+    }
+
+    /// How far the stamp clock has run past the schedule clock, in
+    /// milliseconds.
+    ///
+    /// The two clocks are seeded from the same reading at channel start, but
+    /// `transcoded_until` also carries `start_time_offset`, the distance to a
+    /// configured `virtual_start`. That offset is deliberate and permanent, so
+    /// it has to be added back before the two can be compared.
+    ///
+    /// Subtracting them raw would report the whole virtual start offset as
+    /// error. Since the correction below drives that error toward zero, a
+    /// channel with `virtual_start` set would have its content trimmed or
+    /// padded by the clamp on every item until the offset closed.
+    fn stamp_error_ms(
+        last_segment_end: OffsetDateTime,
+        transcoded_until: OffsetDateTime,
+        start_time_offset: time::Duration,
+    ) -> i64 {
+        (last_segment_end + start_time_offset - transcoded_until).whole_milliseconds() as i64
+    }
+
+    /// How much of this pipeline's output duration to give back to the
+    /// schedule, in milliseconds. Positive shortens the pipeline's -t,
+    /// negative lengthens it.
+    ///
+    /// `stamp_error_ms` is the same timeline position read on the stamp clock
+    /// and on the schedule clock, with the virtual start offset taken back out.
+    /// With every pipeline padded to its clamp, the -t cut is frame-quantized
+    /// upward (the frame straddling the cut is emitted whole), so each item
+    /// emits up to one frame more than its slot and the stamp clock
+    /// integrates that forever. Handing the measured error back to the next
+    /// pipeline's output duration bounds it at about one frame instead.
+    ///
+    /// The correction is clamped so a wild clock (a failed pipeline, a
+    /// corrupted playlist) slews back over several items instead of opening
+    /// one large hole, and it never eats more than half the pipeline it is
+    /// applied to.
+    fn emission_trim_ms(stamp_error_ms: i64, pipeline_ms: u64) -> i64 {
+        const MAX_CORRECTION_MS: i64 = 500;
+        stamp_error_ms
+            .clamp(-MAX_CORRECTION_MS, MAX_CORRECTION_MS)
+            .min((pipeline_ms / 2) as i64)
+    }
+
+    /// Applies an emission trim to one input's timing. Only the emitted
+    /// duration moves: `in_point` (where reading starts) and `finish` (how
+    /// far the schedule advances) are schedule-derived and stay untouched.
+    /// Output timing is measured, and measurement must never inform where a
+    /// source is read from.
+    fn apply_emission_trim(timing: TimingResult, trim_ms: i64) -> TimingResult {
+        let out_point = if trim_ms >= 0 {
+            timing
+                .out_point
+                .saturating_sub(Duration::from_millis(trim_ms as u64))
+        } else {
+            timing.out_point + Duration::from_millis(trim_ms.unsigned_abs())
+        };
+        TimingResult {
+            out_point,
+            ..timing
         }
     }
 
@@ -1541,6 +1658,57 @@ fn probe_hint_to_result(hint: &ProbeHint, path: String) -> ProbeResult {
 mod tests {
     use super::*;
 
+    fn at(seconds: i64) -> OffsetDateTime {
+        OffsetDateTime::UNIX_EPOCH + time::Duration::seconds(seconds)
+    }
+
+    #[test]
+    fn stamp_error_measures_emission_against_the_schedule() {
+        // 25s more media emitted than the slot called for
+        assert_eq!(
+            ChannelSession::stamp_error_ms(at(1025), at(1000), time::Duration::ZERO),
+            25_000
+        );
+        assert_eq!(
+            ChannelSession::stamp_error_ms(at(995), at(1000), time::Duration::ZERO),
+            -5_000
+        );
+    }
+
+    #[test]
+    fn a_virtual_start_offset_is_not_a_stamp_error() {
+        // ChannelSession::new seeds last_segment_end at `now` and
+        // transcoded_until at `now + start_time_offset`, so the offset is
+        // present from the first pipeline and never goes away. reporting it
+        // as error would make emission_trim_ms claw back the whole virtual
+        // start offset, 500ms of content per item, for as long as it took
+        for offset_secs in [-604_800i64, -3600, -1, 1, 3600, 604_800] {
+            let offset = time::Duration::seconds(offset_secs);
+            assert_eq!(
+                ChannelSession::stamp_error_ms(at(1000), at(1000) + offset, offset),
+                0,
+                "a {offset_secs}s virtual start offset was measured as stamp error"
+            );
+        }
+    }
+
+    #[test]
+    fn a_real_error_is_still_measured_through_a_virtual_start_offset() {
+        let offset = time::Duration::hours(1);
+        assert_eq!(
+            ChannelSession::stamp_error_ms(at(1025), at(1000) + offset, offset),
+            25_000
+        );
+    }
+
+    #[test]
+    fn a_virtual_start_offset_produces_no_emission_trim() {
+        // the end to end shape of the bug: measurement into correction
+        let offset = time::Duration::hours(1);
+        let error = ChannelSession::stamp_error_ms(at(1000), at(1000) + offset, offset);
+        assert_eq!(ChannelSession::emission_trim_ms(error, 30_000), 0);
+    }
+
     /// The channel configuration exactly as the scaffolder writes it, which
     /// is the shape every deployment starts from.
     fn test_channel_config() -> ChannelConfig {
@@ -1604,6 +1772,23 @@ mod tests {
         assert!(!output_settings(false, false, false).realtime);
     }
 
+    /// Every pipeline is padded, whatever kind of item it is. The emission
+    /// trim depends on this: only a padded pipeline can extend to cover a
+    /// negative stamp clock error.
+    #[test]
+    fn every_pipeline_is_padded_to_its_clamp() {
+        for realtime in [false, true] {
+            for is_live in [false, true] {
+                for still in [false, true] {
+                    assert!(
+                        output_settings(realtime, is_live, still).pad_to_duration,
+                        "realtime={realtime} is_live={is_live} still={still} must be padded"
+                    );
+                }
+            }
+        }
+    }
+
     /// A plain file item occupying an 11.021 second slot.
     fn file_item() -> PlayoutItem {
         serde_json::from_value(serde_json::json!({
@@ -1615,7 +1800,12 @@ mod tests {
         .expect("a local file item deserializes")
     }
 
-    fn plan_for(item: &PlayoutItem, start_at_zero: bool, realtime: bool) -> PlannedTimings {
+    fn plan_for(
+        item: &PlayoutItem,
+        start_at_zero: bool,
+        realtime: bool,
+        stamp_error_ms: i64,
+    ) -> PlannedTimings {
         let audio_source =
             ChannelSession::resolve_source(item, |t| t.audio.as_ref()).expect("audio source");
         let video_source =
@@ -1630,6 +1820,7 @@ mod tests {
             realtime,
             is_live,
             transcoded_until: item.start,
+            stamp_error_ms,
         })
     }
 
@@ -1638,7 +1829,7 @@ mod tests {
     #[test]
     fn a_realtime_item_fills_its_slot_in_one_pipeline() {
         let item = file_item();
-        let planned = plan_for(&item, true, true);
+        let planned = plan_for(&item, true, true, 0);
         assert_eq!(planned.audio.in_point, Duration::ZERO);
         assert_eq!(planned.audio.out_point, Duration::from_millis(11_021));
         assert_eq!(planned.video.out_point, Duration::from_millis(11_021));
@@ -1660,11 +1851,88 @@ mod tests {
         .expect("a local file item deserializes");
 
         let limit = Duration::from_secs(SEGMENT_SECONDS as u64 * 11);
-        let planned = plan_for(&item, true, false);
+        let planned = plan_for(&item, true, false, 0);
         assert_eq!(planned.video.in_point, Duration::ZERO);
         assert_eq!(planned.video.out_point, limit);
         assert!(!planned.video.is_complete);
         assert_eq!(planned.video.finish, item.start + limit);
+    }
+
+    /// The steady state the trim exists for: each padded item overshoots its
+    /// slot by up to one frame, and the whole accumulated error comes back on
+    /// the very next pipeline.
+    #[test]
+    fn a_small_stamp_clock_error_is_returned_in_full() {
+        assert_eq!(ChannelSession::emission_trim_ms(27, 11_021), 27);
+        assert_eq!(ChannelSession::emission_trim_ms(-31, 11_021), -31);
+        assert_eq!(ChannelSession::emission_trim_ms(0, 11_021), 0);
+    }
+
+    /// A wild clock slews back over several items rather than opening one
+    /// large hole in a single pipeline.
+    #[test]
+    fn a_large_stamp_clock_error_is_clamped_in_both_directions() {
+        assert_eq!(ChannelSession::emission_trim_ms(6_500, 60_000), 500);
+        assert_eq!(ChannelSession::emission_trim_ms(-6_500, 60_000), -500);
+    }
+
+    /// A short pipeline gives back at most half of itself, so a short item can
+    /// never be trimmed into nothing.
+    #[test]
+    fn a_trim_never_eats_more_than_half_the_pipeline() {
+        assert_eq!(ChannelSession::emission_trim_ms(400, 600), 300);
+    }
+
+    /// Only the emitted duration moves. `in_point` is where reading starts
+    /// and `finish` is how far the schedule advances; a trim that touched
+    /// either would be a measurement driving a seek.
+    #[test]
+    fn a_trim_moves_only_the_out_point() {
+        let finish = OffsetDateTime::parse(
+            "2026-08-15T12:00:11.021-04:00",
+            &time::format_description::well_known::Iso8601::DEFAULT,
+        )
+        .unwrap();
+        let timing = TimingResult {
+            in_point: Duration::from_millis(2_000),
+            out_point: Duration::from_millis(13_021),
+            finish,
+            is_complete: true,
+        };
+
+        let trimmed = ChannelSession::apply_emission_trim(timing, 27);
+        assert_eq!(trimmed.in_point, Duration::from_millis(2_000));
+        assert_eq!(trimmed.out_point, Duration::from_millis(12_994));
+        assert_eq!(trimmed.finish, finish);
+        assert!(trimmed.is_complete);
+
+        let extended = ChannelSession::apply_emission_trim(
+            TimingResult {
+                in_point: Duration::from_millis(2_000),
+                out_point: Duration::from_millis(13_021),
+                finish,
+                is_complete: true,
+            },
+            -40,
+        );
+        assert_eq!(extended.in_point, Duration::from_millis(2_000));
+        assert_eq!(extended.out_point, Duration::from_millis(13_061));
+    }
+
+    /// The trim must land on what the -t actually consumes: both streams'
+    /// out points. A trim that was computed but not applied here is exactly
+    /// the wiring gap that would let the drift keep integrating while every
+    /// unit test stays green.
+    #[test]
+    fn the_trim_reaches_every_stream_the_t_reads() {
+        let item = file_item();
+        let planned = plan_for(&item, true, true, 27);
+        assert_eq!(planned.trim_ms, 27);
+        assert_eq!(planned.audio.out_point, Duration::from_millis(10_994));
+        assert_eq!(planned.video.out_point, Duration::from_millis(10_994));
+        assert_eq!(planned.audio.in_point, Duration::ZERO);
+        assert_eq!(planned.video.in_point, Duration::ZERO);
+        assert_eq!(planned.video.finish, item.finish);
     }
 
     /// A live source never seeks, wherever the session is in the item: the
@@ -1698,6 +1966,7 @@ mod tests {
             is_live: true,
             // ninety seconds into the item
             transcoded_until: item.start + Duration::from_secs(90),
+            stamp_error_ms: 0,
         });
         assert_eq!(planned.video.in_point, Duration::ZERO);
         assert_eq!(planned.video.out_point, Duration::from_secs(60));

--- a/crates/ersatztv-channel/src/playlist_manager.rs
+++ b/crates/ersatztv-channel/src/playlist_manager.rs
@@ -112,6 +112,14 @@ impl PlaylistManager {
         &self.last_progress
     }
 
+    /// Where the next segment's program date time will land: the end of all
+    /// media emitted so far, on the stamp clock. Against `transcoded_until`
+    /// (the same position on the schedule clock) this measures how far the
+    /// two clocks have drifted apart.
+    pub fn last_segment_end(&self) -> OffsetDateTime {
+        self.last_segment_end
+    }
+
     pub fn is_ready(&self) -> &bool {
         &self.ready
     }

--- a/crates/ffpipeline/src/filter_chain.rs
+++ b/crates/ffpipeline/src/filter_chain.rs
@@ -743,7 +743,8 @@ mod tests {
     use crate::overlay_filter::{OverlayFilter, OverlaySource, SoftwareOverlay};
     use crate::pipeline::{HdrFormat, HwPixelFormat};
     use crate::video_filter::{
-        FormatFilter, HwMapFilter, HwUploadFilter, PadFilter, ScaleFilter, ToneMapFilter,
+        FormatFilter, HwMapFilter, HwUploadFilter, PadFilter, ScaleFilter, TPadFilter,
+        ToneMapFilter,
     };
 
     fn vaapi_accel() -> HardwareAccel {
@@ -1907,6 +1908,147 @@ mod tests {
                 })
             ),
             "encoder format hint (NV12) should win over bit-depth canonical (P010le)",
+        );
+    }
+
+    /// `tpad` costs one round trip and nothing more: the scale stays on the
+    /// GPU.
+    ///
+    /// `TPadFilter`'s `required_surface` is `System` because ffmpeg has no
+    /// hardware tpad, which reads like it could drag the whole video chain
+    /// into software. It does not: the resolver re-uploads immediately after
+    /// the pad and the scale still resolves to `scale_vaapi`. The download is
+    /// unavoidable given the filter exists only in software; what matters is
+    /// that it does not spread.
+    #[test]
+    fn tpad_costs_one_roundtrip_and_leaves_the_scale_on_the_gpu() {
+        let ffmpeg_info =
+            ffmpeg_info_with_filters(&[KnownVideoFilter::ScaleVaapi, KnownVideoFilter::PadVaapi]);
+        let filter_options = VideoFilterOptions::default();
+        let initial_state = FrameState {
+            size: FrameSize {
+                width: 1920,
+                height: 1080,
+            },
+            is_anamorphic: false,
+            is_interlaced: false,
+            sample_aspect_ratio: None,
+            display_aspect_ratio: None,
+            surface: FrameSurface::Vaapi,
+            pixel_format: PixelFormat::Nv12,
+            hdr_format: HdrFormat::None,
+        };
+
+        let scale = || {
+            PipelineFilter::Video(
+                ScaleFilter {
+                    size: Some(FrameSize {
+                        width: 1280,
+                        height: 720,
+                    }),
+                    scaling_mode: ScalingMode::ScaleAndPad,
+                    input_is_anamorphic: false,
+                    force_original_aspect_ratio: None,
+                }
+                .into(),
+            )
+        };
+
+        let capable = HardwareAccel::Vaapi(Vaapi {
+            device: String::from("/dev/dri/renderD128"),
+            driver: VaapiDriver::Ihd,
+            capabilities: VaapiCapabilities {
+                vendor: String::from("test"),
+                supported: HashSet::new(),
+                vpp_pixel_formats: HashSet::from([libva_sys::VA_FOURCC_NV12]),
+                can_hdr_to_sdr_tonemap: HashSet::new(),
+                can_hdr_to_hdr_tonemap: HashSet::new(),
+                can_overlay: false,
+                rate_control: HashMap::new(),
+            },
+            opencl_capabilities: OpenCLCapabilities::default(),
+        });
+
+        let build = |filters: Vec<PipelineFilter>| {
+            let mut chain = FilterChain::new(filters);
+            chain.evaluate(&initial_state, &ffmpeg_info);
+            chain.resolve(
+                &ffmpeg_info,
+                &Some(capable.clone()),
+                &filter_options,
+                &initial_state,
+                &FrameSurface::Vaapi,
+                &Some(PixelFormat::Nv12),
+            );
+            chain.build("0:a", "0:v", None, &[]);
+            chain.as_arg()[1].clone()
+        };
+
+        let without_tpad = build(vec![scale()]);
+        assert!(
+            without_tpad.contains("scale_vaapi"),
+            "a hardware channel scales on the GPU when nothing forces it off: {without_tpad}"
+        );
+
+        let with_tpad = build(vec![PipelineFilter::Video(TPadFilter.into()), scale()]);
+        assert!(
+            with_tpad.contains("tpad=stop=-1:stop_mode=clone"),
+            "the pad must still be applied: {with_tpad}"
+        );
+        assert!(
+            with_tpad.contains("hwdownload"),
+            "tpad has no hardware form, so one download is expected: {with_tpad}"
+        );
+        assert!(
+            with_tpad.contains("scale_vaapi"),
+            "the pad must not pull the scale into software with it: {with_tpad}"
+        );
+        assert_eq!(
+            with_tpad.matches("hwdownload").count(),
+            1,
+            "exactly one round trip, not one per filter that follows: {with_tpad}"
+        );
+    }
+
+    #[test]
+    fn tpad_renders_in_software_chain_without_hw_roundtrip() {
+        let initial_state = FrameState {
+            size: FrameSize {
+                width: 1920,
+                height: 1080,
+            },
+            is_anamorphic: false,
+            is_interlaced: false,
+            sample_aspect_ratio: None,
+            display_aspect_ratio: None,
+            surface: FrameSurface::System,
+            pixel_format: PixelFormat::Yuv420p,
+            hdr_format: HdrFormat::None,
+        };
+        let ffmpeg_info = FfmpegInfo::default();
+        let filter_options = VideoFilterOptions::default();
+
+        let mut chain = FilterChain::new(vec![PipelineFilter::Video(TPadFilter.into())]);
+
+        chain.resolve(
+            &ffmpeg_info,
+            &None,
+            &filter_options,
+            &initial_state,
+            &FrameSurface::System,
+            &Some(PixelFormat::Yuv420p),
+        );
+        chain.build("0:a", "0:v", None, &[]);
+
+        let args = chain.as_arg();
+        let filter_complex = &args[1];
+        assert!(
+            filter_complex.contains("tpad=stop=-1:stop_mode=clone"),
+            "filter_complex should contain tpad: {filter_complex}"
+        );
+        assert!(
+            !filter_complex.contains("hwupload") && !filter_complex.contains("hwdownload"),
+            "software tpad must not force a hardware roundtrip: {filter_complex}"
         );
     }
 }

--- a/crates/ffpipeline/src/output_settings.rs
+++ b/crates/ffpipeline/src/output_settings.rs
@@ -18,6 +18,10 @@ pub struct OutputSettings {
     pub accel: Option<HardwareAccel>,
     pub format: OutputFormat,
     pub pts_offset: Option<PtsOffset>,
+    /// Pad an under-running source to the output -t clamp (cloned last video
+    /// frame; audio is always padded), so the item's PTS envelope always ends
+    /// exactly at pts_offset + duration.
+    pub pad_to_duration: bool,
     pub realtime: bool,
     pub is_live: bool,
     pub frame_rate: Option<FrameRate>,

--- a/crates/ffpipeline/src/pipeline.rs
+++ b/crates/ffpipeline/src/pipeline.rs
@@ -27,8 +27,8 @@ use crate::video_decoder::VideoDecoder;
 use crate::video_filter::{
     ColorChannelMixerFilter, CropFilter, DeinterlaceFilter, Dv5WorkaroundFilter, FadeFilter,
     FormatFilter, LoopFilter, PadFilter, ScaleFilter, SoftwareDeinterlaceFilter,
-    SoftwareDeinterlaceOptions, SubtitleImageScaleFilter, SubtitlesFilter, ToneMapFilter,
-    VideoFilter,
+    SoftwareDeinterlaceOptions, SubtitleImageScaleFilter, SubtitlesFilter, TPadFilter,
+    ToneMapFilter, VideoFilter,
 };
 
 pub const KEYFRAME_INTERVAL_SECONDS: u32 = 2;
@@ -394,6 +394,13 @@ impl Pipeline {
             PipelineFilter::Audio(AudioFilter::Resample),
             PipelineFilter::Audio(AudioFilter::Pad),
         ];
+
+        if final_output_settings.pad_to_duration {
+            // pad an under-running source to the output -t clamp by cloning
+            // its last frame, so the item still fills its scheduled duration
+            // (audio is always padded; see AudioFilter::Pad)
+            filters.push(PipelineFilter::Video(TPadFilter.into()));
+        }
 
         filters.extend([
             PipelineFilter::Video(LoopFilter { is_still_image }.into()),
@@ -969,7 +976,20 @@ pub fn generate_pipeline(
 
 #[cfg(test)]
 mod tests {
+    use std::collections::{HashMap, HashSet};
+
+    use time::OffsetDateTime;
+
     use super::*;
+    use crate::input::{LocalInputSource, ProbedInput};
+    use crate::output_format::OutputFormat;
+    use crate::output_settings::{
+        AudioOutputSettings, OutputSettings, ScalingMode, SubtitleMode, VideoFilterOptions,
+    };
+    use crate::probe::{
+        CodecType, ProbeResult, ProbeResultAudioStream, ProbeResultColorParams, ProbeResultStream,
+        ProbeResultVideoStream,
+    };
 
     #[test]
     fn device_name_returns_correct_ffmpeg_device_strings() {
@@ -983,5 +1003,127 @@ mod tests {
             Some("videotoolbox")
         );
         assert_eq!(FrameSurface::System.device_name(), None);
+    }
+
+    fn file_probe(media: Duration) -> ProbeResult {
+        ProbeResult {
+            path: String::from("/media/item.mp4"),
+            streams: vec![
+                ProbeResultStream::Video(Box::new(ProbeResultVideoStream {
+                    stream_index: 0,
+                    codec: String::from("h264"),
+                    codec_type: CodecType::Video,
+                    profile: String::from("high"),
+                    height: Some(1080),
+                    width: Some(1920),
+                    frame_rate: FrameRate::parse("30"),
+                    sample_aspect_ratio: None,
+                    display_aspect_ratio: None,
+                    pix_fmt: String::from("yuv420p"),
+                    color_params: ProbeResultColorParams::default(),
+                    field_order: None,
+                    dv_profile: None,
+                })),
+                ProbeResultStream::Audio(ProbeResultAudioStream {
+                    stream_index: 1,
+                    codec: String::from("aac"),
+                    channels: 2,
+                }),
+            ],
+            duration: Some(media),
+            format_name: Some(String::from("mov,mp4,m4a")),
+        }
+    }
+
+    /// A software pipeline for a plain file item, with or without
+    /// `pad_to_duration`.
+    fn file_pipeline_args(pad_to_duration: bool) -> ArgVec {
+        let probe = file_probe(Duration::from_secs(10));
+        let input_source = InputSource::Local(LocalInputSource {
+            path: String::from("/media/item.mp4"),
+        });
+
+        let probed = |source: InputSource, probe: ProbeResult| ProbedInput {
+            input_source: source,
+            probe_result: probe,
+            in_point: Duration::ZERO,
+            out_point: Duration::from_millis(11_021),
+            stream_index: None,
+        };
+
+        let input_settings = InputSettings {
+            start: OffsetDateTime::UNIX_EPOCH,
+            playout_offset: Duration::ZERO,
+            audio_input: probed(input_source.clone(), probe.clone()),
+            video_input: probed(input_source, probe),
+            subtitle_input: None,
+            graphics_inputs: Vec::new(),
+        };
+
+        let output_settings = OutputSettings {
+            audio: AudioOutputSettings {
+                format: Some(AudioFormat::Aac),
+                bitrate: Some(Kbps(192)),
+                buffer: Some(Kbps(384)),
+                channels: Some(2),
+                sample_rate: Some(Hz(48000)),
+                loudness: None,
+            },
+            video_format: Some(VideoFormat::H264),
+            bit_depth: Some(8),
+            video_bitrate: Some(Kbps(5000)),
+            video_buffer: Some(Kbps(10000)),
+            video_size: None,
+            scaling_mode: ScalingMode::ScaleAndPad,
+            filter_options: VideoFilterOptions::default(),
+            deinterlace: false,
+            accel: None,
+            format: OutputFormat::Hls {
+                playlist: String::from("/session/live.m3u8"),
+                segment_template: String::from("/session/live%05d.ts"),
+                troubleshoot: false,
+            },
+            pts_offset: None,
+            pad_to_duration,
+            realtime: false,
+            is_live: false,
+            frame_rate: None,
+            subtitle_mode: SubtitleMode::Burn,
+            fonts_folder: None,
+            subtitle_force_style: None,
+            reports_folder: None,
+            report_id: None,
+        };
+
+        let ffmpeg_info = FfmpegInfo {
+            hwaccels: HashSet::new(),
+            video_filters: HashSet::new(),
+            preferred_filters: HashMap::new(),
+        };
+
+        let mut pipeline =
+            generate_pipeline(&ffmpeg_info, input_settings, output_settings).unwrap();
+        pipeline.optimize();
+        pipeline.args()
+    }
+
+    /// This guards the wiring rather than the arithmetic: the flag has to
+    /// reach the filter chain, and nothing else in these tests would notice
+    /// if it stopped.
+    #[test]
+    fn padding_to_duration_puts_tpad_in_the_chain() {
+        let has_tpad = |args: &ArgVec| args.iter().any(|a| a.as_ref().contains("tpad="));
+
+        let padded = file_pipeline_args(true);
+        let unpadded = file_pipeline_args(false);
+
+        assert!(
+            has_tpad(&padded),
+            "a padded pipeline must carry tpad, got {padded:?}"
+        );
+        assert!(
+            !has_tpad(&unpadded),
+            "an unpadded pipeline must not, got {unpadded:?}"
+        );
     }
 }

--- a/crates/ffpipeline/src/video_filter.rs
+++ b/crates/ffpipeline/src/video_filter.rs
@@ -68,6 +68,7 @@ pub enum VideoFilter {
     ColorChannelMixer(ColorChannelMixerFilter),
     Fade(FadeFilter),
     Crop(CropFilter),
+    TPad(TPadFilter),
     Dv5Workaround(Dv5WorkaroundFilter),
     // CUDA hardware filters
     ScaleCuda(accel::cuda::ScaleCuda),
@@ -607,6 +608,30 @@ impl VideoFilterOp for ColorChannelMixerFilter {
 
     fn as_arg(&self) -> Option<String> {
         Some(format!("colorchannelmixer=aa={}", self.alpha))
+    }
+}
+
+/// Extends the video stream past its source's end by cloning the last frame,
+/// so an under-running source still fills its item's scheduled duration; the
+/// output -t clamp bounds the padding.
+#[derive(Debug, Clone)]
+pub struct TPadFilter;
+
+impl VideoFilterOp for TPadFilter {
+    fn evaluate(&self, _state: &FrameState, _ffmpeg_info: &FfmpegInfo) -> Option<VideoFilter> {
+        Some(self.clone().into())
+    }
+
+    fn apply_to(&self, _state: &mut FrameState) {
+        // no change to state
+    }
+
+    fn required_surface(&self) -> Option<FrameSurface> {
+        Some(FrameSurface::System)
+    }
+
+    fn as_arg(&self) -> Option<String> {
+        Some(String::from("tpad=stop=-1:stop_mode=clone"))
     }
 }
 

--- a/crates/ffpipeline/tests/common/mod.rs
+++ b/crates/ffpipeline/tests/common/mod.rs
@@ -289,6 +289,7 @@ pub fn build_output(dir: &Path, params: TestOutputParams) -> OutputSettings {
             troubleshoot: false,
         },
         pts_offset: None,
+        pad_to_duration: false,
         realtime: false,
         is_live: false,
         frame_rate: params.frame_rate,


### PR DESCRIPTION

## Problem

The channel timeline is integrated, not anchored. `last_segment_end` advances by emitted EXTINF, and nothing compares it back to the schedule. Any difference between the requested emission and the actual emission accumulates forever. Two defects feed that integrator, with opposite signs. Neither can be fixed alone.

The first defect loses time. Some files have a video stream that ends before the container does. Real media files get this shape easily, because an audio tail often runs past the last video frame. Such an item books more slot than its video can fill. ffmpeg emits what the video has, the item comes up short, and the missing time is never recovered. Every program date time after it, and the served window, sit that much further behind the wall clock. The loss repeats on every airing of every such file, so it compounds for as long as the channel runs. As an example of scale: in one measured library, about one in five files had this shape, and the accumulated offset reached several seconds within days. Audio does not have this problem, because the chain always carries apad (`AudioFilter::Pad`). Video has no equivalent.

The second defect gains time, and it is why the obvious fix fails on its own. With tpad in the chain, the video stream never reaches EOF, so the output `-t` cut decides the emitted duration. That cut is frame-quantized upward, because the frame that straddles the cut is emitted with its full duration. An item whose slot is not frame-aligned emits `ceil(slot x fps) / fps`, up to one frame long. The integrator that could only lose time now only gains it, at a rate set by the item rate of the schedule. As an example: a live deployment that ran padding alone gained about 500ms per hour, and each item's step matched the ceil prediction with 0.2ms mean error over 25 consecutive items.

## Fix

The fix is a pair. Each half needs the other.

1. `pad_to_duration` puts `tpad=stop=-1:stop_mode=clone` in the filter chain for every pipeline, so every item fills its slot.
2. Before each pipeline, the session measures `last_segment_end` minus `transcoded_until`. These are the same timeline position on the stamp clock and on the schedule clock, once `start_time_offset` is added back. The session subtracts the difference from the new pipeline's output duration.

That offset correction matters. The two clocks are seeded from the same reading at channel start, but `transcoded_until` also carries `start_time_offset`, the distance to a configured `virtual_start`. That offset is deliberate and permanent, so subtracting the two raw would measure it as error. Since the correction drives the error toward zero, a channel with `virtual_start` set would have content trimmed or padded at the clamp on every item until the whole offset closed. It is a no-op on any channel that does not set `virtual_start`, because `start_time_offset` is zero there.

A positive error shortens the next `-t`. A negative error lengthens it, and only a padded pipeline can honor that. The correction is clamped to 500ms and to half the pipeline, so a wild clock slews back over several items instead of opening one hole. With the loop closed, the error is bounded at about one frame instead of integrating.

One point I want to make explicit, because of the lesson from #187: the fix never moves a read position. `in_point` stays schedule-derived. `finish` advances the schedule exactly as before. The measured error touches only the emitted duration. A test pins this, and a trim that moves `in_point` or `finish` fails it.

## Cost

ffmpeg has no hardware tpad. On a hardware pipeline, the pad costs one hwdownload/hwupload round trip per frame. Burned subtitles, watermark fades, and the software tonemap and deinterlace fallbacks already carry the same class of cost. Two tests pin the bound. The pad stays exactly one round trip, and the scale still resolves to its hardware form. A software chain gains no round trip at all. As an example of the wall-clock cost: on one hardware pipeline with readrate pacing, the pad recovered a 480ms shortfall on an 11s item for 0.04s of extra wall clock.

The viewer-visible change: a short item now holds its last frame to the slot boundary, instead of sliding the rest of the schedule earlier.

## Verification

A three-arm bench generated a 19-item timeline (mixed 29.97/30/25/23.976 fps, two files whose video ends before the container) and measured per-item `first_segment_pdt` minus `scheduled_start`:

- No padding lost 2822ms across 19 items. This is the shortfall staircase.
- Padding without the trim gained 113ms over 17 steady items, +20/+26ms per padded item, matching the quantization law exactly.
- The pair held a bounded walk that never left one frame.

The first commit is a pure refactor that gives the pipeline plan a test seam, with no behavior change. The second commit is the fix. Six targeted mutations (padding made conditional, trim unapplied, either clamp dropped, the chain push removed, the trim touching `in_point`) each fail exactly one test.

I run this code in production, and both halves have live time there. Padding ran alone first, which is how I found and measured the quantization. The pair together holds drift flat where padding alone climbed within its first hour. As with my other PRs, I am collaborating with Claude Code on this work. The AI did most of the measurement and verification, so extra scrutiny in review is welcome.

