### PR TITLE
feat: add a {{channel:number}} variable for remote source urls

### DIFF
--- a/crates/ersatztv-channel/src/channel_session.rs
+++ b/crates/ersatztv-channel/src/channel_session.rs
@@ -866,6 +866,15 @@ impl ChannelSession {
         Ok(source.probe(&probe_deps).await?)
     }
 
+    /// Expands `{{ENV}}` templates and then stream variables in a source URI.
+    fn expand_source_uri(&self, uri: &str) -> Result<String, ChannelError> {
+        let expanded = expand_template(uri)?;
+        Ok(ersatztv_playout::stream_variables::expand(
+            &expanded,
+            self.channel_config.number(),
+        ))
+    }
+
     fn playout_source_to_input_source(
         &self,
         source: PlayoutItemSource,
@@ -887,7 +896,7 @@ impl ChannelSession {
                 keep_alive,
                 ..
             } => {
-                let expanded_uri = expand_template(&uri)?;
+                let expanded_uri = self.expand_source_uri(&uri)?;
                 let expanded_headers: Vec<String> = headers
                     .unwrap_or_default()
                     .iter()
@@ -910,7 +919,7 @@ impl ChannelSession {
             PlayoutItemSource::Rtsp {
                 uri, timeout_us, ..
             } => {
-                let expanded_uri = expand_template(&uri)?;
+                let expanded_uri = self.expand_source_uri(&uri)?;
 
                 Ok(InputSource::Rtsp(RtspInputSource {
                     uri: expanded_uri,

--- a/crates/ersatztv-playout/src/lib.rs
+++ b/crates/ersatztv-playout/src/lib.rs
@@ -1,3 +1,4 @@
 pub mod error;
 pub mod playout;
+pub mod stream_variables;
 pub mod template;

--- a/crates/ersatztv-playout/src/playout.rs
+++ b/crates/ersatztv-playout/src/playout.rs
@@ -226,7 +226,10 @@ pub enum PlayoutItemSource {
         probe_hint: Option<ProbeHint>,
     },
     Http {
-        /// URI template, e.g. "https://example.com/file.mkv?token={{MY_SECRET}}"
+        /// URI template, e.g. "https://example.com/file.mkv?token={{MY_SECRET}}".
+        /// A name with no namespace is an environment variable. A namespaced
+        /// name is resolved by the server: `{{channel:number}}` is the number
+        /// of the channel being transcoded. See [`crate::stream_variables`].
         uri: String,
         /// Whether the content is live and therefore cannot seek or work
         /// ahead (default: false)
@@ -259,6 +262,8 @@ pub enum PlayoutItemSource {
         probe_hint: Option<ProbeHint>,
     },
     Rtsp {
+        /// RTSP URI template, e.g. "rtsp://user:{{PASSWORD}}@camera.lan:554/stream".
+        /// Expanded the same way as the [`PlayoutItemSource::Http`] uri.
         uri: String,
         #[serde(skip_serializing_if = "Option::is_none")]
         timeout_us: Option<u64>,

--- a/crates/ersatztv-playout/src/stream_variables.rs
+++ b/crates/ersatztv-playout/src/stream_variables.rs
@@ -1,0 +1,182 @@
+//! Expansion of stream variables in playout item source URIs.
+//!
+//! Stream variables share the `{{ }}` delimiters with environment templates
+//! (see [`crate::template`]) and are told apart by a namespace prefix:
+//!
+//! - `{{NAME}}`, no namespace, is an environment variable
+//! - `{{channel:number}}` is the number of the channel being transcoded
+//!
+//! Sharing the delimiters is safe because a name containing a colon is not a
+//! valid environment variable name, so [`crate::template::expand_template`]
+//! re-emits it verbatim rather than resolving or rejecting it. This module
+//! runs second and claims what the first pass left behind. A test below pins
+//! that contract.
+//!
+//! Anything that is not a known stream variable is left as written, so an
+//! unresolved environment template, a future namespace, and a URI that
+//! merely contains braces all pass through unchanged.
+
+const CHANNEL_NUMBER: &str = "channel:number";
+
+/// Expands stream variables in `input`.
+///
+/// Values are substituted verbatim, with no escaping of any kind. Whatever a
+/// value contains reaches the remote server as written, and nothing here
+/// bounds which part of the URI a substitution can affect. That is acceptable
+/// only because the channel number is operator-authored, coming from the same
+/// lineup as the template it lands in, so it is trusted to the same degree as
+/// the text around it.
+///
+/// A value from a less trusted source, a request parameter for instance,
+/// needs percent-encoding and a rule about which parts of the URI a
+/// substitution may change. Do not resolve such a value here without adding
+/// both.
+pub fn expand(input: &str, channel_number: &str) -> String {
+    let mut result = String::with_capacity(input.len());
+    let mut remaining = input;
+
+    loop {
+        let Some(open) = remaining.find("{{") else {
+            result.push_str(remaining);
+            return result;
+        };
+
+        result.push_str(&remaining[..open]);
+        let after_open = &remaining[open + 2..];
+
+        match after_open.find("}}") {
+            Some(close) if after_open[..close].trim() == CHANNEL_NUMBER => {
+                result.push_str(channel_number);
+                remaining = &after_open[close + 2..];
+            }
+            _ => {
+                // not a stream variable, so it belongs to whoever wrote it,
+                // and scanning continues past the braces we just emitted
+                result.push_str("{{");
+                remaining = after_open;
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::expand;
+
+    #[test]
+    fn expands_the_channel_number() {
+        assert_eq!(
+            expand(
+                "http://origin.lan:8000/{{channel:number}}/stream.m3u8",
+                "30"
+            ),
+            "http://origin.lan:8000/30/stream.m3u8"
+        );
+    }
+
+    #[test]
+    fn expands_every_occurrence() {
+        assert_eq!(
+            expand(
+                "http://origin.lan:8000/{{channel:number}}/{{channel:number}}.m3u8",
+                "30"
+            ),
+            "http://origin.lan:8000/30/30.m3u8"
+        );
+    }
+
+    #[test]
+    fn substitutes_the_channel_number_verbatim() {
+        // nothing constrains a channel number, and it is operator-authored,
+        // so it reaches the uri exactly as the lineup spells it
+        assert_eq!(
+            expand(
+                "http://origin.lan:8000/{{channel:number}}/stream.m3u8",
+                "30.1"
+            ),
+            "http://origin.lan:8000/30.1/stream.m3u8"
+        );
+    }
+
+    #[test]
+    fn tolerates_whitespace_inside_the_braces() {
+        assert_eq!(
+            expand(
+                "http://origin.lan:8000/{{ channel:number }}/stream.m3u8",
+                "30"
+            ),
+            "http://origin.lan:8000/30/stream.m3u8"
+        );
+    }
+
+    #[test]
+    fn survives_the_environment_pass() {
+        // the two passes share a delimiter, so this pins the property that
+        // makes that safe: a name that is not a valid environment variable
+        // name is re-emitted verbatim by the first pass instead of being
+        // resolved or rejected
+        let after_env =
+            crate::template::expand_template("http://origin.lan:8000/{{channel:number}}/s.m3u8")
+                .unwrap();
+        assert_eq!(expand(&after_env, "30"), "http://origin.lan:8000/30/s.m3u8");
+    }
+
+    #[test]
+    fn leaves_an_environment_variable_reference_unchanged() {
+        // the environment pass runs first and normally consumes these; an
+        // unresolved one must not be mistaken for a stream variable
+        assert_eq!(
+            expand("http://origin.lan:8000/{{MY_SECRET}}/stream.m3u8", "30"),
+            "http://origin.lan:8000/{{MY_SECRET}}/stream.m3u8"
+        );
+    }
+
+    #[test]
+    fn leaves_an_unknown_namespace_unchanged() {
+        assert_eq!(
+            expand("http://origin.lan:8000/{{query:region}}/stream.m3u8", "30"),
+            "http://origin.lan:8000/{{query:region}}/stream.m3u8"
+        );
+    }
+
+    #[test]
+    fn leaves_single_braces_unchanged() {
+        // single braces are not a stream variable delimiter, so a uri that
+        // happens to contain them is content
+        assert_eq!(
+            expand("http://origin.lan:8000/{channel:number}/stream.m3u8", "30"),
+            "http://origin.lan:8000/{channel:number}/stream.m3u8"
+        );
+    }
+
+    #[test]
+    fn leaves_an_unclosed_variable_unchanged() {
+        assert_eq!(
+            expand("http://origin.lan:8000/{{channel:number/stream.m3u8", "30"),
+            "http://origin.lan:8000/{{channel:number/stream.m3u8"
+        );
+    }
+
+    #[test]
+    fn leaves_a_uri_without_variables_unchanged() {
+        assert_eq!(
+            expand("http://origin.lan:8000/stream.m3u8", "30"),
+            "http://origin.lan:8000/stream.m3u8"
+        );
+    }
+
+    #[test]
+    fn expands_a_variable_that_follows_multibyte_content() {
+        // the scan indexes by byte, so a multibyte character ahead of the
+        // variable would break it if any offset were computed wrongly
+        assert_eq!(
+            expand("http://origin.lan:8000/café/{{channel:number}}.m3u8", "30"),
+            "http://origin.lan:8000/café/30.m3u8"
+        );
+    }
+
+    #[test]
+    fn empty_input_stays_empty() {
+        assert_eq!(expand("", "30"), "");
+    }
+}

--- a/schema/playout.json
+++ b/schema/playout.json
@@ -433,7 +433,7 @@
         },
         "uri": {
           "type": "string",
-          "description": "URI template, e.g. \"https://example.com/file.mkv?token={{MY_SECRET}}\"."
+          "description": "URI template, e.g. \"https://example.com/file.mkv?token={{MY_SECRET}}\". A name with no namespace is an environment variable. A name with a namespace is resolved by the server: `{{channel:number}}` is the number of the channel being transcoded, as in \"http://origin.lan:8000/{{channel:number}}/stream.m3u8\". Anything else in braces is left as written."
         },
         "is_live": {
           "type": [
@@ -532,7 +532,7 @@
         },
         "uri": {
           "type": "string",
-          "description": "RTSP URI template, e.g. \"rtsp://user:{{PASSWORD}}@camera.lan:554/stream\"."
+          "description": "RTSP URI template, e.g. \"rtsp://user:{{PASSWORD}}@camera.lan:554/stream\". Expanded the same way as the `HttpSource` URI: an unnamespaced name is an environment variable, and `{{channel:number}}` is the number of the channel being transcoded."
         },
         "timeout_us": {
           "type": [


### PR DESCRIPTION
## What this adds

A remote source URI can contain `{{channel:number}}`. The channel worker replaces it at playback with the number of the channel it is transcoding.

```json
"uri": "http://origin.lan:8000/{{channel:number}}/stream.m3u8"
```

On channel 30 that opens `http://origin.lan:8000/30/stream.m3u8`. One playout item now serves a whole lineup. Today the same item has to be written once per channel with a literal URI.

## Why

A source URI supports only `{{VAR}}`, which `expand_template` reads from the server environment. Every channel gets the same string back, so the URIs differ only by a number the server already knows.

The syntax matters more than this one variable. I have further features in progress that need to put server-known values into remote stream URIs. They should all use one convention, and settling its shape is what I am really asking for here.

## Design

There is one delimiter, `{{ }}`. What sits inside it decides who resolves it.

| written in the playout | who resolves it |
|---|---|
| `{{MY_SECRET}}` | the environment, exactly as today |
| `{{channel:number}}` | the server, at playback |
| `{{query:region}}` | nobody yet, so it passes through as written |

A colon means the name is namespaced and the server owns it. No colon means it is an environment variable, and nothing about those changes.

Sharing the delimiter is safe because of how `expand_template` already behaves. A name that fails `is_valid_var_name` is written to the output unchanged, neither resolved nor rejected. A colon fails that check, so the environment pass walks past `{{channel:number}}` and the new pass claims it. That is behavior rather than a documented contract, so one test sends a URI through both passes in order.

The alternative was a second delimiter, `{ }` or `[[ ]]`. It works, but it leaves two conventions and only history to say which one a variable uses.

The namespace also removes a trap. `{{channel_number}}` reads like the correct spelling, and it would fail as a missing environment variable.

The new pass runs on http and rtsp URIs only.

Values are substituted with no escaping, and nothing bounds which part of the URI a value can change. That is acceptable only because the operator writes the channel number. A value from a less trusted source needs percent-encoding and an origin rule, which the function documents.

## Compatibility

On current main, `{{name:with:colons}}` is written to the output as written, so no working URI uses this syntax today. No field is added.

## Cost

No new dependency. One public function, 23 lines plus tests.

## Verification

`cargo test --workspace` passes 126 tests, 12 of them in the new module. Clippy with `-D clippy::all` and `cargo +nightly fmt --all -- --check` are clean.

I ran nine mutations. Seven break one decision each, and each killed only the tests that cover that decision. The other two break copied text rather than substituted text, and killed eleven and nine of the twelve tests. `empty_input_stays_empty` survives all nine, because it guards an edge case rather than a decision.

It is also running successfully in my production box today.

## Open questions

**Is the shared delimiter right?** It rests on `expand_template` passing unknown names through. A test holds that, but you may prefer the two syntaxes kept apart. This is the answer my later features are waiting on.

**Is `channel:number` the right name?** It leaves room for more channel attributes later. A flat `{{channel_number}}` is not available, since that is a valid environment variable name.

**Is `ersatztv-playout` the right home?** The playout declares the templates. The alternative is the channel worker, the only caller today.