### PR TITLE
feat: graphics canvas

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -474,6 +474,7 @@ version = "0.1.0"
 dependencies = [
  "serde",
  "serde_json",
+ "tempfile",
  "thiserror",
  "time",
  "tokio",

--- a/crates/ersatztv-channel/src/channel_session.rs
+++ b/crates/ersatztv-channel/src/channel_session.rs
@@ -9,8 +9,8 @@ use ersatztv_channel::config::ChannelConfig;
 use ersatztv_channel::error::ChannelError;
 use ersatztv_core::{READY_FILE_NAME, empty_folder};
 use ersatztv_playout::playout::{
-    AudioHint, PeriodicClock, PlayoutItem, PlayoutItemSource, PlayoutItemTracks, ProbeHint,
-    TrackSelection, VideoHint, WatermarkLocation, WatermarkTiming,
+    AudioHint, GraphicsLayerKind, PeriodicClock, PlayoutItem, PlayoutItemSource, PlayoutItemTracks,
+    ProbeHint, TrackSelection, VideoHint, WatermarkLocation, WatermarkTiming,
 };
 use ersatztv_playout::template::expand_template;
 use ffpipeline::ffmpeg_info::FfmpegInfo;
@@ -485,8 +485,20 @@ impl ChannelSession {
             |(layer_index, layer)| async move {
                 let input_source = session.playout_source_to_input_source(layer.source.clone())?;
                 let location = playout_location_to_pipeline(&layer.location);
+                let kind = playout_graphics_kind_to_pipeline(&layer.kind);
                 let timing = playout_timing_to_pipeline(layer.timing.as_ref());
                 let probe_result = session.resolve_probe(&layer.source, &input_source).await?;
+
+                let in_point = if let PlayoutItemSource::Local {
+                    in_point_ms: Some(in_point_ms),
+                    ..
+                } = layer.source
+                {
+                    Duration::from_millis(in_point_ms)
+                } else {
+                    Duration::ZERO
+                };
+
                 Ok::<_, ChannelError>(GraphicsInput {
                     layer_index,
                     input_source,
@@ -498,6 +510,8 @@ impl ChannelSession {
                     horizontal_margin_percent: layer.horizontal_margin_percent,
                     vertical_margin_percent: layer.vertical_margin_percent,
                     opacity_percent: layer.opacity_percent,
+                    kind,
+                    in_point,
                     timing,
                 })
             },
@@ -671,6 +685,7 @@ impl ChannelSession {
             },
             subtitle_input,
             graphics_inputs,
+            channel_number: Some(self.channel_config.number().to_owned()),
         };
 
         let mut subtitle_source: Option<SubtitleSource> = None;
@@ -1341,6 +1356,16 @@ fn playout_location_to_pipeline(value: &WatermarkLocation) -> ffpipeline::input:
         WatermarkLocation::BottomLeft => ffpipeline::input::WatermarkLocation::BottomLeft,
         WatermarkLocation::BottomCenter => ffpipeline::input::WatermarkLocation::BottomCenter,
         WatermarkLocation::BottomRight => ffpipeline::input::WatermarkLocation::BottomRight,
+    }
+}
+
+fn playout_graphics_kind_to_pipeline(
+    value: &Option<GraphicsLayerKind>,
+) -> ffpipeline::input::GraphicsKind {
+    match value {
+        Some(GraphicsLayerKind::Media) => ffpipeline::input::GraphicsKind::Media,
+        Some(GraphicsLayerKind::Canvas) => ffpipeline::input::GraphicsKind::Canvas,
+        None => ffpipeline::input::GraphicsKind::Media,
     }
 }
 

--- a/crates/ersatztv-playout/Cargo.toml
+++ b/crates/ersatztv-playout/Cargo.toml
@@ -9,3 +9,6 @@ serde_json = { workspace = true }
 thiserror = { workspace = true }
 time = { workspace = true }
 tokio = { workspace = true }
+
+[dev-dependencies]
+tempfile = { workspace = true }

--- a/crates/ersatztv-playout/src/playout.rs
+++ b/crates/ersatztv-playout/src/playout.rs
@@ -13,7 +13,7 @@ pub const DATE_FORMAT: Iso8601<DATE_CONFIG> = Iso8601::<DATE_CONFIG>;
 
 pub const SUPPORTED_SCHEMA: SchemaVersion = SchemaVersion {
     breaking: 0,
-    compatible: 3,
+    compatible: 4,
 };
 const VERSION_URI_PREFIX: &str = "https://ersatztv.org/playout/version/0.";
 
@@ -137,6 +137,8 @@ pub struct GraphicsLayer {
     pub source: PlayoutItemSource,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub stream_index: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub kind: Option<GraphicsLayerKind>,
     pub location: GraphicsLocation,
     /// Scale to this percent of primary content width (0–100).
     /// Omitted = actual size.
@@ -166,6 +168,13 @@ pub struct GraphicsLayer {
 }
 
 pub type Watermark = GraphicsLayer;
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum GraphicsLayerKind {
+    Media,
+    Canvas,
+}
 
 #[derive(Debug, Deserialize, Serialize)]
 #[serde(rename_all = "snake_case")]
@@ -499,5 +508,45 @@ mod tests {
             })
             .collect();
         assert_eq!(paths, ["legacy.png", "middle.png", "top.png"]);
