### PR TITLE
fix: clamp an item out_point to its scheduled slot

### DIFF
--- a/crates/ersatztv-channel/src/channel_session.rs
+++ b/crates/ersatztv-channel/src/channel_session.rs
@@ -952,17 +952,27 @@ impl ChannelSession {
         let item_start = current_item.start;
         let item_finish = current_item.finish;
         let item_duration = current_item.finish - current_item.start;
+        let item_slot_ms = item_duration.whole_milliseconds().max(0) as u64;
         let item_in_point_base_ms = match source {
             PlayoutItemSource::Local { in_point_ms, .. }
             | PlayoutItemSource::Http { in_point_ms, .. } => in_point_ms.unwrap_or(0),
             _ => 0,
         };
-        let item_out_point_ms = match source {
+        let explicit_out_point_ms = match source {
             PlayoutItemSource::Local { out_point_ms, .. }
-            | PlayoutItemSource::Http { out_point_ms, .. } => out_point_ms
-                .unwrap_or(item_in_point_base_ms + item_duration.whole_milliseconds() as u64),
-            _ => item_in_point_base_ms + item_duration.whole_milliseconds() as u64,
+            | PlayoutItemSource::Http { out_point_ms, .. } => *out_point_ms,
+            _ => None,
         };
+        let (item_out_point_ms, overrun_ms) =
+            effective_out_point_ms(explicit_out_point_ms, item_in_point_base_ms, item_slot_ms);
+        if overrun_ms > 0 {
+            log::warn!(
+                "item {} out_point overruns its {}ms slot by {}ms; clamping to the slot",
+                current_item.id,
+                item_slot_ms,
+                overrun_ms
+            );
+        }
 
         let effective_now = if start_at_zero {
             item_start
@@ -1374,6 +1384,35 @@ fn playout_timing_to_pipeline(
     })
 }
 
+/// The out point this item will actually be read to, and how far the
+/// declared one overran its slot.
+///
+/// A declared out point may NARROW an item, so a scheduler can play less of
+/// a file than its slot would allow. It may not WIDEN one: the pipeline
+/// duration is `out_point - in_point`, so an out point past the end of the
+/// slot makes ffmpeg emit more media than the schedule booked, and
+/// `last_segment_end` only ever advances by emitted EXTINF. The surplus is
+/// never reconciled, so it becomes permanent drift between the stream and
+/// the schedule, growing with every airing of every such item.
+///
+/// The slot is the authority because it is what every other consumer of the
+/// playout already believes: the guide, the next item's start, and the
+/// session's own `transcoded_until`.
+fn effective_out_point_ms(
+    explicit_out_point_ms: Option<u64>,
+    in_point_base_ms: u64,
+    slot_ms: u64,
+) -> (u64, u64) {
+    let slot_out_point_ms = in_point_base_ms + slot_ms;
+    match explicit_out_point_ms {
+        Some(out_point_ms) if out_point_ms > slot_out_point_ms => {
+            (slot_out_point_ms, out_point_ms - slot_out_point_ms)
+        }
+        Some(out_point_ms) => (out_point_ms, 0),
+        None => (slot_out_point_ms, 0),
+    }
+}
+
 fn source_is_live(source: &PlayoutItemSource) -> bool {
     matches!(
         source,
@@ -1446,5 +1485,58 @@ fn probe_hint_to_result(hint: &ProbeHint, path: String) -> ProbeResult {
         streams: video.chain(audio).chain(subtitle).collect(),
         duration: hint.duration_ms.map(Duration::from_millis),
         format_name: hint.format_name.clone().or(Some(String::from("mpegts"))),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The measured case this was written for: a filler item whose slot ran
+    /// 50.209s while the playout declared a 60.007s out point, taken from a
+    /// scheduler that reused a rejected candidate's duration. The pipeline
+    /// ran 9.798s long every time the item aired.
+    #[test]
+    fn an_out_point_past_the_slot_is_clamped_to_the_slot() {
+        assert_eq!(
+            effective_out_point_ms(Some(60_007), 0, 50_209),
+            (50_209, 9_798)
+        );
+    }
+
+    /// A declared out point inside the slot is honored: a scheduler may
+    /// play less of a file than the slot allows.
+    #[test]
+    fn an_out_point_inside_the_slot_is_honored() {
+        assert_eq!(effective_out_point_ms(Some(30_000), 0, 50_209), (30_000, 0));
+    }
+
+    /// With no declared out point the item plays its whole slot.
+    #[test]
+    fn no_declared_out_point_plays_the_whole_slot() {
+        assert_eq!(effective_out_point_ms(None, 0, 50_209), (50_209, 0));
+    }
+
+    /// The slot measures content, not position, so an item seeking into a
+    /// file gets its slot from the in point rather than from zero. Clamping
+    /// against the slot alone would cut every seeked item short.
+    #[test]
+    fn the_slot_is_measured_from_the_in_point() {
+        assert_eq!(
+            effective_out_point_ms(Some(600_000), 120_000, 50_209),
+            (170_209, 429_791)
+        );
+        assert_eq!(
+            effective_out_point_ms(Some(170_209), 120_000, 50_209),
+            (170_209, 0)
+        );
+        assert_eq!(effective_out_point_ms(None, 120_000, 50_209), (170_209, 0));
+    }
+
+    /// An out point exactly on the slot boundary is not an overrun, so a
+    /// correct scheduler never triggers the warning.
+    #[test]
+    fn an_out_point_exactly_on_the_boundary_is_not_an_overrun() {
+        assert_eq!(effective_out_point_ms(Some(50_209), 0, 50_209), (50_209, 0));
     }
 }


### PR DESCRIPTION
## Problem

A playout item can declare an `out_point_ms` past the end of its slot. The pipeline duration is `out_point - in_point`, so ffmpeg then emits more media than the schedule booked for that item.

Nothing takes the surplus back. `last_segment_end` only ever advances by emitted EXTINF, so the extra media becomes part of the timeline permanently, and every airing of every such item pushes the stream further behind its own schedule. The guide, which comes from the schedule, stays where it was. The failure is silent and cumulative: no error, no warning, just a channel that is progressively later than it claims to be.

Measured on a real deployment before the clamp: a filler item with a 50.209 second slot declared a 60.007 second out point, and ffmpeg ran with `-t 60007ms`. That is roughly 9.8 seconds of surplus per airing. On one channel it accrued around 85 seconds per hour, and a long session reached about nineteen minutes behind schedule, with the work-ahead buffer growing to nearly 300 segments instead of holding steady.

The data came from a scheduler bug (a fallback branch reused a rejected candidate's duration and never reset the out point), which is being fixed separately at its source. next consumes playout JSON from whatever scheduler an operator runs, so it should not depend on every scheduler being correct to keep its own timeline.

## Fix

A declared out point may narrow an item, and may not widen it past the slot.

Narrowing is legitimate: it is a scheduler asking to play less of a file than the slot allows. Widening contradicts the slot, and the slot is what every other consumer of the playout already believes, including the guide, the next item's start, and the session's own `transcoded_until`.

When a clamp happens the session warns with the item id and the size of the overrun, so bad playout data is traceable to the scheduler that produced it instead of being silently absorbed.

The slot is measured from the in point, so an item that seeks into a file keeps its full slot rather than being cut short.

Bad data is fixed at the boundary rather than absorbed later, and the difference matters. Clamping truncates the item that overran, so it gives back its own surplus and nothing else is touched. Absorbing the same error downstream would shorten the pipelines that follow, which takes content away from innocent items to pay for an earlier one, while the offending item still airs material the schedule assigned to something else. The timeline would then read as on time while the content no longer matched the guide.

That is also why this is not the same concern as the emission trim in #212, if that lands first. The trim exists for frame quantization, which cannot be prevented at the source: any output cut that does not land on a frame boundary emits the straddling frame whole, whatever the playout says. It is bounded to 500ms and half a pipeline precisely so it can only ever absorb error at that scale, and never a data problem. The two PRs are independent and can land in either order.

## Verification

Five unit tests on the pure function that makes the decision: the measured 50.209s slot against a 60.007s declared out point, a declared out point inside the slot, no declared out point at all, an out point exactly on the boundary (which must not warn), and an item seeking 120s into a file, where the slot has to be measured from the in point.

Two mutations confirm those tests can fail. Disabling the clamp fails the overrun test alone. Measuring the slot from zero rather than from the in point fails the seek test alone.

Full workspace tests, clippy with the repo flags, and a nightly fmt check are clean.

The clamp has production time behind it, where it fired on real playout data, brought the affected items back to their slots, and stopped the drift from accruing.

## Risks

1. An operator whose scheduler deliberately books an item longer than its slot loses that behavior. I know of no reason to do it, and it cannot work as intended anyway, since the next item's start does not move; the overrun simply displaces everything after it.
2. The warning is emitted from the timing routine, which runs once per stream, so a clamped item logs the same line up to three times. Deduplicating it would mean moving the warning up to the caller, which seemed like more structure than the message is worth. Happy to do it if you prefer.

As with my other PRs, I am collaborating with Claude Code on this work. The AI did most of the verification, so extra scrutiny in review is welcome.
