### PR TITLE
fix: one grep finds every black-air line, and each names its slot

### DIFF
--- a/crates/ersatztv-channel/src/channel_session.rs
+++ b/crates/ersatztv-channel/src/channel_session.rs
@@ -368,27 +368,22 @@ impl ChannelSession {
         let current_item = match current_item_result {
             Ok(playout_item) => playout_item,
             Err(ChannelError::PlayoutJsonNoItem { next_start }) => {
-                // filling a schedule gap with black is normal; log it so black
-                // air is explainable
-                match next_start {
-                    Some(start) => {
-                        let gap = start - self.transcoded_until;
-                        log::debug!(
-                            "no playout item covers {}; filling with black/silence for {}m {}s until the next item",
-                            self.transcoded_until,
-                            gap.whole_minutes(),
-                            gap.whole_seconds() % 60
-                        );
-                    }
-                    None => log::debug!(
-                        "no playout item covers {} and none is scheduled after it; filling with black/silence",
-                        self.transcoded_until
-                    ),
-                }
+                log::debug!(
+                    "no playout item covers {}, replacing with black/silence until {}",
+                    self.transcoded_until,
+                    next_start.map_or_else(
+                        || String::from("the next reload"),
+                        |start| start.to_string()
+                    )
+                );
                 self.fake_playout_item(next_start)
             }
             Err(err) => {
-                log::error!("{}", err);
+                log::error!(
+                    "no item could be selected for {}, replacing with black/silence: {}",
+                    self.transcoded_until,
+                    err
+                );
                 self.fake_playout_item(None)
             }
         };
@@ -405,7 +400,13 @@ impl ChannelSession {
             Err(e @ ChannelError::Stalled(_)) => return Err(e),
             Err(e) if troubleshoot => return Err(e),
             Err(e) => {
-                log::error!("item failed, replacing with black/silence: {e}");
+                log::error!(
+                    "item {} ({} .. {}) failed, replacing with black/silence: {}",
+                    current_item.id,
+                    current_item.start,
+                    current_item.finish,
+                    e
+                );
                 let fake_item = self.fake_playout_item(Some(current_item.finish));
                 self.transcode_item(&fake_item, realtime, troubleshoot, pts_duration)
                     .await?


### PR DESCRIPTION
## Problem

Overnight, 144 items aired black on one of my channels. Every log line looked the same, so I could not tell if 144 slots failed once each, or one slot failed 144 times.

I traced it to three separate code paths that put black on a channel. Each one logged it in different words, so no single grep caught all three, and the one that fired most did not say which item it lost.

I already tried to fix part of this in #196, which gave the silent schedule gap a log line. It missed the other two paths.

## Fix

All three paths now log a line containing `replacing with black/silence`, and each one names the slot.

1. Schedule gap. This line already existed. It now says when the black air ends. Two forms, depending on whether anything is scheduled after the gap.

   If a later item exists:
   ```
   no playout item covers 2026-08-15 12:00:00.0 -04:00:00, replacing with black/silence until 2026-08-15 12:00:11.021 -04:00:00
   ```

   If nothing is scheduled after it:
   ```
   no playout item covers 2026-08-15 12:00:00.0 -04:00:00, replacing with black/silence until the next reload
   ```

2. No item could be selected. This is the main fix. Before, the code just logged the bare error, with no mention of black air and no timestamp:
   ```
   no item could be selected for 2026-08-15 12:00:00.0 -04:00:00, replacing with black/silence: failed to scan for last pts
   ```

3. Item failed to transcode. This path already said `replacing with black/silence`, but did not say which item. Now it names the item id and the slot's start and finish:
   ```
   item 0f9c2b31-... (2026-08-15 12:00:00.0 -04:00:00 .. 2026-08-15 12:00:11.021 -04:00:00) failed, replacing with black/silence: failed to scan for last pts
   ```

Levels are unchanged. The schedule gap stays at debug, since it is expected. The other two stay at error.

I wrote #196's line as `filling with black/silence`, when `replacing with black/silence` had been the wording since #22. That mismatch is mine.

## Verification

Two tests. One builds all three messages and checks each one contains `replacing with black/silence` plus its timestamps, and the item id for path 3. The other covers the schedule gap variant where nothing is scheduled after it.

`cargo test --workspace`, clippy with `-D clippy::all`, and `cargo +nightly fmt --all -- --check` are all clean.

## Risks

Only log text changes. No behavior changes.

Anyone grepping the old `filling` wording stops matching the schedule gap line.