+    }
+    #[test]
+    fn graphics_kind_round_trips_and_absent_kind_stays_omitted() {
+        for kind in [None, Some("media"), Some("canvas")] {
+            let mut value = layer("canvas.nut");
+            if let Some(kind) = kind {
+                value["kind"] = serde_json::json!(kind);
+            }
+            let parsed: GraphicsLayer = serde_json::from_value(value.clone()).unwrap();
+            match kind {
+                None => assert!(parsed.kind.is_none()),
+                Some("media") => assert!(matches!(parsed.kind, Some(GraphicsLayerKind::Media))),
+                Some("canvas") => assert!(matches!(parsed.kind, Some(GraphicsLayerKind::Canvas))),
+                _ => unreachable!(),
+            }
+            assert_eq!(serde_json::to_value(parsed).unwrap(), value);
+        }
+    }
+
+    #[tokio::test]
+    async fn schema_003_and_004_files_load() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("playout.json");
+        for version in ["0.0.3", "0.0.4"] {
+            let mut item = item_json();
+            let mut graphics = layer("canvas.nut");
+            if version == "0.0.4" {
+                graphics["kind"] = serde_json::json!("canvas");
+            }
+            item["graphics"] = serde_json::json!([graphics]);
+            let value = serde_json::json!({
+                "version": format!("https://ersatztv.org/playout/version/{version}"),
+                "items": [item]
+            });
+            tokio::fs::write(&path, serde_json::to_vec(&value).unwrap())
+                .await
+                .unwrap();
+            let loaded = from_file(path.to_str().unwrap()).await.unwrap().playout;
+            assert_eq!(serde_json::to_value(loaded).unwrap(), value);
+        }
     }
 }

--- a/crates/ffpipeline/src/input.rs
+++ b/crates/ffpipeline/src/input.rs
@@ -21,6 +21,7 @@ pub struct InputSettings {
     pub video_input: ProbedInput,
     pub subtitle_input: Option<ProbedInput>,
     pub graphics_inputs: Vec<GraphicsInput>,
+    pub channel_number: Option<String>,
 }
 
 impl InputSettings {
@@ -253,47 +254,8 @@ pub struct HttpInputSource {
     pub options: HttpInputOptions,
 }
 
-#[derive(Debug, Clone)]
-pub struct RtspInputSource {
-    pub uri: String,
-    pub options: RtspInputOptions,
-}
-
-#[derive(Debug, Clone)]
-#[enum_dispatch(Probeable)]
-#[enum_dispatch(FfmpegInputArgs)]
-pub enum InputSource {
-    Local(LocalInputSource),
-    Lavfi(LavfiInputSource),
-    Http(HttpInputSource),
-    Rtsp(RtspInputSource),
-}
-
-#[enum_dispatch]
-pub trait FfmpegInputArgs {
-    fn args_for_input(&self) -> ArgVec;
-    fn input_path(&self) -> Option<String>;
-}
-
-impl FfmpegInputArgs for LocalInputSource {
-    fn args_for_input(&self) -> ArgVec {
-        vec![]
-    }
-    fn input_path(&self) -> Option<String> {
-        self.expand_path()
-    }
-}
-
-impl FfmpegInputArgs for LavfiInputSource {
-    fn args_for_input(&self) -> ArgVec {
-        args!["-f", "lavfi"]
-    }
-    fn input_path(&self) -> Option<String> {
-        Some(self.params.clone())
-    }
-}
-impl FfmpegInputArgs for HttpInputSource {
-    fn args_for_input(&self) -> ArgVec {
+impl HttpInputSource {
+    fn base_args(&self) -> ArgVec {
         let mut args: ArgVec = Vec::new();
 
         if self.options.reconnect {
@@ -322,6 +284,72 @@ impl FfmpegInputArgs for HttpInputSource {
             args.extend(args!["-user_agent", ua.clone()]);
         }
 
+        args.extend(args![
+            "-protocol_whitelist",
+            "file,http,https,tcp,tls,crypto",
+        ]);
+
+        args
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct RtspInputSource {
+    pub uri: String,
+    pub options: RtspInputOptions,
+}
+
+#[derive(Debug, Clone)]
+#[enum_dispatch(Probeable)]
+#[enum_dispatch(FfmpegInputArgs)]
+pub enum InputSource {
+    Local(LocalInputSource),
+    Lavfi(LavfiInputSource),
+    Http(HttpInputSource),
+    Rtsp(RtspInputSource),
+}
+
+pub struct FfmpegInputRequestContext {
+    pub channel_number: Option<String>,
+    pub playout_offset: Duration,
+    pub duration: Duration,
+    pub frame_rate: String,
+}
+
+#[enum_dispatch]
+pub trait FfmpegInputArgs {
+    fn args_for_input(&self) -> ArgVec;
+    fn args_for_input_with_context(&self, context: &FfmpegInputRequestContext) -> ArgVec;
+    fn input_path(&self) -> Option<String>;
+}
+
+impl FfmpegInputArgs for LocalInputSource {
+    fn args_for_input(&self) -> ArgVec {
+        vec![]
+    }
+    fn args_for_input_with_context(&self, _context: &FfmpegInputRequestContext) -> ArgVec {
+        self.args_for_input()
+    }
+    fn input_path(&self) -> Option<String> {
+        self.expand_path()
+    }
+}
+
+impl FfmpegInputArgs for LavfiInputSource {
+    fn args_for_input(&self) -> ArgVec {
+        args!["-f", "lavfi"]
+    }
+    fn args_for_input_with_context(&self, _context: &FfmpegInputRequestContext) -> ArgVec {
+        self.args_for_input()
+    }
+    fn input_path(&self) -> Option<String> {
+        Some(self.params.clone())
+    }
+}
+impl FfmpegInputArgs for HttpInputSource {
+    fn args_for_input(&self) -> ArgVec {
+        let mut args: ArgVec = self.base_args();
+
         if !self.options.headers.is_empty() {
             // FFmpeg expects headers separated by \r\n, with trailing \r\n
             let combined: String = self
@@ -333,10 +361,38 @@ impl FfmpegInputArgs for HttpInputSource {
             args.extend(args!["-headers", combined]);
         }
 
-        args.extend(args![
-            "-protocol_whitelist",
-            "file,http,https,tcp,tls,crypto",
-        ]);
+        args
+    }
+
+    fn args_for_input_with_context(&self, context: &FfmpegInputRequestContext) -> ArgVec {
+        let mut args: ArgVec = self.base_args();
+
+        let mut merged_headers: Vec<String> = self.options.headers.clone();
+
+        if let Some(channel_number) = context.channel_number.as_deref() {
+            merged_headers.push(format!("x-etv-channel:{}", channel_number))
+        }
+
+        merged_headers.push(format!(
+            "x-etv-offset-ms:{}",
+            context.playout_offset.as_millis()
+        ));
+
+        merged_headers.push(format!(
+            "x-etv-duration-ms:{}",
+            context.duration.as_millis()
+        ));
+
+        merged_headers.push(format!("x-etv-frame-rate:{}", context.frame_rate));
+
+        if !merged_headers.is_empty() {
+            // FFmpeg expects headers separated by \r\n, with trailing \r\n
+            let combined: String = merged_headers
+                .iter()
+                .map(|h| format!("{}\r\n", h))
+                .collect();
+            args.extend(args!["-headers", combined]);
+        }
 
         args
     }
@@ -360,6 +416,10 @@ impl FfmpegInputArgs for RtspInputSource {
         ]);
 
         args
+    }
+
+    fn args_for_input_with_context(&self, _context: &FfmpegInputRequestContext) -> ArgVec {
+        self.args_for_input()
     }
 
     fn input_path(&self) -> Option<String> {
@@ -387,7 +447,15 @@ pub struct GraphicsInput {
     pub horizontal_margin_percent: Option<f32>,
     pub vertical_margin_percent: Option<f32>,
     pub opacity_percent: Option<f32>,
+    pub kind: GraphicsKind,
+    pub in_point: Duration,
     pub timing: Option<GraphicsTiming>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum GraphicsKind {
+    Media,
+    Canvas,
 }
 
 #[derive(Debug, Clone)]

--- a/crates/ffpipeline/src/pipeline.rs
+++ b/crates/ffpipeline/src/pipeline.rs
@@ -16,12 +16,15 @@ use crate::frame_rate::FrameRate;
 use crate::frame_size::FrameSize;
 use crate::global_option::{GlobalOption, LogLevel};
 use crate::hw_accel::{HardwareAccel, HwAccel};
-use crate::input::{FfmpegInputArgs, GraphicsInput, InputSettings, InputSource};
+use crate::input::{
+    FfmpegInputArgs, FfmpegInputRequestContext, GraphicsInput, GraphicsKind, GraphicsLocation,
+    InputSettings, InputSource,
+};
 use crate::output_option::OutputOption;
 use crate::output_settings::{
     OutputSettings, ScalingMode, SubtitleMode, VideoFilterOptions, YadifOptions,
 };
-use crate::overlay_filter::{OverlayFilter, OverlaySource, SoftwareOverlay};
+use crate::overlay_filter::{FramePoint, OverlayFilter, OverlaySource, SoftwareOverlay};
 use crate::video_codec::VideoCodec;
 use crate::video_decoder::VideoDecoder;
 use crate::video_filter::{
@@ -272,6 +275,7 @@ pub struct Pipeline {
     output_options: Vec<OutputOption>,
     env_vars: Vec<EnvironmentVariable>,
 
+    input_request_context: FfmpegInputRequestContext,
     output_context: OutputContext,
 }
 
@@ -562,7 +566,58 @@ impl Pipeline {
                     graphics_input.layer_index,
                 ));
             };
-            let extra_input_args = if graphics_stream.is_still_image() {
+            if graphics_input.kind == GraphicsKind::Canvas {
+                // location is required by the schema, so only a non-default value is worth naming
+                let ignored = [
+                    (
+                        !matches!(graphics_input.location, GraphicsLocation::TopLeft),
+                        "location",
+                    ),
+                    (graphics_input.width_percent.is_some(), "width_percent"),
+                    (
+                        graphics_input.within_source_content.is_some(),
+                        "within_source_content",
+                    ),
+                    (
+                        graphics_input.horizontal_margin_percent.is_some(),
+                        "horizontal_margin_percent",
+                    ),
+                    (
+                        graphics_input.vertical_margin_percent.is_some(),
+                        "vertical_margin_percent",
+                    ),
+                    (graphics_input.opacity_percent.is_some(), "opacity_percent"),
+                    (graphics_input.timing.is_some(), "timing"),
+                ]
+                .into_iter()
+                .filter_map(|(present, name)| present.then_some(name))
+                .collect::<Vec<_>>();
+
+                if !ignored.is_empty() {
+                    log::warn!(
+                        "ignoring {} on canvas graphics layer {}",
+                        ignored.join(", "),
+                        graphics_input.layer_index
+                    );
+                }
+            }
+
+            let extra_input_args = if graphics_input.kind == GraphicsKind::Canvas {
+                // local canvas shouldn't restart from beginning after bursting
+                let seek = input_settings.playout_offset + graphics_input.in_point;
+                if seek > Duration::ZERO
+                    && matches!(graphics_input.input_source, InputSource::Local(_))
+                {
+                    args![
+                        "-ss",
+                        format!("{}ms", seek.as_millis()),
+                        "-t",
+                        format!("{}ms", duration.as_millis())
+                    ]
+                } else {
+                    args!["-t", format!("{}ms", duration.as_millis())]
+                }
+            } else if graphics_stream.is_still_image() {
                 // decode a single frame; the loop filter below repeats it *after* scaling, so
                 // decode and scale happen once instead of once per output frame
                 args![
@@ -613,6 +668,21 @@ impl Pipeline {
                 .as_ref()
                 .unwrap_or(&initial_state.size);
 
+            // a canvas is authored at the output size; a mismatch means the playout metadata is
+            // stale, so scale rather than fail the whole item
+            let canvas_needs_scale = graphics_input.kind == GraphicsKind::Canvas
+                && video_size != &secondary_initial_state.size;
+            if canvas_needs_scale {
+                log::warn!(
+                    "canvas graphics layer {} is {}x{} but output is {}x{}; scaling in software",
+                    graphics_input.layer_index,
+                    secondary_initial_state.size.width,
+                    secondary_initial_state.size.height,
+                    video_size.width,
+                    video_size.height
+                );
+            }
+
             let source_content_size = match final_output_settings.scaling_mode {
                 ScalingMode::ScaleAndPad => video_size.square_pixel_size_contain(&initial_state),
                 ScalingMode::Crop | ScalingMode::Stretch => *video_size,
@@ -623,35 +693,62 @@ impl Pipeline {
                 final_output_settings.video_size,
             );
 
-            let location =
-                Some(graphics_input.frame_location(&source_content_size, &scaled_size, video_size));
+            let location = if graphics_input.kind == GraphicsKind::Canvas {
+                Some(FramePoint { x: 0, y: 0 })
+            } else {
+                Some(graphics_input.frame_location(&source_content_size, &scaled_size, video_size))
+            };
 
-            let fade_filters = FadeFilter::for_graphics(
-                graphics_input.timing.as_ref(),
-                input_settings.start,
-                input_settings.playout_offset,
-                duration,
-            );
+            let fade_filters = if graphics_input.kind == GraphicsKind::Canvas {
+                vec![]
+            } else {
+                FadeFilter::for_graphics(
+                    graphics_input.timing.as_ref(),
+                    input_settings.start,
+                    input_settings.playout_offset,
+                    duration,
+                )
+            };
 
-            let mut secondary_filters: Vec<VideoFilter> = vec![
-                ColorChannelMixerFilter {
-                    alpha: graphics_input.opacity_percent.unwrap_or(100f32) / 100.0f32,
-                }
-                .into(),
-                FormatFilter {
-                    format: match secondary_initial_state.pixel_format.bit_depth() {
-                        10 => PixelFormat::Yuva420p10le,
-                        _ => PixelFormat::Yuva420p,
-                    },
-                }
-                .into(),
-                ScaleFilter {
-                    size: Some(scaled_size),
-                    scaling_mode: ScalingMode::ScaleAndPad,
-                    input_is_anamorphic: false,
-                }
-                .into(),
-            ];
+            let format_filter: VideoFilter = FormatFilter {
+                format: match secondary_initial_state.pixel_format.bit_depth() {
+                    10 => PixelFormat::Yuva420p10le,
+                    _ => PixelFormat::Yuva420p,
+                },
+            }
+            .into();
+
+            let mut secondary_filters: Vec<VideoFilter> =
+                if graphics_input.kind == GraphicsKind::Canvas {
+                    let mut filters = vec![format_filter];
+                    if canvas_needs_scale {
+                        // stretch, not contain: the canvas has to stay exactly the output size or
+                        // the (0,0) overlay would pin a smaller canvas to the top left corner
+                        filters.push(
+                            ScaleFilter {
+                                size: Some(*video_size),
+                                scaling_mode: ScalingMode::Stretch,
+                                input_is_anamorphic: false,
+                            }
+                            .into(),
+                        );
+                    }
+                    filters
+                } else {
+                    vec![
+                        ColorChannelMixerFilter {
+                            alpha: graphics_input.opacity_percent.unwrap_or(100f32) / 100.0f32,
+                        }
+                        .into(),
+                        format_filter,
+                        ScaleFilter {
+                            size: Some(scaled_size),
+                            scaling_mode: ScalingMode::ScaleAndPad,
+                            input_is_anamorphic: false,
+                        }
+                        .into(),
+                    ]
+                };
 
             // a still image is decoded as a single frame; only fades need it repeated (they act on
             // frame timestamps). otherwise the overlay's repeatlast holds it, which keeps the
@@ -712,6 +809,17 @@ impl Pipeline {
             }
         }
 
+        let input_request_context = FfmpegInputRequestContext {
+            channel_number: input_settings.channel_number.clone(),
+            playout_offset: input_settings.playout_offset,
+            duration,
+            frame_rate: final_output_settings
+                .frame_rate
+                .as_ref()
+                .map(|fr| fr.r_frame_rate.clone())
+                .unwrap_or(output_context.media_frame_rate.r_frame_rate.clone()),
+        };
+
         Ok(Pipeline {
             ffmpeg_info: ffmpeg_info.clone(),
             accel: final_output_settings.accel.clone(),
@@ -749,6 +857,7 @@ impl Pipeline {
                 OutputOption::FrameRate(final_output_settings.frame_rate.clone()),
                 OutputOption::Format(final_output_settings.format),
             ],
+            input_request_context,
             output_context,
             env_vars,
         })
@@ -909,6 +1018,7 @@ impl Pipeline {
                         // TODO: seek?
 
                         result.extend(input_source.args_for_input());
+
                         result.extend(args!["-i", path.to_owned()]);
                     }
 
@@ -930,6 +1040,7 @@ impl Pipeline {
                         }
 
                         result.extend(input_source.args_for_input());
+
                         result.extend(args!["-i", path.to_owned()]);
                     }
 
@@ -945,7 +1056,16 @@ impl Pipeline {
                     extra_input_args,
                 } => {
                     input_paths.push(path.as_str());
-                    result.extend(input.input_source.args_for_input());
+
+                    if input.kind == GraphicsKind::Canvas {
+                        result.extend(
+                            input
+                                .input_source
+                                .args_for_input_with_context(&self.input_request_context),
+                        );
+                    } else {
+                        result.extend(input.input_source.args_for_input());
+                    }
                     result.extend(extra_input_args.clone());
                     result.extend(args!["-i", path.to_owned()]);
                     let graphics_input_index = input_paths.len() - 1;
@@ -1068,6 +1188,7 @@ mod tests {
             video_input: probed_input(probe_result),
             subtitle_input: None,
             graphics_inputs: Vec::new(),
+            channel_number: None,
         }
     }
 
@@ -1127,5 +1248,231 @@ mod tests {
         assert_eq!(args[downmix + 1], "stereo");
         assert!(downmix < input, "-downmix must precede -i: {args:?}");
         assert_eq!(args.iter().filter(|a| *a == "-i").count(), 1);
+    }
+    fn canvas_input(source: InputSource) -> GraphicsInput {
+        let mut probe = multichannel_ac3_input("canvas.nut")
+            .video_input
+            .probe_result;
+        probe.path = source.input_path().unwrap();
+        probe.format_name = Some("nut".to_owned());
+        probe
+            .streams
+            .retain(|s| matches!(s, crate::probe::ProbeResultStream::Video(_)));
+        if let crate::probe::ProbeResultStream::Video(video) = &mut probe.streams[0] {
+            video.codec = "ffv1".to_owned();
+            video.pix_fmt = "bgra".to_owned();
+            video.width = Some(1280);
+            video.height = Some(720);
+        }
+        GraphicsInput {
+            layer_index: 0,
+            input_source: source,
+            probe_result: probe,
+            stream_index: None,
+            kind: GraphicsKind::Canvas,
+            in_point: Duration::from_secs(3),
+            // Canvas must ignore native graphics placement, opacity and timing.
+            location: crate::input::GraphicsLocation::BottomRight,
+            width_percent: Some(10.0),
+            within_source_content: Some(true),
+            horizontal_margin_percent: Some(5.0),
+            vertical_margin_percent: Some(5.0),
+            opacity_percent: Some(0.0),
+            timing: Some(crate::input::GraphicsTiming::Periodic(
+                crate::input::PeriodicTiming {
+                    clock: crate::input::PeriodicClock::Content,
+                    frequency_ms: 10000,
+                    phase_offset_ms: None,
+                    disable_after_ms: None,
+                    fade_ms: Some(1000),
+                    hold_ms: 2000,
+                },
+            )),
+        }
+    }
+
+    #[test]
+    fn canvas_sized_for_another_resolution_is_scaled_instead_of_failing() {
+        let mut input = multichannel_ac3_input("main.mkv");
+        let mut graphics = canvas_input(InputSource::Local(crate::input::LocalInputSource {
+            path: "canvas.nut".to_owned(),
+        }));
+        if let crate::probe::ProbeResultStream::Video(video) = &mut graphics.probe_result.streams[0]
+        {
+            video.width = Some(1920);
+            video.height = Some(1080);
+        }
+        input.graphics_inputs.push(graphics);
+        let mut pipeline = Pipeline::full(&FfmpegInfo::default(), input, stereo_output()).unwrap();
+        pipeline.optimize();
+        let filter = pipeline
+            .args()
+            .windows(2)
+            .filter(|a| a[0] == "-filter_complex")
+            .map(|a| a[1].as_ref())
+            .collect::<Vec<_>>()
+            .join(";");
+        assert!(filter.contains("scale=1280:720"), "{filter}");
+        assert!(filter.contains("overlay=x=0:y=0"), "{filter}");
+    }
+
+    #[test]
+    fn canvas_local_seeks_to_schedule_offset_plus_source_in_point() {
+        for offset in [0, 44, 88] {
+            let mut input = multichannel_ac3_input("main.mkv");
+            input.playout_offset = Duration::from_secs(offset);
+            input.graphics_inputs.push(canvas_input(InputSource::Local(
+                crate::input::LocalInputSource {
+                    path: "canvas.nut".to_owned(),
+                },
+            )));
+            let mut pipeline =
+                Pipeline::full(&FfmpegInfo::default(), input, stereo_output()).unwrap();
+            pipeline.optimize();
+            let args = pipeline.args();
+            let canvas = args.iter().position(|a| a == "canvas.nut").unwrap();
+            assert_eq!(
+                args[canvas - 5..canvas]
+                    .iter()
+                    .map(|a| a.as_ref())
+                    .collect::<Vec<_>>(),
+                [
+                    "-ss",
+                    &format!("{}ms", (offset + 3) * 1000),
+                    "-t",
+                    "30000ms",
+                    "-i"
+                ]
+            );
+            assert!(
+                !args
+                    .iter()
+                    .any(|a| matches!(a.as_ref(), "-stream_loop" | "-ignore_loop" | "-framerate"))
+            );
+            let filter = args
+                .windows(2)
+                .filter(|a| a[0] == "-filter_complex")
+                .map(|a| a[1].as_ref())
+                .collect::<Vec<_>>()
+                .join(";");
+            assert!(filter.contains("overlay=x=0:y=0"), "{filter}");
+            assert!(
+                !filter.contains("fade=")
+                    && !filter.contains("colorchannelmixer")
+                    && !filter.contains("loop="),
+                "{filter}"
+            );
+        }
+    }
+
+    #[test]
+    fn canvas_http_headers_use_process_context_without_seeking() {
+        use crate::input::{HttpInputOptions, HttpInputSource};
+        let source = InputSource::Http(HttpInputSource {
+            uri: "http://localhost/canvas".to_owned(),
+            options: HttpInputOptions {
+                headers: vec!["Authorization: Bearer test".to_owned()],
+                ..Default::default()
+            },
+        });
+        // Probing/extraction retain only configured headers.
+        let probe_args = source.args_for_input().join(" ");
+        assert!(probe_args.contains("Authorization: Bearer test"));
+        assert!(!probe_args.contains("x-etv-"));
+        for offset in [0, 44, 88] {
+            for override_rate in [None, Some(FrameRate::parse("25/1"))] {
+                let mut input = multichannel_ac3_input("main.mkv");
+                input.channel_number = Some("12.1".to_owned());
+                input.playout_offset = Duration::from_secs(offset);
+                input.graphics_inputs.push(canvas_input(source.clone()));
+                let mut output = stereo_output();
+                output.frame_rate = override_rate.clone();
+                let pipeline = Pipeline::full(&FfmpegInfo::default(), input, output).unwrap();
+                let args = pipeline.args();
+                let headers = args.windows(2).find(|a| a[0] == "-headers").unwrap()[1].as_ref();
+                let expected_rate = override_rate
+                    .as_ref()
+                    .map_or("30000/1001", |r| r.r_frame_rate.as_str());
+                assert_eq!(
+                    headers,
+                    format!(
+                        "Authorization: Bearer test\r\nx-etv-channel:12.1\r\nx-etv-offset-ms:{}\r\nx-etv-duration-ms:30000\r\nx-etv-frame-rate:{expected_rate}\r\n",
+                        offset * 1000
+                    )
+                );
+                assert_eq!(args.iter().filter(|a| *a == "-headers").count(), 1);
+                assert!(!args.iter().any(|a| matches!(
+                    a.as_ref(),
+                    "-ss" | "-stream_loop" | "-framerate" | "-ignore_loop"
+                )));
+                let canvas = args
+                    .iter()
+                    .position(|a| a == "http://localhost/canvas")
+                    .unwrap();
+                assert_eq!(
+                    args[canvas - 3..canvas]
+                        .iter()
+                        .map(|a| a.as_ref())
+                        .collect::<Vec<_>>(),
+                    ["-t", "30000ms", "-i"]
+                );
+            }
+        }
+    }
+    #[test]
+    fn contextual_headers_reach_only_canvas_http_inputs() {
+        use crate::input::{HttpInputOptions, HttpInputSource};
+        let http = |uri: &str| {
+            InputSource::Http(HttpInputSource {
+                uri: uri.to_owned(),
+                options: HttpInputOptions::default(),
+            })
+        };
+        let mut input = multichannel_ac3_input("http://localhost/video");
+        input.video_input.input_source = http("http://localhost/video");
+        input.audio_input.input_source = http("http://localhost/audio");
+        input.audio_input.probe_result.path = "http://localhost/audio".to_owned();
+        // Media seeks include a source in-point; headers must report schedule time only.
+        input.video_input.in_point = Duration::from_secs(54);
+        input.video_input.out_point = Duration::from_secs(98);
+        input.audio_input.in_point = Duration::from_secs(54);
+        input.audio_input.out_point = Duration::from_secs(98);
+        input.playout_offset = Duration::from_secs(44);
+        input.channel_number = Some("7".to_owned());
+        let mut subtitle = multichannel_ac3_input("http://localhost/subtitle").video_input;
+        subtitle.input_source = http("http://localhost/subtitle");
+        subtitle.probe_result.streams.truncate(1);
+        if let crate::probe::ProbeResultStream::Video(video) = &mut subtitle.probe_result.streams[0]
+        {
+            video.codec_type = crate::probe::CodecType::Subtitle;
+            video.codec = "hdmv_pgs_subtitle".to_owned();
+        }
+        input.subtitle_input = Some(subtitle);
+        input
+            .graphics_inputs
+            .push(canvas_input(http("http://localhost/canvas")));
+        let pipeline = Pipeline::full(&FfmpegInfo::default(), input, stereo_output()).unwrap();
+        let args = pipeline.args();
+        let mut inputs = 0;
+        for group in args.split_inclusive(|a| a.starts_with("http://localhost/")) {
+            if !group
+                .last()
+                .is_some_and(|a| a.starts_with("http://localhost/"))
+            {
+                continue;
+            }
+            inputs += 1;
+            let headers: Vec<_> = group.windows(2).filter(|a| a[0] == "-headers").collect();
+            if group.last().is_some_and(|a| a.ends_with("/canvas")) {
+                assert_eq!(headers.len(), 1, "{group:?}");
+                assert_eq!(
+                    headers[0][1],
+                    "x-etv-channel:7\r\nx-etv-offset-ms:44000\r\nx-etv-duration-ms:44000\r\nx-etv-frame-rate:30000/1001\r\n"
+                );
+            } else {
+                assert!(headers.is_empty(), "{group:?}");
+            }
+        }
+        assert_eq!(inputs, 4);
     }
 }

--- a/crates/ffpipeline/tests/common/mod.rs
+++ b/crates/ffpipeline/tests/common/mod.rs
@@ -7,8 +7,8 @@ use ffpipeline::frame_rate::FrameRate;
 use ffpipeline::frame_size::FrameSize;
 use ffpipeline::hw_accel::HardwareAccel;
 use ffpipeline::input::{
-    InputSettings, InputSource, LocalInputSource, ProbedInput, WatermarkInput, WatermarkLocation,
-    WatermarkTiming,
+    GraphicsKind, InputSettings, InputSource, LocalInputSource, ProbedInput, WatermarkInput,
+    WatermarkLocation, WatermarkTiming,
 };
 use ffpipeline::output_format::OutputFormat;
 use ffpipeline::output_settings::{
@@ -292,6 +292,8 @@ pub async fn build_watermark_input(
         horizontal_margin_percent: Some(5.0),
         vertical_margin_percent: Some(5.0),
         opacity_percent: watermark.opacity_percent,
+        kind: GraphicsKind::Media,
+        in_point: Duration::ZERO,
         timing: watermark.timing.clone(),
     }
 }
@@ -324,6 +326,7 @@ pub fn build_input(
         },
         subtitle_input: None,
         graphics_inputs: watermark.into_iter().collect(),
+        channel_number: None,
     }
 }
 

--- a/crates/ffpipeline/tests/software.rs
+++ b/crates/ffpipeline/tests/software.rs
@@ -374,3 +374,173 @@ async fn motion_check_rejects_missing_deinterlace(
         "negative control failed to detect combing: {score}"
     );
 }
+
+/// Generate both inputs locally so this test needs no checked-in media fixtures.
+#[tokio::test]
+#[ignore = "requires local ffmpeg and ffprobe"]
+async fn canvas_local() {
+    use std::time::Duration;
+
+    use ffpipeline::input::{
+        GraphicsInput, GraphicsKind, GraphicsLocation, InputSource, LocalInputSource,
+    };
+    use ffpipeline::pipeline::generate_pipeline;
+
+    let env = test_env().await.unwrap();
+    let dir = tempfile::tempdir().unwrap();
+    let main = dir.path().join("main.mkv");
+    let canvas = dir.path().join("canvas.nut");
+    for (path, args) in [
+        (
+            &main,
+            vec![
+                "-f",
+                "lavfi",
+                "-i",
+                "color=blue:s=320x180:r=24",
+                "-f",
+                "lavfi",
+                "-i",
+                "anullsrc=r=48000:cl=stereo",
+                "-t",
+                "4",
+                "-c:v",
+                "ffv1",
+                "-c:a",
+                "pcm_s16le",
+            ],
+        ),
+        (
+            &canvas,
+            vec![
+                "-f",
+                "lavfi",
+                "-i",
+                "color=black@0:s=320x180:r=24,format=bgra,drawbox=x=0:y=0:w=80:h=80:color=red@1:t=fill:replace=1",
+                "-t",
+                "4",
+                "-c:v",
+                "ffv1",
+                "-pix_fmt",
+                "bgra",
+                "-f",
+                "nut",
+            ],
+        ),
+    ] {
+        let generated = tokio::time::timeout(
+            Duration::from_secs(30),
+            tokio::process::Command::new(&env.ffmpeg)
+                .args(["-nostdin", "-hide_banner", "-loglevel", "error", "-y"])
+                .args(args)
+                .arg(path)
+                .kill_on_drop(true)
+                .output(),
+        )
+        .await
+        .expect("fixture generation timed out")
+        .unwrap();
+        assert!(
+            generated.status.success(),
+            "{}",
+            String::from_utf8_lossy(&generated.stderr)
+        );
+    }
+    let graphics = GraphicsInput {
+        layer_index: 0,
+        input_source: InputSource::Local(LocalInputSource {
+            path: canvas.to_string_lossy().into_owned(),
+        }),
+        probe_result: probe_file(&env.ffmpeg, &env.ffprobe, &canvas).await,
+        stream_index: None,
+        kind: GraphicsKind::Canvas,
+        in_point: Duration::from_millis(500),
+        location: GraphicsLocation::BottomRight,
+        width_percent: Some(10.0),
+        within_source_content: Some(true),
+        horizontal_margin_percent: Some(5.0),
+        vertical_margin_percent: Some(5.0),
+        opacity_percent: Some(0.0),
+        timing: None,
+    };
+    let probe = probe_file(&env.ffmpeg, &env.ffprobe, &main).await;
+    let mut input = build_input(&main, probe, Duration::from_secs(1), Some(graphics));
+    input.playout_offset = Duration::from_millis(500);
+    let output = build_output(
+        dir.path(),
+        TestOutputParams {
+            video_size: Some(FrameSize {
+                width: 320,
+                height: 180,
+            }),
+            ..Default::default()
+        },
+    );
+    let mut pipeline = generate_pipeline(&env.ffmpeg_info, input, output).unwrap();
+    pipeline.optimize();
+    let args = pipeline.args();
+    let canvas_index = args
+        .iter()
+        .position(|a| a.as_ref() == canvas.to_str().unwrap())
+        .unwrap();
+    assert_eq!(
+        args[canvas_index - 5..canvas_index]
+            .iter()
+            .map(|a| a.as_ref())
+            .collect::<Vec<_>>(),
+        ["-ss", "1000ms", "-t", "1000ms", "-i"]
+    );
+    assert!(
+        !args
+            .iter()
+            .any(|a| matches!(a.as_ref(), "-stream_loop" | "-ignore_loop" | "-framerate"))
+    );
+    let filter = args
+        .windows(2)
+        .filter(|a| a[0] == "-filter_complex")
+        .map(|a| a[1].as_ref())
+        .collect::<Vec<_>>()
+        .join(";");
+    assert!(filter.contains("overlay=x=0:y=0"), "{filter}");
+    let (success, stderr) = run_ffmpeg_pipeline(&env.ffmpeg, &pipeline).await;
+    assert!(success, "{stderr}");
+
+    let segment = find_first_segment(dir.path());
+    let decoded = tokio::time::timeout(
+        Duration::from_secs(30),
+        tokio::process::Command::new(&env.ffmpeg)
+            .args(["-nostdin", "-v", "error", "-i"])
+            .arg(segment)
+            .args([
+                "-frames:v",
+                "1",
+                "-pix_fmt",
+                "rgb24",
+                "-f",
+                "rawvideo",
+                "pipe:1",
+            ])
+            .kill_on_drop(true)
+            .output(),
+    )
+    .await
+    .expect("frame decode timed out")
+    .unwrap();
+    assert!(
+        decoded.status.success(),
+        "{}",
+        String::from_utf8_lossy(&decoded.stderr)
+    );
+    assert_eq!(decoded.stdout.len(), 320 * 180 * 3);
+    let pixel = |x: usize, y: usize| &decoded.stdout[(y * 320 + x) * 3..(y * 320 + x) * 3 + 3];
+    let red = pixel(40, 40);
+    assert!(
+        red[0] > 200 && red[1] < 50 && red[2] < 50,
+        "canvas foreground missing: {red:?}"
+    );
+    let blue = pixel(200, 100);
+    assert!(
+        blue[0] < 50 && blue[1] < 50 && blue[2] > 200,
+        "canvas background lost transparency: {blue:?}"
+    );
+}

--- a/schema/playout.json
+++ b/schema/playout.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://ersatztv.org/playout/version/0.0.3",
+  "$id": "https://ersatztv.org/playout/version/0.0.4",
   "title": "Playout",
   "description": "A playout schedule for a single time window.\n\nFiles should be named `{start}_{finish}.json` using compact ISO 8601 (no separators), e.g. `20260413T000000.000000000-0500_20260414T002131.620000000-0500.json`, so that the channel can locate the correct file for the current time.",
   "type": "object",
@@ -171,6 +171,10 @@
           "minimum": 0,
           "description": "Zero-based stream index within the source. If omitted, the server picks the first video stream."
         },
+        "kind": {
+          "description": "Graphics layer kind.",
+          "$ref": "#/definitions/GraphicsLayerKind"
+        },
         "location": {
           "description": "Anchor position within the primary content frame.",
           "$ref": "#/definitions/GraphicsLocation"
@@ -302,6 +306,14 @@
       "enum": [
         "wall",
         "content"
+      ]
+    },
+    "GraphicsLayerKind": {
+      "type": "string",
+      "description": "canvas: a full-frame layer whose frames are already the output size and carry alpha. It is composited at (0,0) and is content-locked: the channel seeks it to its own position in the item. `location`, margins, `width_percent`, `within_source_content`, `opacity_percent` and `timing` are ignored (a warning is logged if present). HTTP canvas sources receive `x-etv-channel`, `x-etv-offset-ms`, `x-etv-duration-ms` and `x-etv-frame-rate` headers.",
+      "enum": [
+        "media",
+        "canvas"
       ]
     },
     "GraphicsLocation": {


### PR DESCRIPTION
This helps with #72 in a way - it adds a graphics layer `kind` of `canvas` that basically means don't process the graphics layer at all. This will let legacy run its original graphics engine as an http input to next.